### PR TITLE
Add empty Czech templates (cs)

### DIFF
--- a/responses/cs/HassClimateGetTemperature.yaml
+++ b/responses/cs/HassClimateGetTemperature.yaml
@@ -1,0 +1,5 @@
+language: cs
+responses:
+  intents:
+    HassClimateGetTemperature:
+      success: []

--- a/sentences/cs/_common.yaml
+++ b/sentences/cs/_common.yaml
@@ -1,0 +1,12 @@
+language: cs
+responses:
+  errors:
+    no_intent: "Omlouvám se, ale nerozuměl jsem tomu"
+    no_area: "Nepojmenovaná oblast {{ area }}"
+    no_domain: "{{ area }} neobsahuje {{ domain }}"
+    no_device_class: "{{ area }} neobsahuje {{ device_class }}"
+    no_entity: "Žádné zařízení ani entita se nejmenuje {{ entity }}"
+    handle_error: "Při zpracování došlo k neočekávané chybě."
+lists: {}
+expansion_rules: {}
+skip_words: []

--- a/sentences/cs/climate_HassClimateGetTemperature.yaml
+++ b/sentences/cs/climate_HassClimateGetTemperature.yaml
@@ -1,0 +1,5 @@
+language: cs
+intents:
+  HassClimateGetTemperature:
+    data:
+    - sentences: []

--- a/sentences/cs/climate_HassClimateSetTemperature.yaml
+++ b/sentences/cs/climate_HassClimateSetTemperature.yaml
@@ -1,0 +1,5 @@
+language: cs
+intents:
+  HassClimateSetTemperature:
+    data:
+    - sentences: []

--- a/sentences/cs/cover_HassCloseCover.yaml
+++ b/sentences/cs/cover_HassCloseCover.yaml
@@ -1,0 +1,5 @@
+language: cs
+intents:
+  HassCloseCover:
+    data:
+    - sentences: []

--- a/sentences/cs/cover_HassOpenCover.yaml
+++ b/sentences/cs/cover_HassOpenCover.yaml
@@ -1,0 +1,5 @@
+language: cs
+intents:
+  HassOpenCover:
+    data:
+    - sentences: []

--- a/sentences/cs/fan_HassTurnOff.yaml
+++ b/sentences/cs/fan_HassTurnOff.yaml
@@ -1,0 +1,8 @@
+language: cs
+intents:
+  HassTurnOff:
+    data:
+    - sentences: []
+      slots:
+        domain: fan
+        name: all

--- a/sentences/cs/fan_HassTurnOn.yaml
+++ b/sentences/cs/fan_HassTurnOn.yaml
@@ -1,0 +1,8 @@
+language: cs
+intents:
+  HassTurnOn:
+    data:
+    - sentences: []
+      slots:
+        domain: fan
+        name: all

--- a/sentences/cs/homeassistant_HassTurnOff.yaml
+++ b/sentences/cs/homeassistant_HassTurnOff.yaml
@@ -1,0 +1,5 @@
+language: cs
+intents:
+  HassTurnOff:
+    data:
+    - sentences: []

--- a/sentences/cs/homeassistant_HassTurnOn.yaml
+++ b/sentences/cs/homeassistant_HassTurnOn.yaml
@@ -1,0 +1,5 @@
+language: cs
+intents:
+  HassTurnOn:
+    data:
+    - sentences: []

--- a/sentences/cs/light_HassLightSet.yaml
+++ b/sentences/cs/light_HassLightSet.yaml
@@ -1,0 +1,5 @@
+language: cs
+intents:
+  HassLightSet:
+    data:
+    - sentences: []

--- a/sentences/cs/light_HassTurnOff.yaml
+++ b/sentences/cs/light_HassTurnOff.yaml
@@ -1,0 +1,8 @@
+language: cs
+intents:
+  HassTurnOff:
+    data:
+    - sentences: []
+      slots:
+        domain: light
+        name: all

--- a/sentences/cs/light_HassTurnOn.yaml
+++ b/sentences/cs/light_HassTurnOn.yaml
@@ -1,0 +1,8 @@
+language: cs
+intents:
+  HassTurnOn:
+    data:
+    - sentences: []
+      slots:
+        domain: light
+        name: all

--- a/tests/cs/_common.yaml
+++ b/tests/cs/_common.yaml
@@ -1,0 +1,23 @@
+language: cs
+areas:
+- name: Kuchyň
+  id: kitchen
+- name: Obývací pokoj
+  id: living_room
+- name: Ložnice
+  id: bedroom
+- name: Garáž
+  id: garage
+entities:
+- name: Lampa v ložnici
+  id: light.bedroom_lamp
+  area: bedroom
+  domain: light
+- name: Kuchyňský vypínač
+  id: switch.kitchen
+  area: kitchen
+  domain: switch
+- name: Stropní ventilátor
+  id: fan.ceiling
+  area: living_room
+  domain: fan

--- a/tests/cs/climate_HassClimateGetTemperature.yaml
+++ b/tests/cs/climate_HassClimateGetTemperature.yaml
@@ -1,0 +1,6 @@
+language: cs
+tests:
+- sentences: []
+  intent:
+    name: HassClimateGetTemperature
+    slots: {}

--- a/tests/cs/climate_HassClimateSetTemperature.yaml
+++ b/tests/cs/climate_HassClimateSetTemperature.yaml
@@ -1,0 +1,6 @@
+language: cs
+tests:
+- sentences: []
+  intent:
+    name: HassClimateSetTemperature
+    slots: {}

--- a/tests/cs/cover_HassCloseCover.yaml
+++ b/tests/cs/cover_HassCloseCover.yaml
@@ -1,0 +1,6 @@
+language: cs
+tests:
+- sentences: []
+  intent:
+    name: HassCloseCover
+    slots: {}

--- a/tests/cs/cover_HassOpenCover.yaml
+++ b/tests/cs/cover_HassOpenCover.yaml
@@ -1,0 +1,6 @@
+language: cs
+tests:
+- sentences: []
+  intent:
+    name: HassOpenCover
+    slots: {}

--- a/tests/cs/fan_HassTurnOff.yaml
+++ b/tests/cs/fan_HassTurnOff.yaml
@@ -1,0 +1,6 @@
+language: cs
+tests:
+- sentences: []
+  intent:
+    name: HassTurnOff
+    slots: {}

--- a/tests/cs/fan_HassTurnOn.yaml
+++ b/tests/cs/fan_HassTurnOn.yaml
@@ -1,0 +1,6 @@
+language: cs
+tests:
+- sentences: []
+  intent:
+    name: HassTurnOn
+    slots: {}

--- a/tests/cs/homeassistant_HassTurnOff.yaml
+++ b/tests/cs/homeassistant_HassTurnOff.yaml
@@ -1,0 +1,6 @@
+language: cs
+tests:
+- sentences: []
+  intent:
+    name: HassTurnOff
+    slots: {}

--- a/tests/cs/homeassistant_HassTurnOn.yaml
+++ b/tests/cs/homeassistant_HassTurnOn.yaml
@@ -1,0 +1,6 @@
+language: cs
+tests:
+- sentences: []
+  intent:
+    name: HassTurnOn
+    slots: {}

--- a/tests/cs/light_HassLightSet.yaml
+++ b/tests/cs/light_HassLightSet.yaml
@@ -1,0 +1,6 @@
+language: cs
+tests:
+- sentences: []
+  intent:
+    name: HassLightSet
+    slots: {}

--- a/tests/cs/light_HassTurnOff.yaml
+++ b/tests/cs/light_HassTurnOff.yaml
@@ -1,0 +1,6 @@
+language: cs
+tests:
+- sentences: []
+  intent:
+    name: HassTurnOff
+    slots: {}

--- a/tests/cs/light_HassTurnOn.yaml
+++ b/tests/cs/light_HassTurnOn.yaml
@@ -1,0 +1,6 @@
+language: cs
+tests:
+- sentences: []
+  intent:
+    name: HassTurnOn
+    slots: {}


### PR DESCRIPTION
#57

This adds basic support for Czech, with the features implemented that `python3 -m script.intentfest add_language cs` suggested for the initial commit. And common translations. I'm going to keep adding sentences