### PR TITLE
[NL] Remove duplicate sentences

### DIFF
--- a/sentences/nl/homeassistant_HassTurnOff.yaml
+++ b/sentences/nl/homeassistant_HassTurnOff.yaml
@@ -4,4 +4,3 @@ intents:
     data:
       - sentences:
           - "<doe> <name> uit"
-          - "<doe> <name> uit"

--- a/sentences/nl/homeassistant_HassTurnOn.yaml
+++ b/sentences/nl/homeassistant_HassTurnOn.yaml
@@ -4,4 +4,3 @@ intents:
     data:
       - sentences:
           - "<doe> <name> aan"
-          - "<doe> <name> aan"


### PR DESCRIPTION
I think these duplicates have originated from the singular / plural <doe> format.