### PR TITLE
Validate to guard no question marks added to sentences

### DIFF
--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -79,6 +79,11 @@ INTENT_ERRORS = {
     "handle_error",
 }
 
+SENTENCE_MATCHER = vol.Match(
+    r"^[\w \|\(\)\[\]\{\}\<\>]+$",
+    msg="Sentences should only contain words and matching syntax. They should not contain punctuation.",
+)
+
 SENTENCE_SCHEMA = vol.Schema(
     {
         vol.Required("language"): str,
@@ -86,7 +91,7 @@ SENTENCE_SCHEMA = vol.Schema(
             str: {
                 vol.Required("data"): [
                     {
-                        vol.Required("sentences"): [str],
+                        vol.Required("sentences"): [SENTENCE_MATCHER],
                         vol.Optional("slots"): {
                             str: match_anything,
                         },


### PR DESCRIPTION
Validate to ensure match sentences do not contain any punctuation.

Punctuation is already ignored by the matcher and we don't want to have characters in our match sentences that are going to be ignored, as it that can lead to confusion.