### PR TITLE
Fix a typo in the Polish common sentences

### DIFF
--- a/sentences/pl/_common.yaml
+++ b/sentences/pl/_common.yaml
@@ -16,7 +16,7 @@ lists:
         out: "black"
       - in: "czerwień | czerwon(y|o)"
         out: "red"
-      - in: "pomranańcz | pomarańczow(y|o)"
+      - in: "pomarańcz | pomarańczow(y|o)"
         out: "orange"
       - in: "żółt(y|o)"
         out: "yellow"


### PR DESCRIPTION
https://pl.wiktionary.org/wiki/pomara%C5%84cz