### PR TITLE
Validate that all sentences have at least 1 test

### DIFF
--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -336,7 +336,7 @@ def validate_language(intent_schemas, language, errors):
             errors[language].append(f"{path}: has no matching sentence file")
             continue
 
-        sentence_files.pop(test_file.name)
+        sentence_file = sentence_files.pop(test_file.name)
 
         content = yaml.safe_load(test_file.read_text())
 
@@ -372,6 +372,17 @@ def validate_language(intent_schemas, language, errors):
             errors[language].append(
                 f"{path}: tests extra intents {', '.join(sorted(extra_intents))}. Only {intent} allowed"
             )
+
+        if tested_intents != {intent}:
+            return
+
+        test_count = sum(len(test["sentences"]) for test in content["tests"])
+        sentence_count = sum(
+            len(data["sentences"]) for data in sentence_file["intents"][intent]["data"]
+        )
+
+        if sentence_count > test_count:
+            errors[language].append(f"{path}: not all sentences have tests")
 
     if sentence_files:
         for sentence_file in sentence_files:


### PR DESCRIPTION
This does a rough validation to ensure that all sentences are tested. 

If all sentences are tested, the number of test cases should be equal or higher than the number of sentences. This first pass validation checks this number. More refinement is possible and could be added in the future.

Current output:

- [x] Fix Dutch #15 
- [x] Fix English #21
- [x] Fix French #20

```
❯ python3 -m script.intentfest validate
Validation failed

Language: nl
 - tests/nl/cover_HassOpenCover.yaml: not all sentences have tests
 - tests/nl/cover_HassCloseCover.yaml: not all sentences have tests

Language: fr
 - tests/fr/homeassistant_HassTurnOn.yaml: not all sentences have tests
 - tests/fr/homeassistant_HassToggle.yaml: not all sentences have tests
 - tests/fr/homeassistant_HassTurnOff.yaml: not all sentences have tests

Language: en
 - tests/en/homeassistant_HassTurnOn.yaml: not all sentences have tests
 - tests/en/light_HassTurnOff.yaml: not all sentences have tests
 - tests/en/cover_HassOpenCover.yaml: not all sentences have tests
 - tests/en/light_HassTurnOn.yaml: not all sentences have tests
 - tests/en/light_HassLightSet.yaml: not all sentences have tests
 - tests/en/fan_HassTurnOff.yaml: not all sentences have tests
 - tests/en/cover_HassCloseCover.yaml: not all sentences have tests
 - tests/en/homeassistant_HassTurnOff.yaml: not all sentences have tests
```