### PR TITLE
generate codeowners based on languages.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,3 +31,4 @@ jobs:
       - run: script/lint
       - run: script/test
       - run: venv/bin/python3 -m script.intentfest parse --language en --sentence 'turn on the lights in the kitchen'
+      - run: venv/bin/python3 -m script.intentfest codeowners --check

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,25 +2,21 @@ sentences/de/ @Scorpoon
 responses/de/ @Scorpoon
 tests/de/ @Scorpoon
 
-sentences/en/ @synesthesiam
-responses/en/ @synesthesiam
-tests/en/ @synesthesiam
-
 sentences/fr/ @benjaminlecouteux
 responses/fr/ @benjaminlecouteux
 tests/fr/ @benjaminlecouteux
 
-sentences/it/ @auanasgheps @xraver
-responses/it/ @auanasgheps @xraver
-tests/it/ @auanasgheps @xraver
-
-sentences/he/ @leranp, @haim-b
-responses/he/ @leranp, @haim-b
-tests/he/ @leranp, @haim-b
+sentences/he/ @haim-b @leranp
+responses/he/ @haim-b @leranp
+tests/he/ @haim-b @leranp
 
 sentences/hu/ @nagyrobi
 responses/hu/ @nagyrobi
 tests/hu/ @nagyrobi
+
+sentences/it/ @auanasgheps @xraver
+responses/it/ @auanasgheps @xraver
+tests/it/ @auanasgheps @xraver
 
 sentences/nl/ @TheFes
 responses/nl/ @TheFes

--- a/languages.yaml
+++ b/languages.yaml
@@ -37,6 +37,9 @@ hu:
   - nagyrobi
 it:
   nativeName: Italiano
+  leaders:
+  - auanasgheps
+  - xraver
 ka:
   nativeName: "\u0C95\u0CA8\u0CCD\u0CA8\u0CA1"
 nb:
@@ -53,6 +56,8 @@ ro:
   nativeName: "Rom\xE2n\u0103"
 ru:
   nativeName: "\u0420\u0443\u0441\u0441\u043A\u0438\u0439"
+  leaders:
+  - HepoH3
 sk:
   nativeName: "Sloven\u010Dina"
 sl:
@@ -69,6 +74,8 @@ uk:
   - skynetua
 ur:
   nativeName: "\u0627\u064F\u0631\u062F\u064F\u0648"
+  leaders:
+  - AalianKhan
 vi:
   nativeName: "Ti\u1EBFng Vi\u1EC7t"
 zh:

--- a/script/intentfest/codeowners.py
+++ b/script/intentfest/codeowners.py
@@ -1,0 +1,58 @@
+"""Generate codeowners."""
+from __future__ import annotations
+
+import argparse
+
+import yaml
+
+from .const import ROOT, LANGUAGES_FILE
+from .util import get_base_arg_parser
+
+
+CODEOWNERS_FILE = ROOT / "CODEOWNERS"
+
+
+def get_arguments() -> argparse.Namespace:
+    """Get parsed passed in arguments."""
+    parser = get_base_arg_parser()
+    parser.add_argument(
+        "--check",
+        required=False,
+        action="store_true",
+        help="Check if the file is correct format instead of writing it.",
+    )
+    return parser.parse_args()
+
+
+def run() -> int:
+    args = get_arguments()
+
+    languages = yaml.safe_load(LANGUAGES_FILE.read_text())
+
+    parts = []
+
+    for language, info in languages.items():
+        if not info.get("leaders"):
+            continue
+
+        leaders = " ".join(f"@{leader}" for leader in sorted(info["leaders"]))
+        parts.extend(
+            [
+                f"sentences/{language}/ {leaders}",
+                f"responses/{language}/ {leaders}",
+                f"tests/{language}/ {leaders}",
+                "",
+            ]
+        )
+
+    output = "\n".join(parts)
+
+    if args.check:
+        if CODEOWNERS_FILE.read_text() != output:
+            print("Codeowners file is not up to date")
+            print("Update with: python3 -m script.intentfest codeowners")
+            return 1
+        return 0
+
+    CODEOWNERS_FILE.write_text(output)
+    return 0

--- a/script/intentfest/codeowners.py
+++ b/script/intentfest/codeowners.py
@@ -5,9 +5,8 @@ import argparse
 
 import yaml
 
-from .const import ROOT, LANGUAGES_FILE
+from .const import LANGUAGES_FILE, ROOT
 from .util import get_base_arg_parser
-
 
 CODEOWNERS_FILE = ROOT / "CODEOWNERS"
 

--- a/script/intentfest/util.py
+++ b/script/intentfest/util.py
@@ -15,6 +15,7 @@ def get_base_arg_parser() -> argparse.ArgumentParser:
         type=str,
         choices=[
             "add_language",
+            "codeowners",
             "parse",
             "sample_template",
             "sample",


### PR DESCRIPTION
- Add new `codeowners` command to generate the `CODEOWNERS` file
- Check the file is up to date as part of CI
- Update `languages.yaml` with all code owners
