### PR TITLE
[NL] Merge doe_enkelvoud and doe_meervoud

### DIFF
--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -38,8 +38,7 @@ lists:
 expansion_rules:
   name: "[de | het] {name}"
   area: "[de | het] {area}"
-  doe_enkelvoud: "(zet | mag | doe | verander)"
-  doe_meervoud: "(zet | mogen | doe | verander)"
+  doe: "(zet | mag | mogen | doe | verander | maak)"
   naar: "(naar | op)"
   helderheid: "(helderheid | felheid | intensiteit)"
   brightness: "{brightness:brightness_pct} [procent]"

--- a/sentences/nl/homeassistant_HassTurnOff.yaml
+++ b/sentences/nl/homeassistant_HassTurnOff.yaml
@@ -3,5 +3,5 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "<doe_enkelvoud> <name> uit"
-          - "<doe_meervoud> <name> uit"
+          - "<doe> <name> uit"
+          - "<doe> <name> uit"

--- a/sentences/nl/homeassistant_HassTurnOn.yaml
+++ b/sentences/nl/homeassistant_HassTurnOn.yaml
@@ -3,5 +3,5 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "<doe_enkelvoud> <name> aan"
-          - "<doe_meervoud> <name> aan"
+          - "<doe> <name> aan"
+          - "<doe> <name> aan"

--- a/sentences/nl/light_HassLightSet.yaml
+++ b/sentences/nl/light_HassLightSet.yaml
@@ -4,14 +4,14 @@ intents:
     data:
       # brightness
       - sentences:
-          - "<doe> <name> <naar> <brightness>"
-          - "<doe> [de] <helderheid> van <name> <naar> <brightness>"
+          - "<doe> <name> [<naar>] <brightness>"
+          - "<doe> [de] <helderheid> van <name> [<naar>] <brightness>"
       - sentences:
-          - "<doe> [de] <helderheid> in <area> <naar> <brightness>"
-          - "<doe> <area> <helderheid> <naar> <brightness>"
+          - "<doe> [de] <helderheid> in <area> [<naar>] <brightness>"
+          - "<doe> <area> <helderheid> [<naar>] <brightness>"
         slots:
           name: "all"
       # color
       - sentences:
           - "<doe> <name> [kleur] [<naar>] {color}"
-          - "<doe> [[de] kleur van] <name> <naar> {color}"
+          - "<doe> [[de] kleur van] <name> [<naar>] {color}"

--- a/sentences/nl/light_HassLightSet.yaml
+++ b/sentences/nl/light_HassLightSet.yaml
@@ -4,14 +4,14 @@ intents:
     data:
       # brightness
       - sentences:
-          - "<doe_enkelvoud> <name> <naar> <brightness>"
-          - "<doe_enkelvoud> [de] <helderheid> van <name> <naar> <brightness>"
+          - "<doe> <name> <naar> <brightness>"
+          - "<doe> [de] <helderheid> van <name> <naar> <brightness>"
       - sentences:
-          - "<doe_enkelvoud> [de] <helderheid> in <area> <naar> <brightness>"
-          - "<doe_enkelvoud> <area> <helderheid> <naar> <brightness>"
+          - "<doe> [de] <helderheid> in <area> <naar> <brightness>"
+          - "<doe> <area> <helderheid> <naar> <brightness>"
         slots:
           name: "all"
       # color
       - sentences:
-          - "<doe_enkelvoud> <name> [kleur] <naar> {color}"
-          - "<doe_enkelvoud> [[de] kleur van] <name> <naar> {color}"
+          - "<doe> <name> [kleur] <naar> {color}"
+          - "<doe> [[de] kleur van] <name> <naar> {color}"

--- a/sentences/nl/light_HassLightSet.yaml
+++ b/sentences/nl/light_HassLightSet.yaml
@@ -4,7 +4,7 @@ intents:
     data:
       # brightness
       - sentences:
-          - "<doe> <name> [<naar>] <brightness>"
+          - "<doe> <name> [<helderheid>] [<naar>] <brightness>"
           - "<doe> [de] <helderheid> van <name> [<naar>] <brightness>"
       - sentences:
           - "<doe> [de] <helderheid> in <area> [<naar>] <brightness>"

--- a/sentences/nl/light_HassLightSet.yaml
+++ b/sentences/nl/light_HassLightSet.yaml
@@ -13,5 +13,5 @@ intents:
           name: "all"
       # color
       - sentences:
-          - "<doe> <name> [kleur] <naar> {color}"
+          - "<doe> <name> [kleur] [<naar>] {color}"
           - "<doe> [[de] kleur van] <name> <naar> {color}"

--- a/sentences/nl/light_HassTurnOff.yaml
+++ b/sentences/nl/light_HassTurnOff.yaml
@@ -3,8 +3,8 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "<doe_enkelvoud> het licht uit in <area>"
-          - "<doe_meervoud> de lampen uit in <area>"
+          - "<doe> het licht uit in <area>"
+          - "<doe> de lampen uit in <area>"
         slots:
           domain: light
           name: all

--- a/sentences/nl/light_HassTurnOn.yaml
+++ b/sentences/nl/light_HassTurnOn.yaml
@@ -3,8 +3,8 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "<doe_enkelvoud> het licht aan in <area>"
-          - "<doe_meervoud> de lampen aan in <area>"
+          - "<doe> het licht aan in <area>"
+          - "<doe> de lampen aan in <area>"
         slots:
           domain: light
           name: all

--- a/tests/nl/light_HassLightSet.yaml
+++ b/tests/nl/light_HassLightSet.yaml
@@ -11,7 +11,7 @@ tests:
         name: light.slaapkamer_lamp
   - sentences:
       - "verander de felheid in de slaapkamer naar 75 procent"
-      - "zet de slaapkamer helderheid op 75%"
+      - "maak de slaapkamer helderheid 75%"
     intent:
       name: "HassLightSet"
       slots:

--- a/tests/nl/light_HassLightSet.yaml
+++ b/tests/nl/light_HassLightSet.yaml
@@ -3,6 +3,8 @@ tests:
   # brightness
   - sentences:
       - "zet slaapkamer lamp op 50%"
+      - "mag de intensiteit van slaapkamer lamp naar 50 procent"
+      - "doe de slaapkamer lamp intensiteit naar 50%"
       - "verander de helderheid van de slaapkamer lamp naar 50 procent"
     intent:
       name: "HassLightSet"
@@ -12,6 +14,8 @@ tests:
   - sentences:
       - "verander de felheid in de slaapkamer naar 75 procent"
       - "maak de slaapkamer helderheid 75%"
+      - "doe de slaapkamer intensiteit naar 75%"
+      - "mag de helderheid in de slaapkamer naar 75%"
     intent:
       name: "HassLightSet"
       slots:
@@ -20,7 +24,10 @@ tests:
   # color
   - sentences:
       - "maak slaapkamer lamp blauw"
+      - "doe de slaapkamer lamp naar blauw"
       - "zet de kleur van de slaapkamer lamp op blauw"
+      - "verander de slaapkamer lamp naar blauw"
+      - "mag de slaapkamer lamp blauw"
     intent:
       name: "HassLightSet"
       slots:

--- a/tests/nl/light_HassLightSet.yaml
+++ b/tests/nl/light_HassLightSet.yaml
@@ -19,7 +19,7 @@ tests:
         area: "slaapkamer"
   # color
   - sentences:
-      - "verander de slaapkamer lamp kleur naar blauw"
+      - "maak slaapkamer lamp blauw"
       - "zet de kleur van de slaapkamer lamp op blauw"
     intent:
       name: "HassLightSet"


### PR DESCRIPTION
Merge `doe_enkelvoud` and `doe_meervoud`. Most were the same, only  mag/mogen was using an singular and plural form.
Also added `maak` to make `maak bolletje rood` a possible option ~~(will do that in a separate PR)~~ (made `<naar>` optional to support this)