### PR TITLE
Make test output slightly more readable if slot missing

### DIFF
--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -57,7 +57,10 @@ def do_test_language_sentences_file(
                 if not isinstance(slot_dict, dict):
                     slot_dict = {"value": slot_dict}
                 assert (
-                    slot_name in result.entities
+                    slot_name
+                    in
+                    # wrap it in a list to get more readable pytest assertion
+                    list(result.entities)
                 ), f"For '{sentence}' did not receive slot '{slot_name}'"
                 assert result.entities[slot_name].value == slot_dict["value"]
 


### PR DESCRIPTION
Before:

```
E                   AssertionError: For 'éteins la lumière de la chambre' did not receive slot 'name'
E                   assert 'name' in {'area': MatchEntity(name='area', value='bedroom'), 'domain': MatchEntity(name='domain', value='light')}
```

After:

```
E                   AssertionError: For 'éteins la lumière de la chambre' did not receive slot 'name'
E                   assert 'name' in ['area', 'domain']
E                    +  where ['area', 'domain'] = list({'area': MatchEntity(name='area', value='bedroom'), 'domain': MatchEntity(name='domain', value='light')})
```