### PR TITLE
Remove category

### DIFF
--- a/sentences/README.md
+++ b/sentences/README.md
@@ -9,7 +9,6 @@ YAML files for each domain and language with sentences and the intents that they
 language: "<language code>"
 intents:
   <intent name>:
-    category: "action" # or "query"
     data:
       # List of sentences/slots
       - sentences:
@@ -18,7 +17,7 @@ intents:
         slots:
           # Fixed slots for the recognized intent
           <name>: <value>
-          
+
 # Optional lists of items that become alternatives in sentence templates
 lists:
   # Referenced as {list_name}
@@ -31,7 +30,7 @@ lists:
     range:
       from: 0
       to: 100
-      
+
 # Optional rules that are expanded in sentence templates
 expansion_rules:
   # Referenced as <rule_name>

--- a/sentences/en/cover_HassCloseCover.yaml
+++ b/sentences/en/cover_HassCloseCover.yaml
@@ -1,7 +1,6 @@
 language: "en"
 intents:
   HassCloseCover:
-    category: "action"
     data:
       - sentences:
           - "close <name>"

--- a/sentences/en/cover_HassOpenCover.yaml
+++ b/sentences/en/cover_HassOpenCover.yaml
@@ -1,7 +1,6 @@
 language: "en"
 intents:
   HassOpenCover:
-    category: "action"
     data:
       - sentences:
           - "open <name>"


### PR DESCRIPTION
The cover intents still had the old category key. If we want that one, we should add it to `intents.yaml`