### PR TITLE
Add script to generate language table

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,22 +18,38 @@ See the [documentation](docs/README.md) for more information.
 
 ## Supported Languages
 
-| Code | Language         | Leaders               |
-|------|------------------|-----------------------|
-| `de` | German           | @Scorpoon             |
-| `dk` | Danish           | (position open)       |
-| `en` | English          | (position open)       |
-| `fr` | French           | @benjaminlecouteux    |
-| `he` | Hebrew           | @leranp, @haim-b      |
-| `hu` | Hungarian        | @nagyrobi             |
-| `it` | Italian          | @auanasgheps, @xraver |
-| `nb` | Norwegian Bokmål | (position open)       |
-| `nl` | Dutch            | @TheFes               |
-| `pl` | Polish           | (position open)       |
-| `ru` | Russian          | @HepoH3               |
-| `sk` | Slovak           | (position open)       |
-| `sv` | Swedish          | (position open)       |
-| `ur` | Urdu             | @AalianKhan           |
+| Code | Language     | Leaders            |
+|------|--------------|--------------------|
+| `ar` | العربية      | (position open)    |
+| `ca` | Català       | (position open)    |
+| `cs` | Čeština      | (position open)    |
+| `da` | Dansk        | (position open)    |
+| `de` | Deutsch      | @Scorpoon          |
+| `el` | Ελληνικά     | (position open)    |
+| `en` | English      | (position open)    |
+| `es` | Español      | (position open)    |
+| `fr` | Français     | @benjaminlecouteux |
+| `he` | עברית        | @leranp, @haim-b   |
+| `hr` | Hrvatski     | (position open)    |
+| `hu` | Magyar       | @nagyrobi          |
+| `it` | Italiano     | (position open)    |
+| `ka` | ಕನ್ನಡ         | (position open)    |
+| `nb` | Norsk Bokmål | (position open)    |
+| `nl` | Nederlands   | @TheFes            |
+| `pl` | Polski       | (position open)    |
+| `pt` | Português    | (position open)    |
+| `ro` | Română       | (position open)    |
+| `ru` | Русский      | (position open)    |
+| `sk` | Slovenčina   | (position open)    |
+| `sl` | Slovenščina  | (position open)    |
+| `sr` | Српски       | (position open)    |
+| `sv` | Svenska      | (position open)    |
+| `tr` | Türkçe       | (position open)    |
+| `uk` | Українська   | (position open)    |
+| `ur` | اُردُو         | (position open)    |
+| `vi` | Tiếng Việt   | (position open)    |
+| `zh` | 中文         | (position open)    |
+
 
 ## Language leader
 

--- a/languages.yaml
+++ b/languages.yaml
@@ -1,10 +1,10 @@
 ar:
-  nativeName: "\u0627\u0644\u0639\u0631\u0628\u064A\u0629"
+  nativeName: العربية
   isRTL: true
 ca:
-  nativeName: "Catal\xE0"
+  nativeName: Català
 cs:
-  nativeName: "\u010Ce\u0161tina"
+  nativeName: Čeština
 da:
   nativeName: Dansk
 de:
@@ -12,17 +12,17 @@ de:
   leaders:
   - Scorpoon
 el:
-  nativeName: "\u0395\u03BB\u03BB\u03B7\u03BD\u03B9\u03BA\u03AC"
+  nativeName: Ελληνικά
 en:
   nativeName: English
 es:
-  nativeName: "Espa\xF1ol"
+  nativeName: Español
 fr:
-  nativeName: "Fran\xE7ais"
+  nativeName: Français
   leaders:
   - benjaminlecouteux
 he:
-  nativeName: "\u05E2\u05D1\u05E8\u05D9\u05EA"
+  nativeName: עברית
   isRTL: true
   leaders:
   - leranp
@@ -36,9 +36,9 @@ hu:
 it:
   nativeName: Italiano
 ka:
-  nativeName: "\u0C95\u0CA8\u0CCD\u0CA8\u0CA1"
+  nativeName: ಕನ್ನಡ
 nb:
-  nativeName: "Norsk Bokm\xE5l"
+  nativeName: Norsk Bokmål
 nl:
   nativeName: Nederlands
   leaders:
@@ -46,26 +46,26 @@ nl:
 pl:
   nativeName: Polski
 pt:
-  nativeName: "Portugu\xEAs"
+  nativeName: Português
 ro:
-  nativeName: "Rom\xE2n\u0103"
+  nativeName: Română
 ru:
-  nativeName: "\u0420\u0443\u0441\u0441\u043A\u0438\u0439"
+  nativeName: Русский
 sk:
-  nativeName: "Sloven\u010Dina"
+  nativeName: Slovenčina
 sl:
-  nativeName: "Sloven\u0161\u010Dina"
+  nativeName: Slovenščina
 sr:
-  nativeName: "\u0421\u0440\u043F\u0441\u043A\u0438"
+  nativeName: Српски
 sv:
   nativeName: Svenska
 tr:
-  nativeName: "T\xFCrk\xE7e"
+  nativeName: Türkçe
 uk:
-  nativeName: "\u0423\u043A\u0440\u0430\u0457\u043D\u0441\u044C\u043A\u0430"
+  nativeName: Українська
 ur:
-  nativeName: "\u0627\u064F\u0631\u062F\u064F\u0648"
+  nativeName: اُردُو
 vi:
-  nativeName: "Ti\u1EBFng Vi\u1EC7t"
+  nativeName: Tiếng Việt
 zh:
-  nativeName: "\u4E2D\u6587"
+  nativeName: 中文

--- a/script/intentfest/const.py
+++ b/script/intentfest/const.py
@@ -1,4 +1,4 @@
-"""Costants."""
+"""Constants."""
 
 from pathlib import Path
 

--- a/script/intentfest/language_table.py
+++ b/script/intentfest/language_table.py
@@ -1,0 +1,24 @@
+"""Script to print Markdown language table."""
+import yaml
+
+from .const import LANGUAGES_FILE
+
+
+def run() -> int:
+    print("|Code|Language|Leaders|")
+    print("|--|--|--|")
+
+    languages = yaml.safe_load(LANGUAGES_FILE.read_text())
+    for code in sorted(languages):
+        info = languages[code]
+        name = info["nativeName"]
+        leaders = info.get("leaders")
+
+        if leaders:
+            leaders_str = ", ".join(f"@{leader}" for leader in leaders)
+        else:
+            leaders_str = "(position open)"
+
+        print("|", f"`{code}`", "|", name, "|", leaders_str, "|")
+
+    return 0

--- a/script/intentfest/util.py
+++ b/script/intentfest/util.py
@@ -20,6 +20,7 @@ def get_base_arg_parser() -> argparse.ArgumentParser:
             "sample",
             "website_summary",
             "validate",
+            "language_table",
         ],
     )
     parser.add_argument("--debug", action="store_true", help="Enable log output")


### PR DESCRIPTION
Don't escape Unicode characters in `languages.yaml`

Add `python3 -m script.intentfest language_table` to generate the Markdown table of languages for the README