### PR TITLE
Validate color names are outputted in English

### DIFF
--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -267,6 +267,15 @@ def validate_language(intent_schemas, language, errors):
         if "expansion_rules" in content:
             expansion_rules.update(content["expansion_rules"])
 
+    # Validate if colors are translated if not English
+    if language != "en" and (values := lists.get("color", {}).get("values", [])):
+        for color in values:
+            if not isinstance(color, dict):
+                errors[language].append(
+                    "Colors should use the in-out format to output English color names for Home Assistant to consume. See sentences/nl/_common.yaml for an example."
+                )
+                break
+
     for sentence_file, content in sentence_files.items():
         if sentence_file.startswith("_"):
             if "intents" in content:


### PR DESCRIPTION
Home Assistant intents only work with English colors. Any color matched in non-English needs to be translated using the in-out format. Example:

```yaml
lists:
  color:
    values:
      - in: "wit"
        out: "white"
      - in: "zwart"
        out: "black"
```

This validation currently fails on:

 - [x] Swedish #121
 - [x] Hungarian #122
 - [x] Norwegian #120

```
❯ python3 -m script.intentfest validate
Validation failed

Language: sv
 - Colors should use the in-out format to output English color names for Home Assistant. See sentences/nl/_common.yaml for an example.

Language: hu
 - Colors should use the in-out format to output English color names for Home Assistant. See sentences/nl/_common.yaml for an example.

Language: nb
 - Colors should use the in-out format to output English color names for Home Assistant. See sentences/nl/_common.yaml for an example.
```