### PR TITLE
Add VSCode task to test current file or language

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,34 +2,48 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "Run Tests",
+      "label": "Run Test for current file",
       "type": "shell",
-      "command": "pytest tests",
-      "dependsOn": ["Validate files"],
+      "command": "script/test_file",
+      "args": ["${relativeFile}"],
       "group": {
         "kind": "test",
         "isDefault": true
       },
       "presentation": {
         "reveal": "always",
-        "panel": "new"
-      },
-      "problemMatcher": []
+        "panel": "shared",
+        "clear": true
+      }
     },
     {
-      "label": "Validate files",
+      "label": "Run Test for current language",
       "type": "shell",
-      "command": "python3 -m script.intentfest validate",
-      "dependsOn": [],
+      "command": "script/test_file",
+      "args": ["${relativeFile}", "--select-language"],
       "group": {
         "kind": "test",
         "isDefault": true
       },
       "presentation": {
         "reveal": "always",
-        "panel": "new"
+        "panel": "shared",
+        "clear": true
+      }
+    },
+    {
+      "label": "Run Tests for all languages",
+      "type": "shell",
+      "command": "python3 -m script.intentfest validate && pytest tests",
+      "group": {
+        "kind": "test",
+        "isDefault": false
       },
-      "problemMatcher": []
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared",
+        "clear": true
+      }
     }
   ]
 }

--- a/docs/codespace/README.md
+++ b/docs/codespace/README.md
@@ -1,6 +1,6 @@
 # Codespaces Workflow
 
-A complete development environment can be accessed through [Github codespaces](https://docs.github.com/en/codespaces/overview). 
+A complete development environment can be accessed through [Github codespaces](https://docs.github.com/en/codespaces/overview).
 
 To get started, click the green "Code" button on the repository's main page, and then click "Create codespace on main":
 
@@ -26,7 +26,7 @@ Once you've made some changes, you can run the tests right here! Choose "Termina
 
 ![Run task](run_task.jpg)
 
-Next, type "test" into the text box at the top and click "Run Tests":
+Next, type "test" into the text box at the top and click "Run Test for current file":
 
 ![Run tests](run_tests.jpg)
 

--- a/script/test_file
+++ b/script/test_file
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+"""
+This script will run the tests for a given file.
+"""
+
+import sys
+from pathlib import Path
+import subprocess
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: scrip/test_file <path> [--select-language]")
+        sys.exit(1)
+
+    target_path = Path(sys.argv[1])
+    select_language = len(sys.argv) > 2 and sys.argv[2] == "--select-language"
+
+    if len(target_path.parts) != 3 or target_path.parts[0] not in (
+        "sentences",
+        "tests",
+    ):
+        print("Error: File must be in the sentences or tests directory")
+        sys.exit(2)
+
+    language = target_path.parts[1]
+    file_name = target_path.parts[2]
+
+    test_cmd = [
+        "pytest",
+        "-v",
+        "--language",
+        language,
+    ]
+
+    if select_language or file_name in ("_fixtures.yaml", "_common.yaml"):
+        print(f"Running all tests for {language.upper()}")
+
+    else:
+        print("Running tests for file", file_name)
+        test_cmd.extend(["-k", target_path.stem])
+
+    print()
+
+    try:
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "script.intentfest",
+                "validate",
+                "--language",
+                language,
+            ],
+            cwd=Path(__file__).parent.parent,
+            check=True,
+        )
+    except subprocess.CalledProcessError as err:
+        sys.exit(err.returncode)
+
+    try:
+        subprocess.run(
+            test_cmd,
+            cwd=Path(__file__).parent.parent,
+            check=True,
+        )
+    except subprocess.CalledProcessError as err:
+        sys.exit(err.returncode)
+
+
+main()


### PR DESCRIPTION
- Add scrip to run the tests for a specific file `script/test_file `script/test_file sentences/nl/fan_HassTurnOn.yaml`
  - Select all tests of language of passed in file by adding `--select-language` to the command.
- Add VSCode task that leverages this script

![CleanShot 2022-12-26 at 22 15 48](https://user-images.githubusercontent.com/1444314/209605590-afe64db0-4a36-4274-a218-83c4b4fd03f7.png)

![CleanShot 2022-12-26 at 22 16 30](https://user-images.githubusercontent.com/1444314/209605618-5bbdee37-3dd7-4970-a8ff-abcac2f76c37.png)

![CleanShot 2022-12-26 at 22 18 50](https://user-images.githubusercontent.com/1444314/209605822-1e7253a9-008a-4ccf-a291-65b4edc9e7ba.png)

