### PR TITLE
[PT] New skip_word and error message "no_entity" tweak

### DIFF
--- a/sentences/pt/_common.yaml
+++ b/sentences/pt/_common.yaml
@@ -5,7 +5,7 @@ responses:
     no_area: "Não existe nenhuma área com o nome {{ area }}."
     no_domain: "{{ area }} não contém {{ domain }}."
     no_device_class: "{{ area }} não contém {{ device_class }}."
-    no_entity: "Nenhum dispositivo ou entidade com o nome {{ entity }}."
+    no_entity: "Não existe nenhum dispositivo ou entidade com o nome {{ entity }}."
     handle_error: "Ocurreu um erro inesperado ao processar o pedido."
 lists:
   color:
@@ -72,3 +72,4 @@ skip_words:
   - "por favor"
   - "se faz favor"
   - "pode"
+  - "podes"


### PR DESCRIPTION
The frase "Não existe nenhum dispositivo ou entidade com o nome {{ entity }}." sounds more natural and complete. 