### PR TITLE
Refactor tests to move some from validate to tests

### DIFF
--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -267,21 +267,8 @@ def validate_language(intent_schemas, language, errors):
         if "expansion_rules" in content:
             expansion_rules.update(content["expansion_rules"])
 
-    # Validate if colors are translated if not English
-    if language != "en" and (values := lists.get("color", {}).get("values", [])):
-        for color in values:
-            if not isinstance(color, dict):
-                errors[language].append(
-                    "Colors should use the in-out format to output English color names for Home Assistant to consume. See sentences/nl/_common.yaml for an example."
-                )
-                break
-
     for sentence_file, content in sentence_files.items():
         if sentence_file.startswith("_"):
-            if "intents" in content:
-                errors[language].append(
-                    f"{path}: is a common file and should not contain intents"
-                )
             continue
 
         domain, intent = sentence_file.split(".")[0].split("_")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Any, Dict
 
 import yaml
-from hassil.util import merge_dict
 
 _DIR = Path(__file__).parent
 _BASE_DIR = _DIR.parent
@@ -18,6 +17,7 @@ def load_sentences(language: str):
     """Load sentences from sentences/ for a language"""
     lang_dir = USER_SENTENCES_DIR / language
     files: Dict[str, Any] = {}
+
     for yaml_path in lang_dir.glob("*.yaml"):
         with open(yaml_path, "r", encoding="utf-8") as yaml_file:
             yaml_dict = yaml.safe_load(yaml_file)
@@ -26,16 +26,17 @@ def load_sentences(language: str):
                 yaml_dict["language"] == language
             ), f"Expected language '{language}', got '{yaml_dict['language']}'"
             files[yaml_path.name] = yaml_dict
+
     return files
 
 
 def load_tests(language: str):
     """Load test sentences from tests/ for a language"""
     lang_dir = TEST_SENTENCES_DIR / language
-    tests_dict: Dict[str, Any] = {}
+    files: Dict[str, Any] = {}
+
     for yaml_path in lang_dir.rglob("*.yaml"):
         with open(yaml_path, "r", encoding="utf-8") as yaml_file:
-            merge_dict(tests_dict, yaml.safe_load(yaml_file))
+            files[yaml_path.name] = yaml.safe_load(yaml_file)
 
-    assert tests_dict, "No test YAML files loaded"
-    return tests_dict
+    return files

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -30,13 +30,16 @@ def load_sentences(language: str):
     return files
 
 
-def load_tests(language: str):
+def load_test(language: str, test_name: str):
     """Load test sentences from tests/ for a language"""
-    lang_dir = TEST_SENTENCES_DIR / language
-    files: Dict[str, Any] = {}
+    return yaml.safe_load(
+        (TEST_SENTENCES_DIR / language / f"{test_name}.yaml").read_text()
+    )
+    # lang_dir = TEST_SENTENCES_DIR / language
+    # files: Dict[str, Any] = {}
 
-    for yaml_path in lang_dir.rglob("*.yaml"):
-        with open(yaml_path, "r", encoding="utf-8") as yaml_file:
-            files[yaml_path.name] = yaml.safe_load(yaml_file)
+    # for yaml_path in lang_dir.rglob("*.yaml"):
+    #     with open(yaml_path, "r", encoding="utf-8") as yaml_file:
+    #         files[yaml_path.name] = yaml.safe_load(yaml_file)
 
-    return files
+    # return files

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Any, Dict
 
 import yaml
-from hassil import Intents
 from hassil.util import merge_dict
 
 _DIR = Path(__file__).parent
@@ -15,10 +14,10 @@ TEST_SENTENCES_DIR = _BASE_DIR / "tests"
 LANGUAGES = [p.name for p in USER_SENTENCES_DIR.iterdir() if p.is_dir()]
 
 
-def load_intents(language: str):
-    """Load sentences/intents from sentences/ for a language"""
+def load_sentences(language: str):
+    """Load sentences from sentences/ for a language"""
     lang_dir = USER_SENTENCES_DIR / language
-    input_dict: Dict[str, Any] = {}
+    files: Dict[str, Any] = {}
     for yaml_path in lang_dir.glob("*.yaml"):
         with open(yaml_path, "r", encoding="utf-8") as yaml_file:
             yaml_dict = yaml.safe_load(yaml_file)
@@ -26,10 +25,8 @@ def load_intents(language: str):
             assert (
                 yaml_dict["language"] == language
             ), f"Expected language '{language}', got '{yaml_dict['language']}'"
-            merge_dict(input_dict, yaml_dict)
-
-    assert input_dict, f"No intent YAML files loaded for {language}"
-    return Intents.from_dict(input_dict)
+            files[yaml_path.name] = yaml_dict
+    return files
 
 
 def load_tests(language: str):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import yaml
 from hassil import Intents
 from hassil.util import merge_dict
 
-from . import INTENTS_FILE, LANGUAGES, load_sentences, load_tests
+from . import INTENTS_FILE, LANGUAGES, load_sentences
 
 
 def pytest_addoption(parser):
@@ -45,18 +45,3 @@ def language_sentences(language_sentences_yaml: dict):
         merge_dict(merged, intents_dict)
 
     return Intents.from_dict(merged)
-
-
-@pytest.fixture(name="language_tests_yaml", scope="session")
-def language_tests_yaml_fixture(language: str):
-    """Loads the language tests."""
-    return load_tests(language)
-
-
-@pytest.fixture(scope="session")
-def language_tests(language_tests_yaml: dict):
-    """Loads the language tests."""
-    merged: dict = {}
-    for tests in language_tests_yaml.values():
-        merge_dict(merged, tests)
-    return merged

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,10 @@
 """Test configuration and fixtures."""
+from hassil import Intents
+from hassil.util import merge_dict
 import pytest
 import yaml
 
-from . import INTENTS_FILE, LANGUAGES, load_intents, load_tests
+from . import INTENTS_FILE, LANGUAGES, load_sentences, load_tests
 
 
 def pytest_addoption(parser):
@@ -27,13 +29,23 @@ def intent_schemas():
         return yaml.safe_load(schema_file)
 
 
+@pytest.fixture(name="language_sentences_yaml", scope="session")
+def language_sentences_yaml_fixture(language: str):
+    """Loads the language sentences."""
+    return load_sentences(language)
+
+
 @pytest.fixture(scope="session")
-def language_intents(language: str):
-    """Loads the base intents file"""
-    return load_intents(language)
+def language_sentences(language_sentences_yaml: dict):
+    """Parse language sentences."""
+    merged = {}
+    for intents_dict in language_sentences_yaml.values():
+        merge_dict(merged, intents_dict)
+
+    return Intents.from_dict(merged)
 
 
 @pytest.fixture(scope="session")
 def language_tests(language: str):
-    """Loads the base intents file"""
+    """Loads the language tests."""
     return load_tests(language)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,10 @@
 """Test configuration and fixtures."""
-from hassil import Intents
-from hassil.util import merge_dict
+from __future__ import annotations
+
 import pytest
 import yaml
+from hassil import Intents
+from hassil.util import merge_dict
 
 from . import INTENTS_FILE, LANGUAGES, load_sentences, load_tests
 
@@ -38,14 +40,23 @@ def language_sentences_yaml_fixture(language: str):
 @pytest.fixture(scope="session")
 def language_sentences(language_sentences_yaml: dict):
     """Parse language sentences."""
-    merged = {}
+    merged: dict = {}
     for intents_dict in language_sentences_yaml.values():
         merge_dict(merged, intents_dict)
 
     return Intents.from_dict(merged)
 
 
-@pytest.fixture(scope="session")
-def language_tests(language: str):
+@pytest.fixture(name="language_tests_yaml", scope="session")
+def language_tests_yaml_fixture(language: str):
     """Loads the language tests."""
     return load_tests(language)
+
+
+@pytest.fixture(scope="session")
+def language_tests(language_tests_yaml: dict):
+    """Loads the language tests."""
+    merged: dict = {}
+    for tests in language_tests_yaml.values():
+        merge_dict(merged, tests)
+    return merged

--- a/tests/test_language_intents.py
+++ b/tests/test_language_intents.py
@@ -34,9 +34,7 @@ def test_language_common(
 
 
 def test_language_sentences(
-    language_sentences: Intents,
-    language_sentences_yaml: Dict[str, Any],
-    intent_schemas: Dict[str, Any],
+    language_sentences: Intents, intent_schemas: Dict[str, Any]
 ):
     """Ensure all language sentences contain valid slots, lists, rules, etc."""
     # Add placeholder slots that HA will generate

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -5,13 +5,13 @@ import pytest
 from hassil import recognize
 from hassil.intents import TextSlotList
 
-from . import TEST_SENTENCES_DIR
+from . import TEST_SENTENCES_DIR, load_test
 
 
 @pytest.fixture(name="slot_lists", scope="session")
-def slot_lists_fixture(language_tests_yaml):
+def slot_lists_fixture(language):
     """Loads the slot lists for the language."""
-    fixtures = language_tests_yaml["_fixtures.yaml"]
+    fixtures = load_test(language, "_fixtures")
     return {
         "area": TextSlotList.from_tuples(
             (area["name"], area["id"]) for area in fixtures["areas"]
@@ -23,10 +23,10 @@ def slot_lists_fixture(language_tests_yaml):
 
 
 def do_test_language_sentences_file(
-    test_file, language_tests_yaml, slot_lists, language_sentences
+    language, test_file, slot_lists, language_sentences
 ):
     """Tests recognition all of the test sentences for a language"""
-    for test in language_tests_yaml[test_file]["tests"]:
+    for test in load_test(language, test_file)["tests"]:
         intent = test["intent"]
         for sentence in test["sentences"]:
             result = recognize(sentence, language_sentences, slot_lists=slot_lists)
@@ -44,9 +44,9 @@ def do_test_language_sentences_file(
 
 
 def gen_test(test_file):
-    def test_func(language_tests_yaml, slot_lists, language_sentences):
+    def test_func(language, slot_lists, language_sentences):
         do_test_language_sentences_file(
-            test_file.name, language_tests_yaml, slot_lists, language_sentences
+            language, test_file.stem, slot_lists, language_sentences
         )
 
     test_func.__name__ = f"test_{test_file.stem}"

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -1,26 +1,32 @@
 """Test language sentences."""
+import sys
 
 import pytest
 from hassil import recognize
 from hassil.intents import TextSlotList
 
+from . import TEST_SENTENCES_DIR
+
 
 @pytest.fixture(name="slot_lists", scope="session")
-def slot_lists_fixture(language_tests):
+def slot_lists_fixture(language_tests_yaml):
     """Loads the slot lists for the language."""
+    fixtures = language_tests_yaml["_fixtures.yaml"]
     return {
         "area": TextSlotList.from_tuples(
-            (area["name"], area["id"]) for area in language_tests["areas"]
+            (area["name"], area["id"]) for area in fixtures["areas"]
         ),
         "name": TextSlotList.from_tuples(
-            (entity["name"], entity["id"]) for entity in language_tests["entities"]
+            (entity["name"], entity["id"]) for entity in fixtures["entities"]
         ),
     }
 
 
-def test_language_sentences(slot_lists, language_sentences, language_tests):
+def do_test_language_sentences_file(
+    test_file, language_tests_yaml, slot_lists, language_sentences
+):
     """Tests recognition all of the test sentences for a language"""
-    for test in language_tests["tests"]:
+    for test in language_tests_yaml[test_file]["tests"]:
         intent = test["intent"]
         for sentence in test["sentences"]:
             result = recognize(sentence, language_sentences, slot_lists=slot_lists)
@@ -35,3 +41,24 @@ def test_language_sentences(slot_lists, language_sentences, language_tests):
                     slot_name in result.entities
                 ), f"For '{sentence}' did not receive slot '{slot_name}'"
                 assert result.entities[slot_name].value == slot_dict["value"]
+
+
+def gen_test(test_file):
+    def test_func(language_tests_yaml, slot_lists, language_sentences):
+        do_test_language_sentences_file(
+            test_file.name, language_tests_yaml, slot_lists, language_sentences
+        )
+
+    test_func.__name__ = f"test_{test_file.stem}"
+    setattr(sys.modules[__name__], test_func.__name__, test_func)
+
+
+def gen_tests():
+    lang_dir = TEST_SENTENCES_DIR / "en"
+
+    for test_file in lang_dir.glob("*.yaml"):
+        if test_file.name != "_fixtures.yaml":
+            gen_test(test_file)
+
+
+gen_tests()

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -18,12 +18,12 @@ def slot_lists_fixture(language_tests):
     }
 
 
-def test_language_sentences(slot_lists, language_intents, language_tests):
+def test_language_sentences(slot_lists, language_sentences, language_tests):
     """Tests recognition all of the test sentences for a language"""
     for test in language_tests["tests"]:
         intent = test["intent"]
         for sentence in test["sentences"]:
-            result = recognize(sentence, language_intents, slot_lists=slot_lists)
+            result = recognize(sentence, language_sentences, slot_lists=slot_lists)
             assert result is not None, f"Recognition failed for '{sentence}'"
             assert (
                 result.intent.name == intent["name"]


### PR DESCRIPTION
I want the validate step to be more about file format. The tests should test if all sentences are referencing correct intents. This is a first step to allow this structure. It moves the tests for a language common file into a new test.