### PR TITLE
Add languages yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
           python-version: "3.10"
           cache: "pip"
       - run: script/setup
-      - run: venv/bin/python3 -m script.intentfest add_language test_add_language_generates_valid_data
+      - run: venv/bin/python3 -m script.intentfest add_language test_add_language_generates_valid_data "CI Added Language"
       - run: script/lint
       - run: script/test
       - run: venv/bin/python3 -m script.intentfest parse --language en --sentence 'turn on the lights in the kitchen'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ The filenames of sentences and tests are named like `<domain>_<intent>.yaml`. So
 
 ## Adding a new language
 
-New languages should be based on the output of `python3 -m script.intentfest add_language <language>`, which generates an empty language directory with all the files needed for a new language.
+New languages should be based on the output of `python3 -m script.intentfest add_language <language code> <language name>`, which generates an empty language directory with all the files needed for a new language.
 
 Limit the first contribution to translations of the error sentences in `_common.yaml` and adding sentences and tests for the `homeassistant` domain.
 

--- a/README.md
+++ b/README.md
@@ -155,9 +155,9 @@ python3 -m script.intentfest sample_template 'set color to <color> and brightnes
 ## Add new language
 
 ```
-python3 -m script.intentfest add_language <language>
+python3 -m script.intentfest add_language <language code> <language name>
 ```
 
-`<language>` should be something like `en` or `pl` according to [ISO 639](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
+`<language code>` should be something like `en` or `pl` according to [ISO 639](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).
 
-Before you start on a new language, confirm that no one else is already working on one.
+Language name should be the name of the language in its own language.

--- a/docs/forking/README.md
+++ b/docs/forking/README.md
@@ -4,7 +4,7 @@
 2. Clone your fork locally with `git clone <url>`
 3. Set up a local development environment with `script/setup`
 4. Create a new branch off of `main` with `git checkout -b <branch>`
-5. If your [language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) does not exist yet, run `python3 -m script.intentfest add_language <language_code>`
+5. If your [language code](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) does not exist yet, run `python3 -m script.intentfest add_language <language_code> <language name>`
 6. Modify the files for your language in:
     * `sentences/<language>`
     * `tests/<language>`

--- a/languages.yaml
+++ b/languages.yaml
@@ -1,0 +1,65 @@
+ar:
+  nativeName: "\u0627\u0644\u0639\u0631\u0628\u064A\u0629"
+  isRTL: true
+ca:
+  nativeName: "Catal\xE0"
+cs:
+  nativeName: "\u010Ce\u0161tina"
+da:
+  nativeName: Dansk
+de:
+  nativeName: Deutsch
+  leaders:
+    - Scorpoon
+el:
+  nativeName: "\u0395\u03BB\u03BB\u03B7\u03BD\u03B9\u03BA\u03AC"
+en:
+  nativeName: English
+es:
+  nativeName: "Espa\xF1ol"
+fr:
+  nativeName: "Fran\xE7ais"
+  leaders:
+    - benjaminlecouteux
+he:
+  nativeName: "\u05E2\u05D1\u05E8\u05D9\u05EA"
+  isRTL: true
+  leaders:
+    - leranp
+    - haim-b
+hr:
+  nativeName: Hrvatski
+hu:
+  nativeName: Magyar
+  leaders:
+    - nagyrobi
+it:
+  nativeName: Italiano
+nb:
+  nativeName: "Norsk Bokm\xE5l"
+nl:
+  nativeName: Nederlands
+  leaders:
+    - TheFes
+pl:
+  nativeName: Polski
+pt:
+  nativeName: "Portugu\xEAs"
+ro:
+  nativeName: "Rom\xE2n\u0103"
+sk:
+  nativeName: "Sloven\u010Dina"
+sl:
+  nativeName: "Sloven\u0161\u010Dina"
+sr:
+  nativeName: "\u0421\u0440\u043F\u0441\u043A\u0438"
+sv:
+  nativeName: Svenska
+tr:
+  nativeName: "T\xFCrk\xE7e"
+uk:
+  nativeName: "\u0423\u043A\u0440\u0430\u0457\u043D\u0441\u044C\u043A\u0430"
+ur:
+  nativeName: "\u0627\u064F\u0631\u062F\u064F\u0648"
+vi:
+  nativeName: "Ti\u1EBFng Vi\u1EC7t"

--- a/languages.yaml
+++ b/languages.yaml
@@ -10,7 +10,7 @@ da:
 de:
   nativeName: Deutsch
   leaders:
-    - Scorpoon
+  - Scorpoon
 el:
   nativeName: "\u0395\u03BB\u03BB\u03B7\u03BD\u03B9\u03BA\u03AC"
 en:
@@ -20,19 +20,19 @@ es:
 fr:
   nativeName: "Fran\xE7ais"
   leaders:
-    - benjaminlecouteux
+  - benjaminlecouteux
 he:
   nativeName: "\u05E2\u05D1\u05E8\u05D9\u05EA"
   isRTL: true
   leaders:
-    - leranp
-    - haim-b
+  - leranp
+  - haim-b
 hr:
   nativeName: Hrvatski
 hu:
   nativeName: Magyar
   leaders:
-    - nagyrobi
+  - nagyrobi
 it:
   nativeName: Italiano
 nb:
@@ -40,7 +40,7 @@ nb:
 nl:
   nativeName: Nederlands
   leaders:
-    - TheFes
+  - TheFes
 pl:
   nativeName: Polski
 pt:

--- a/script/intentfest/add_language.py
+++ b/script/intentfest/add_language.py
@@ -3,14 +3,28 @@ import argparse
 
 import yaml
 
-from .const import RESPONSE_DIR, ROOT, SENTENCE_DIR, TESTS_DIR
+from .const import LANGUAGES_FILE, RESPONSE_DIR, ROOT, SENTENCE_DIR, TESTS_DIR
 from .util import get_base_arg_parser, require_sentence_domain_slot
 
 
 def get_arguments() -> argparse.Namespace:
     """Get parsed passed in arguments."""
     parser = get_base_arg_parser()
-    parser.add_argument("language", type=str, help="The language to add.")
+    parser.add_argument(
+        "language",
+        type=str,
+        help="ISO 639 code of the language.",
+    )
+    parser.add_argument(
+        "native_name",
+        type=str,
+        help="Name of the language in its own language.",
+    )
+    parser.add_argument(
+        "--rtl",
+        action="store_true",
+        help="Specify if the language is right-to-left.",
+    )
     return parser.parse_args()
 
 
@@ -167,6 +181,22 @@ def run() -> int:
                 sort_keys=False,
             )
         )
+
+    # Update languages.yaml
+    languages = yaml.safe_load(LANGUAGES_FILE.read_text())
+    languages[language] = {
+        "nativeName": args.native_name,
+    }
+    if args.rtl:
+        languages[language]["isRTL"] = True
+
+    LANGUAGES_FILE.write_text(
+        yaml.dump(
+            # Sort the languages by code.
+            dict(sorted(languages.items())),
+            sort_keys=False,
+        )
+    )
 
     rel_sentence_dir = sentence_dir.relative_to(ROOT)
     rel_test_dir = tests_dir.relative_to(ROOT)

--- a/script/intentfest/const.py
+++ b/script/intentfest/const.py
@@ -6,5 +6,6 @@ ROOT = Path(__file__).parent.parent.parent
 SENTENCE_DIR = ROOT / "sentences"
 RESPONSE_DIR = ROOT / "responses"
 TESTS_DIR = ROOT / "tests"
+LANGUAGES_FILE = ROOT / "languages.yaml"
 INTENTS_FILE = ROOT / "intents.yaml"
 LANGUAGES = sorted(p.name for p in SENTENCE_DIR.iterdir() if p.is_dir())

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -11,8 +11,8 @@ from voluptuous.humanize import validate_with_humanized_errors
 
 from .const import (
     INTENTS_FILE,
-    LANGUAGES_FILE,
     LANGUAGES,
+    LANGUAGES_FILE,
     RESPONSE_DIR,
     ROOT,
     SENTENCE_DIR,

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -224,9 +224,9 @@ def run() -> int:
     else:
         languages = [args.language]
 
-    load_errors = []
+    load_errors: list[str] = []
     intent_schemas = _load_yaml_file(load_errors, None, INTENTS_FILE, INTENTS_SCHEMA)
-    if load_errors:
+    if intent_schemas is None:
         print("File intents.yaml has invalid format:")
         for error in load_errors:
             print(f" - {error}")
@@ -236,7 +236,7 @@ def run() -> int:
         load_errors, None, LANGUAGES_FILE, LANGUAGES_SCHEMA
     )
     # If no load errors, validate some info.
-    if not load_errors:
+    if language_infos:
         languages_without_files = set(LANGUAGES) - set(language_infos)
         if languages_without_files:
             load_errors.append(
@@ -245,7 +245,7 @@ def run() -> int:
         if sorted(language_infos) != list(language_infos):
             load_errors.append("Languages should be sorted alphabetically")
 
-    if load_errors:
+    if language_infos is None or load_errors:
         print("File languages.yaml has invalid format:")
         for error in load_errors:
             print(f" - {error}")
@@ -411,8 +411,8 @@ def validate_language(
                 errors.append(f"{path}: not all sentences have tests")
 
     if sentence_files:
-        for sentence_file in sentence_files:
-            errors.append(f"{sentence_file} has no tests")
+        for sentence_file_without_tests in sentence_files:
+            errors.append(f"{sentence_file_without_tests} has no tests")
 
     for response_file in response_dir.iterdir():
         path = str(response_file.relative_to(ROOT))


### PR DESCRIPTION
This adds a languages.YAML file to track leaders and names of the language. Support added to both validate and add_language commands.

We’re going to use this file as a foundation for generating `CODEOWNERS` and language summaries.