### PR TITLE
fix wrong language in area

### DIFF
--- a/tests/en/_fixtures.yaml
+++ b/tests/en/_fixtures.yaml
@@ -18,6 +18,6 @@ entities:
   - name: "Ceiling Fan"
     id: "fan.ceiling"
     area: "living_room"
-  - name: Curtain Left
-    id: cover.curtain_left
-    area: woonkamer
+  - name: "Curtain Left"
+    id: "cover.curtain_left"
+    area: "living_room"


### PR DESCRIPTION
Area name was in Dutch instead of English.
Missing double-quotes for consistency in file.