### PR TITLE
Split language intents tests by file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Repository layout:
 * `tests/<language>`
     * YAML files for `<language>` with test sentences and corresponding intents
     * [File format](tests/README.md#file-format)
-    
+
 See the [documentation](docs/README.md) for more information.
 
 
@@ -75,10 +75,10 @@ Validate the data is correctly formatted.
 python3 -m script.intentfest validate
 ```
 
-Run the tests. Leave `--language` off to run all tests.
+Run the tests. Specify a language with `--language` and specify a file with `-k`. Leave off both to run the full test suite.
 
 ```
-pytest tests --language nl
+pytest tests --language nl -k fan_HassTurnOn
 ```
 
 ## Test parsing sentences

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -347,14 +347,6 @@ def validate_language(intent_schemas, language, errors):
         if sentence_count > test_count:
             errors[language].append(f"{path}: not all sentences have tests")
 
-        test_sentences = set()
-
-        for test in content["tests"]:
-            for sentence in test["sentences"]:
-                if sentence in test_sentences:
-                    errors[language].append(f"{path}: duplicate sentence {sentence}")
-                test_sentences.add(sentence)
-
     if sentence_files:
         for sentence_file in sentence_files:
             errors[language].append(f"{sentence_file} has no tests")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,15 +7,15 @@ import yaml
 _DIR = Path(__file__).parent
 _BASE_DIR = _DIR.parent
 INTENTS_FILE = _BASE_DIR / "intents.yaml"
-USER_SENTENCES_DIR = _BASE_DIR / "sentences"
-TEST_SENTENCES_DIR = _BASE_DIR / "tests"
+SENTENCES_DIR = _BASE_DIR / "sentences"
+TESTS_DIR = _BASE_DIR / "tests"
 
-LANGUAGES = [p.name for p in USER_SENTENCES_DIR.iterdir() if p.is_dir()]
+LANGUAGES = [p.name for p in SENTENCES_DIR.iterdir() if p.is_dir()]
 
 
 def load_sentences(language: str):
     """Load sentences from sentences/ for a language"""
-    lang_dir = USER_SENTENCES_DIR / language
+    lang_dir = SENTENCES_DIR / language
     files: Dict[str, Any] = {}
 
     for yaml_path in lang_dir.glob("*.yaml"):
@@ -32,6 +32,4 @@ def load_sentences(language: str):
 
 def load_test(language: str, test_name: str):
     """Load test sentences from tests/ for a language"""
-    return yaml.safe_load(
-        (TEST_SENTENCES_DIR / language / f"{test_name}.yaml").read_text()
-    )
+    return yaml.safe_load((TESTS_DIR / language / f"{test_name}.yaml").read_text())

--- a/tests/test_language_intents.py
+++ b/tests/test_language_intents.py
@@ -3,19 +3,11 @@ import dataclasses
 import sys
 from typing import Any, Dict, Iterable, Set
 
-import pytest
 from hassil import Intents
 from hassil.expression import Expression, ListReference, RuleReference, Sequence
 from hassil.intents import TextSlotList
 
 from . import USER_SENTENCES_DIR
-
-
-@pytest.fixture(name="common_language_intents", scope="session")
-def common_language_intents_fixture(language, language_sentences_yaml):
-    """Loads the common language intents."""
-    language_sentences_yaml["_common.yaml"].setdefault("intents", {})
-    return Intents.from_dict(language_sentences_yaml["_common.yaml"])
 
 
 def test_language_common(
@@ -49,7 +41,7 @@ def do_test_language_sentences(
     file_name: str,
     intent_schemas: Dict[str, Any],
     language_sentences_yaml: Dict[str, Any],
-    common_language_intents: Intents,
+    language_sentences_common: Intents,
 ):
     """Ensure all language sentences contain valid slots, lists, rules, etc."""
     parsed_sentences_without_common = Intents.from_dict(
@@ -58,7 +50,7 @@ def do_test_language_sentences(
 
     # Merge common rules with file specific intents.
     language_sentences = dataclasses.replace(
-        common_language_intents, intents=parsed_sentences_without_common.intents
+        language_sentences_common, intents=parsed_sentences_without_common.intents
     )
 
     # Add placeholder slots that HA will generate
@@ -162,12 +154,12 @@ def _flatten(expression: Expression) -> Iterable[Expression]:
 
 
 def gen_test(test_file):
-    def test_func(intent_schemas, language_sentences_yaml, common_language_intents):
+    def test_func(intent_schemas, language_sentences_yaml, language_sentences_common):
         do_test_language_sentences(
             test_file.name,
             intent_schemas,
             language_sentences_yaml,
-            common_language_intents,
+            language_sentences_common,
         )
 
     test_func.__name__ = f"test_{test_file.stem}"

--- a/tests/test_language_intents.py
+++ b/tests/test_language_intents.py
@@ -53,7 +53,7 @@ def do_test_language_sentences(
 ):
     """Ensure all language sentences contain valid slots, lists, rules, etc."""
     parsed_sentences_without_common = Intents.from_dict(
-        language_sentences_yaml[f"{file_name}.yaml"]
+        language_sentences_yaml[file_name]
     )
 
     # Merge common rules with file specific intents.
@@ -165,7 +165,7 @@ def _flatten(expression: Expression) -> Iterable[Expression]:
 def gen_test(test_file):
     def test_func(intent_schemas, language_sentences_yaml, common_language_intents):
         do_test_language_sentences(
-            test_file.stem,
+            test_file.name,
             intent_schemas,
             language_sentences_yaml,
             common_language_intents,

--- a/tests/test_language_intents.py
+++ b/tests/test_language_intents.py
@@ -61,7 +61,6 @@ def do_test_language_sentences(
         common_language_intents, intents=parsed_sentences_without_common.intents
     )
 
-    # language_sentences = Intents.from_dict(merged)
     # Add placeholder slots that HA will generate
     language_sentences.slot_lists["area"] = TextSlotList(values=[])
     language_sentences.slot_lists["name"] = TextSlotList(values=[])

--- a/tests/test_language_intents.py
+++ b/tests/test_language_intents.py
@@ -7,7 +7,7 @@ from hassil import Intents
 from hassil.expression import Expression, ListReference, RuleReference, Sequence
 from hassil.intents import TextSlotList
 
-from . import USER_SENTENCES_DIR
+from . import SENTENCES_DIR
 
 
 def test_language_common(
@@ -167,7 +167,7 @@ def gen_test(test_file):
 
 
 def gen_tests():
-    lang_dir = USER_SENTENCES_DIR / "en"
+    lang_dir = SENTENCES_DIR / "en"
 
     for test_file in lang_dir.glob("*.yaml"):
         if test_file.name != "_common.yaml":

--- a/tests/test_language_intents.py
+++ b/tests/test_language_intents.py
@@ -123,7 +123,7 @@ def _verify(
         rule_ref: RuleReference = expression
         assert (
             rule_ref.rule_name in intents.expansion_rules
-        ), f"Missing expansion rule: <{rule_ref.rule_name}>. Are you missing a 'expansion_rules' entry in _common.yaml?"
+        ), f"Missing expansion rule: <{rule_ref.rule_name}>. Are you missing an 'expansion_rules' entry in _common.yaml?"
 
         # Check for recursive rules (not supported)
         assert (

--- a/tests/test_language_intents.py
+++ b/tests/test_language_intents.py
@@ -110,12 +110,12 @@ def _verify(
         # Ensure list exists
         assert (
             list_ref.list_name in intents.slot_lists
-        ), f"Missing slot list: {{{list_ref.list_name}}}. Available slots: {', '.join(intents.slot_lists)}"
+        ), f"Missing slot list: {{{list_ref.list_name}}}. Are you missing a 'lists' entry in _common.yaml?"
 
         # Ensure slot is part of intent
         assert (
             list_ref.slot_name in slot_schema
-        ), f"Unexpected slot '{list_ref.slot_name}' for intent '{intent_name}"
+        ), f"Intent {intent_name} does not support slot '{list_ref.slot_name}'. See intents.yaml for supported slots"
 
         # Track slots for combination check
         found_slots.add(list_ref.slot_name)
@@ -123,7 +123,7 @@ def _verify(
         rule_ref: RuleReference = expression
         assert (
             rule_ref.rule_name in intents.expansion_rules
-        ), f"Missing expansion rule: <{rule_ref.rule_name}>"
+        ), f"Missing expansion rule: <{rule_ref.rule_name}>. Are you missing a 'expansion_rules' entry in _common.yaml?"
 
         # Check for recursive rules (not supported)
         assert (

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -28,6 +28,8 @@ def do_test_language_sentences_file(
     """Tests recognition all of the test sentences for a language"""
     _testing_domain, testing_intent = test_file.split("_", 1)
 
+    seen_sentences = set()
+
     for test in load_test(language, test_file)["tests"]:
         intent = test["intent"]
         assert (
@@ -35,6 +37,11 @@ def do_test_language_sentences_file(
         ), f"File {test_file} should only test for intent {testing_intent}"
 
         for sentence in test["sentences"]:
+            assert (
+                sentence not in seen_sentences
+            ), f"Duplicate sentence found: {sentence}"
+            seen_sentences.add(sentence)
+
             result = recognize(sentence, language_sentences, slot_lists=slot_lists)
             assert result is not None, f"Recognition failed for '{sentence}'"
             assert (

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -5,7 +5,7 @@ import pytest
 from hassil import recognize
 from hassil.intents import TextSlotList
 
-from . import TEST_SENTENCES_DIR, load_test
+from . import TESTS_DIR, load_test
 
 
 @pytest.fixture(name="slot_lists", scope="session")
@@ -67,7 +67,7 @@ def gen_test(test_file):
 
 
 def gen_tests():
-    lang_dir = TEST_SENTENCES_DIR / "en"
+    lang_dir = TESTS_DIR / "en"
 
     for test_file in lang_dir.glob("*.yaml"):
         if test_file.name != "_fixtures.yaml":


### PR DESCRIPTION
This splits language intents tests by file.

Since we only allow lists/expansion rules to be defined in `_common.yaml`, we can limit the intent parser to common + the sentences in the file that we're looking at.

~~This however did not result in a speedup.~~

**Before**

```
48 passed in 11.36s

Slowest:
3.99s setup    tests/test_language_intents.py::test_language_sentences[de]
2.22s setup    tests/test_language_intents.py::test_language_sentences[nl]
1.74s setup    tests/test_language_intents.py::test_language_sentences[hu]
```

**After**

```
288 passed in 38.57s

Slowest:
2.25s call     tests/test_language_intents.py::test_cover_HassOpenCover[de]
1.83s call     tests/test_language_intents.py::test_cover_HassCloseCover[de]
1.76s call     tests/test_language_intents.py::test_climate_HassClimateGetTemperature[de]
```

German is slowest as it's currently the most complete language. Leaving it open as draft so I can tinker with it a bit more. But I doubt this is going somewhere. It's a pity because the per-file feedback is a lot more user friendly.