### PR TITLE
Validate no matching syntax in fixture names

### DIFF
--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -252,6 +252,7 @@ TESTS_SCHEMA = vol.Schema(
     }
 )
 
+NAME_MATCHER = vol.Match(r"^[\w ]+$", "Names cannot contain matching syntax")
 TESTS_FIXTURES = vol.Schema(
     {
         vol.Required("language"): str,
@@ -263,14 +264,14 @@ TESTS_FIXTURES = vol.Schema(
         ],
         vol.Optional("areas"): [
             {
-                vol.Required("name"): str,
+                vol.Required("name"): NAME_MATCHER,
                 vol.Required("id"): str,
                 vol.Optional("floor"): str,
             }
         ],
         vol.Optional("entities"): [
             {
-                vol.Required("name"): str,
+                vol.Required("name"): NAME_MATCHER,
                 vol.Required("id"): str,
                 vol.Optional("area"): str,
                 vol.Optional("device_class"): str,


### PR DESCRIPTION
This updates the validator to catch matching syntax being used in fixture names.

Although our parser allows fixtures with parsing syntax, it's not something Home Assistant would ever provide.

We need a solution where we can define a format how nouns are transformed.

See [files changed](https://github.com/home-assistant/intents/pull/164/files) for languages that fail validation.