### PR TITLE
Make validation more strict

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -35,11 +35,3 @@ def load_test(language: str, test_name: str):
     return yaml.safe_load(
         (TEST_SENTENCES_DIR / language / f"{test_name}.yaml").read_text()
     )
-    # lang_dir = TEST_SENTENCES_DIR / language
-    # files: Dict[str, Any] = {}
-
-    # for yaml_path in lang_dir.rglob("*.yaml"):
-    #     with open(yaml_path, "r", encoding="utf-8") as yaml_file:
-    #         files[yaml_path.name] = yaml.safe_load(yaml_file)
-
-    # return files

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -26,8 +26,14 @@ def do_test_language_sentences_file(
     language, test_file, slot_lists, language_sentences
 ):
     """Tests recognition all of the test sentences for a language"""
+    _testing_domain, testing_intent = test_file.split("_", 1)
+
     for test in load_test(language, test_file)["tests"]:
         intent = test["intent"]
+        assert (
+            intent["name"] == testing_intent
+        ), f"File {test_file} should only test for intent {testing_intent}"
+
         for sentence in test["sentences"]:
             result = recognize(sentence, language_sentences, slot_lists=slot_lists)
             assert result is not None, f"Recognition failed for '{sentence}'"


### PR DESCRIPTION
Our format allows the same keys for `_common.yaml` and the intent files. However, as convention we don't allow that in this repository. This ensures validation checks this.

Also moves that all tested intents match the filename from validation to the test.