### PR TITLE
Rename Danish from DK to DA

### DIFF
--- a/responses/da/HassClimateGetTemperature.yaml
+++ b/responses/da/HassClimateGetTemperature.yaml
@@ -1,4 +1,4 @@
-language: dk
+language: da
 responses:
   intents:
     HassClimateGetTemperature:

--- a/sentences/da/_common.yaml
+++ b/sentences/da/_common.yaml
@@ -1,4 +1,4 @@
-language: dk
+language: da
 responses:
   errors:
     no_intent: "Undskyld, jeg kunne ikke forstå det"

--- a/sentences/da/climate_HassClimateGetTemperature.yaml
+++ b/sentences/da/climate_HassClimateGetTemperature.yaml
@@ -1,5 +1,5 @@
-language: dk
+language: da
 intents:
   HassClimateGetTemperature:
     data:
-    - sentences: []
+      - sentences: []

--- a/sentences/da/climate_HassClimateSetTemperature.yaml
+++ b/sentences/da/climate_HassClimateSetTemperature.yaml
@@ -1,5 +1,5 @@
-language: dk
+language: da
 intents:
   HassClimateSetTemperature:
     data:
-    - sentences: []
+      - sentences: []

--- a/sentences/da/cover_HassCloseCover.yaml
+++ b/sentences/da/cover_HassCloseCover.yaml
@@ -1,5 +1,5 @@
-language: dk
+language: da
 intents:
   HassCloseCover:
     data:
-    - sentences: []
+      - sentences: []

--- a/sentences/da/cover_HassOpenCover.yaml
+++ b/sentences/da/cover_HassOpenCover.yaml
@@ -1,5 +1,5 @@
-language: dk
+language: da
 intents:
   HassOpenCover:
     data:
-    - sentences: []
+      - sentences: []

--- a/sentences/da/fan_HassTurnOff.yaml
+++ b/sentences/da/fan_HassTurnOff.yaml
@@ -1,0 +1,8 @@
+language: da
+intents:
+  HassTurnOff:
+    data:
+      - sentences: []
+        slots:
+          domain: fan
+          name: all

--- a/sentences/da/fan_HassTurnOn.yaml
+++ b/sentences/da/fan_HassTurnOn.yaml
@@ -1,0 +1,8 @@
+language: da
+intents:
+  HassTurnOn:
+    data:
+      - sentences: []
+        slots:
+          domain: fan
+          name: all

--- a/sentences/da/homeassistant_HassTurnOff.yaml
+++ b/sentences/da/homeassistant_HassTurnOff.yaml
@@ -1,6 +1,6 @@
-language: dk
+language: da
 intents:
   HassTurnOff:
     data:
       - sentences:
-        - "sluk {name}(en | et)"
+          - "sluk {name}(en | et)"

--- a/sentences/da/homeassistant_HassTurnOn.yaml
+++ b/sentences/da/homeassistant_HassTurnOn.yaml
@@ -1,6 +1,6 @@
-language: dk
+language: da
 intents:
   HassTurnOn:
     data:
       - sentences:
-        - "tænd {name}(en | et)"
+          - "tænd {name}(en | et)"

--- a/sentences/da/light_HassLightSet.yaml
+++ b/sentences/da/light_HassLightSet.yaml
@@ -1,5 +1,5 @@
-language: dk
+language: da
 intents:
   HassLightSet:
     data:
-    - sentences: []
+      - sentences: []

--- a/sentences/da/light_HassTurnOff.yaml
+++ b/sentences/da/light_HassTurnOff.yaml
@@ -1,0 +1,8 @@
+language: da
+intents:
+  HassTurnOff:
+    data:
+      - sentences: []
+        slots:
+          domain: light
+          name: all

--- a/sentences/da/light_HassTurnOn.yaml
+++ b/sentences/da/light_HassTurnOn.yaml
@@ -1,0 +1,8 @@
+language: da
+intents:
+  HassTurnOn:
+    data:
+      - sentences: []
+        slots:
+          domain: light
+          name: all

--- a/sentences/dk/fan_HassTurnOff.yaml
+++ b/sentences/dk/fan_HassTurnOff.yaml
@@ -1,8 +1,0 @@
-language: dk
-intents:
-  HassTurnOff:
-    data:
-    - sentences: []
-      slots:
-        domain: fan
-        name: all

--- a/sentences/dk/fan_HassTurnOn.yaml
+++ b/sentences/dk/fan_HassTurnOn.yaml
@@ -1,8 +1,0 @@
-language: dk
-intents:
-  HassTurnOn:
-    data:
-    - sentences: []
-      slots:
-        domain: fan
-        name: all

--- a/sentences/dk/light_HassTurnOff.yaml
+++ b/sentences/dk/light_HassTurnOff.yaml
@@ -1,8 +1,0 @@
-language: dk
-intents:
-  HassTurnOff:
-    data:
-    - sentences: []
-      slots:
-        domain: light
-        name: all

--- a/sentences/dk/light_HassTurnOn.yaml
+++ b/sentences/dk/light_HassTurnOn.yaml
@@ -1,8 +1,0 @@
-language: dk
-intents:
-  HassTurnOn:
-    data:
-    - sentences: []
-      slots:
-        domain: light
-        name: all

--- a/tests/da/_fixtures.yaml
+++ b/tests/da/_fixtures.yaml
@@ -1,4 +1,4 @@
-language: dk
+language: da
 areas:
   - name: Køkken
     id: kitchen

--- a/tests/da/climate_HassClimateGetTemperature.yaml
+++ b/tests/da/climate_HassClimateGetTemperature.yaml
@@ -1,0 +1,6 @@
+language: da
+tests:
+  - sentences: []
+    intent:
+      name: HassClimateGetTemperature
+      slots: {}

--- a/tests/da/climate_HassClimateSetTemperature.yaml
+++ b/tests/da/climate_HassClimateSetTemperature.yaml
@@ -1,0 +1,6 @@
+language: da
+tests:
+  - sentences: []
+    intent:
+      name: HassClimateSetTemperature
+      slots: {}

--- a/tests/da/cover_HassCloseCover.yaml
+++ b/tests/da/cover_HassCloseCover.yaml
@@ -1,0 +1,6 @@
+language: da
+tests:
+  - sentences: []
+    intent:
+      name: HassCloseCover
+      slots: {}

--- a/tests/da/cover_HassOpenCover.yaml
+++ b/tests/da/cover_HassOpenCover.yaml
@@ -1,0 +1,6 @@
+language: da
+tests:
+  - sentences: []
+    intent:
+      name: HassOpenCover
+      slots: {}

--- a/tests/da/fan_HassTurnOff.yaml
+++ b/tests/da/fan_HassTurnOff.yaml
@@ -1,0 +1,6 @@
+language: da
+tests:
+  - sentences: []
+    intent:
+      name: HassTurnOff
+      slots: {}

--- a/tests/da/fan_HassTurnOn.yaml
+++ b/tests/da/fan_HassTurnOn.yaml
@@ -1,0 +1,6 @@
+language: da
+tests:
+  - sentences: []
+    intent:
+      name: HassTurnOn
+      slots: {}

--- a/tests/da/homeassistant_HassTurnOff.yaml
+++ b/tests/da/homeassistant_HassTurnOff.yaml
@@ -1,0 +1,8 @@
+language: da
+tests:
+  - sentences:
+      - "sluk soveværelseslyset"
+    intent:
+      name: HassTurnOff
+      slots:
+        name: "light.bedroom_lamp"

--- a/tests/da/homeassistant_HassTurnOn.yaml
+++ b/tests/da/homeassistant_HassTurnOn.yaml
@@ -1,0 +1,8 @@
+language: da
+tests:
+  - sentences:
+      - "tænd soveværelseslyset"
+    intent:
+      name: HassTurnOn
+      slots:
+        name: "light.bedroom_lamp"

--- a/tests/da/light_HassLightSet.yaml
+++ b/tests/da/light_HassLightSet.yaml
@@ -1,0 +1,6 @@
+language: da
+tests:
+  - sentences: []
+    intent:
+      name: HassLightSet
+      slots: {}

--- a/tests/da/light_HassTurnOff.yaml
+++ b/tests/da/light_HassTurnOff.yaml
@@ -1,0 +1,6 @@
+language: da
+tests:
+  - sentences: []
+    intent:
+      name: HassTurnOff
+      slots: {}

--- a/tests/da/light_HassTurnOn.yaml
+++ b/tests/da/light_HassTurnOn.yaml
@@ -1,0 +1,6 @@
+language: da
+tests:
+  - sentences: []
+    intent:
+      name: HassTurnOn
+      slots: {}

--- a/tests/dk/climate_HassClimateGetTemperature.yaml
+++ b/tests/dk/climate_HassClimateGetTemperature.yaml
@@ -1,6 +1,0 @@
-language: dk
-tests:
-- sentences: []
-  intent:
-    name: HassClimateGetTemperature
-    slots: {}

--- a/tests/dk/climate_HassClimateSetTemperature.yaml
+++ b/tests/dk/climate_HassClimateSetTemperature.yaml
@@ -1,6 +1,0 @@
-language: dk
-tests:
-- sentences: []
-  intent:
-    name: HassClimateSetTemperature
-    slots: {}

--- a/tests/dk/cover_HassCloseCover.yaml
+++ b/tests/dk/cover_HassCloseCover.yaml
@@ -1,6 +1,0 @@
-language: dk
-tests:
-- sentences: []
-  intent:
-    name: HassCloseCover
-    slots: {}

--- a/tests/dk/cover_HassOpenCover.yaml
+++ b/tests/dk/cover_HassOpenCover.yaml
@@ -1,6 +1,0 @@
-language: dk
-tests:
-- sentences: []
-  intent:
-    name: HassOpenCover
-    slots: {}

--- a/tests/dk/fan_HassTurnOff.yaml
+++ b/tests/dk/fan_HassTurnOff.yaml
@@ -1,6 +1,0 @@
-language: dk
-tests:
-- sentences: []
-  intent:
-    name: HassTurnOff
-    slots: {}

--- a/tests/dk/fan_HassTurnOn.yaml
+++ b/tests/dk/fan_HassTurnOn.yaml
@@ -1,6 +1,0 @@
-language: dk
-tests:
-- sentences: []
-  intent:
-    name: HassTurnOn
-    slots: {}

--- a/tests/dk/homeassistant_HassTurnOff.yaml
+++ b/tests/dk/homeassistant_HassTurnOff.yaml
@@ -1,8 +1,0 @@
-language: dk
-tests:
-- sentences:
-    - "sluk soveværelseslyset"
-  intent:
-    name: HassTurnOff
-    slots:
-      name: "light.bedroom_lamp"

--- a/tests/dk/homeassistant_HassTurnOn.yaml
+++ b/tests/dk/homeassistant_HassTurnOn.yaml
@@ -1,8 +1,0 @@
-language: dk
-tests:
-- sentences:
-    - "tænd soveværelseslyset"
-  intent:
-    name: HassTurnOn
-    slots:
-      name: "light.bedroom_lamp"

--- a/tests/dk/light_HassLightSet.yaml
+++ b/tests/dk/light_HassLightSet.yaml
@@ -1,6 +1,0 @@
-language: dk
-tests:
-- sentences: []
-  intent:
-    name: HassLightSet
-    slots: {}

--- a/tests/dk/light_HassTurnOff.yaml
+++ b/tests/dk/light_HassTurnOff.yaml
@@ -1,6 +1,0 @@
-language: dk
-tests:
-- sentences: []
-  intent:
-    name: HassTurnOff
-    slots: {}

--- a/tests/dk/light_HassTurnOn.yaml
+++ b/tests/dk/light_HassTurnOn.yaml
@@ -1,6 +1,0 @@
-language: dk
-tests:
-- sentences: []
-  intent:
-    name: HassTurnOn
-    slots: {}


### PR DESCRIPTION
Danish language code is `da`. We had it as `dk`. This PR addresses that.

https://www.loc.gov/standards/iso639-2/php/langcodes_name.php?iso_639_1=da