### PR TITLE
Add command to generate merged output

### DIFF
--- a/script/intentfest/merged_output.py
+++ b/script/intentfest/merged_output.py
@@ -1,0 +1,89 @@
+"""Command to generate merged output."""
+
+import argparse
+from pathlib import Path
+
+import yaml
+from hassil.util import merge_dict
+
+from .const import INTENTS_FILE, LANGUAGES, RESPONSE_DIR, SENTENCE_DIR
+from .util import get_base_arg_parser
+
+
+def get_arguments() -> argparse.Namespace:
+    """Get parsed passed in arguments."""
+    parser = get_base_arg_parser()
+    parser.add_argument("target", type=str, help="The target directory.")
+    return parser.parse_args()
+
+
+def run() -> int:
+    args = get_arguments()
+
+    target = Path(args.target)
+    target.mkdir(exist_ok=True)
+
+    intent_info = yaml.safe_load(INTENTS_FILE.read_text())
+    intent_by_domain: dict[str, list] = {}
+    for intent, info in intent_info.items():
+        intent_by_domain.setdefault(info["domain"], []).append(intent)
+    for intents in intent_by_domain.values():
+        intents.sort()
+
+    for domain in intent_by_domain:
+        (target / domain / "sentences").mkdir(parents=True, exist_ok=True)
+
+    for language in LANGUAGES:
+        merged_sentences: dict = {}
+        for sentence_file in (SENTENCE_DIR / language).iterdir():
+            merge_dict(merged_sentences, yaml.safe_load(sentence_file.read_text()))
+
+        merged_responses: dict = {}
+        for response_file in (RESPONSE_DIR / language).iterdir():
+            merge_dict(merged_responses, yaml.safe_load(response_file.read_text()))
+
+        for domain, supported_intents in intent_by_domain.items():
+            domain_intents = {}
+            for intent, info in merged_sentences["intents"].items():
+                if intent not in supported_intents:
+                    continue
+
+                data = []
+                for data_set in info["data"]:
+                    if len(data_set["sentences"]) > 0:
+                        data.append(data_set)
+
+                if data:
+                    domain_intents[intent] = {
+                        **info,
+                        "data": data,
+                    }
+
+            domain_responses = {
+                intent: info
+                for intent, info in merged_responses["responses"]["intents"].items()
+                if intent in supported_intents and len(info["success"]) > 0
+            }
+
+            if not domain_intents and not domain_responses:
+                continue
+
+            if domain == "homeassistant":
+                output: dict = {
+                    **merged_sentences,
+                    "intents": {},
+                }
+            else:
+                output = {"language": language}
+
+            if domain_intents:
+                output["intents"] = domain_intents
+
+            if domain_responses:
+                output.setdefault("responses", {})["intents"] = domain_responses
+
+            (target / domain / "sentences" / f"{language}.yaml").write_text(
+                yaml.dump(output, sort_keys=False)
+            )
+
+    return 0

--- a/script/intentfest/util.py
+++ b/script/intentfest/util.py
@@ -16,6 +16,7 @@ def get_base_arg_parser() -> argparse.ArgumentParser:
         choices=[
             "add_language",
             "codeowners",
+            "merged_output",
             "parse",
             "sample_template",
             "sample",


### PR DESCRIPTION
This adds a new command to generate merged output as we'll need to export this repository to Home Assistant core.

```
python3 -m script.intentfest merged_output build
```

Merge approach is to first merge all files belonging to a single language, and then split them based on the domain that defines the intent.

The output for the `homeassistant` domain will also include the lists, expansion rules etc.

Marking this PR as a draft until we are sure how the HA Core part will consume this data.