### PR TITLE
Validate area ids correct

### DIFF
--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -324,6 +324,12 @@ def validate_language(intent_schemas, language, errors):
         content = _load_yaml_file(errors[language], language, test_file, schema)
 
         if content is None or test_file.name == "_fixtures.yaml":
+            area_ids = set(area["id"] for area in content.get("areas", []))
+            for entity in content.get("entities", []):
+                if entity["area"] not in area_ids:
+                    errors[language].append(
+                        f"{path}: Entity {entity['name']} references unknown area {entity['id']}"
+                    )
             continue
 
         if test_file.name not in sentence_files:

--- a/tests/pl/_fixtures.yaml
+++ b/tests/pl/_fixtures.yaml
@@ -19,5 +19,5 @@ entities:
     id: fan.ceiling
     area: living_room
   - name: Szuflad(a|ę)
-    id: cover.cloth
-    area: woonkamer
+    id: cover.szuflada
+    area: living_room

--- a/tests/pl/cover_HassCloseCover.yaml
+++ b/tests/pl/cover_HassCloseCover.yaml
@@ -5,13 +5,13 @@ tests:
     intent:
       name: "HassCloseCover"
       slots:
-        name: cover.cloth
+        name: cover.szuflada
   - sentences:
       - "Zamknij szufladę w salonie"
     intent:
       name: "HassCloseCover"
       slots:
-        name: cover.cloth
+        name: cover.szuflada
         area: living_room
 
   - sentences:

--- a/tests/pl/cover_HassOpenCover.yaml
+++ b/tests/pl/cover_HassOpenCover.yaml
@@ -5,13 +5,13 @@ tests:
     intent:
       name: "HassOpenCover"
       slots:
-        name: cover.cloth
+        name: cover.szuflada
   - sentences:
       - "Otwórz szufladę w salonie"
     intent:
       name: "HassOpenCover"
       slots:
-        name: cover.cloth
+        name: cover.szuflada
         area: living_room
 
   - sentences:


### PR DESCRIPTION
Validate that all area IDs used for entity fixtures are valid. Found 1 error for Polish.