### PR TITLE
Make sure SV outputs English color names

### DIFF
--- a/sentences/sv/_common.yaml
+++ b/sentences/sv/_common.yaml
@@ -10,15 +10,24 @@ responses:
 lists:
   color:
     values:
-      - "vit"
-      - "svart"
-      - "röd"
-      - "orange"
-      - "gul"
-      - "grön"
-      - "blå"
-      - "lila"
-      - "brun"
+      - in: "vit"
+        out: "white"
+      - in: "svart"
+        out: "black"
+      - in: "röd"
+        out: "red"
+      - in: "orange"
+        out: "orange"
+      - in: "gul"
+        out: "yellow"
+      - in: "grön"
+        out: "green"
+      - in: "blå"
+        out: "blue"
+      - in: "lila"
+        out: "purple"
+      - in: "brun"
+        out: "brown"
   brightness:
     range:
       type: "percentage"


### PR DESCRIPTION
Color names need to be outputted in English as per #119. This fixes it for SV.