### PR TITLE
Add language leaders to website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Intents for Home Assistant
 
-This repository contains training data for Home Assistant's local voice control.
+This repository contains training data for Home Assistant's local voice control. For a list of supported languages and it's progress, see [the website](https://home-assistant.github.io/intents/).
 
 Repository layout:
 
@@ -15,41 +15,6 @@ Repository layout:
   - [File format](tests/README.md#file-format)
 
 See the [documentation](docs/README.md) for more information.
-
-## Supported Languages
-
-| Code | Language     | Leaders            |
-|------|--------------|--------------------|
-| `ar` | العربية      | (position open)    |
-| `ca` | Català       | (position open)    |
-| `cs` | Čeština      | (position open)    |
-| `da` | Dansk        | (position open)    |
-| `de` | Deutsch      | @Scorpoon          |
-| `el` | Ελληνικά     | (position open)    |
-| `en` | English      | (position open)    |
-| `es` | Español      | (position open)    |
-| `fr` | Français     | @benjaminlecouteux |
-| `he` | עברית        | @leranp, @haim-b   |
-| `hr` | Hrvatski     | (position open)    |
-| `hu` | Magyar       | @nagyrobi          |
-| `it` | Italiano     | (position open)    |
-| `ka` | ಕನ್ನಡ         | (position open)    |
-| `nb` | Norsk Bokmål | (position open)    |
-| `nl` | Nederlands   | @TheFes            |
-| `pl` | Polski       | (position open)    |
-| `pt` | Português    | (position open)    |
-| `ro` | Română       | (position open)    |
-| `ru` | Русский      | (position open)    |
-| `sk` | Slovenčina   | (position open)    |
-| `sl` | Slovenščina  | (position open)    |
-| `sr` | Српски       | (position open)    |
-| `sv` | Svenska      | (position open)    |
-| `tr` | Türkçe       | (position open)    |
-| `uk` | Українська   | @skynetua          |
-| `ur` | اُردُو         | (position open)    |
-| `vi` | Tiếng Việt   | (position open)    |
-| `zh` | 中文         | (position open)    |
-
 
 ## Language leader
 

--- a/script/intentfest/website_summary.py
+++ b/script/intentfest/website_summary.py
@@ -48,6 +48,7 @@ def run() -> int:
             {
                 "language": language,
                 "native_name": language_info[language]["nativeName"],
+                "leaders": language_info[language].get("leaders"),
                 "intents": intent_sentence_count,
                 "responses": response_sentence_count,
                 "errors_translated": errors_translated,

--- a/website/src-11ty/_data/intentSummary.json
+++ b/website/src-11ty/_data/intentSummary.json
@@ -11,6 +11,7 @@
     {
       "language": "nl",
       "native_name": "Test language",
+      "leaders": ["balloob"],
       "intents": {
         "HassTestIntent": 0,
         "HassTestIntentWithResponse": 2

--- a/website/src-11ty/index.html
+++ b/website/src-11ty/index.html
@@ -11,6 +11,7 @@ description: Progress of translations.
       <th>{{intent[0] | remove_first: "Hass"}}</th>
       {% endfor %}
       <th>Errors translated</th>
+      <th>Leader</th>
     </tr>
   </thead>
   <tbody>
@@ -53,6 +54,22 @@ description: Progress of translations.
         >
           {% if summary.errors_translated == true %}yes{% else %}no{% endif %}
         </a>
+      </td>
+      <td
+        class="{% if summary.leaders and (summary.leaders | len) > 1 %}multiple{% endif %}"
+      >
+        {% if summary.leaders %} {% for leader in summary.leaders %}
+        <a href="https://github.com/{{ leader }}" target="_blank">
+          @{{ leader }}
+        </a>
+        {% endfor %} {% else %}
+        <a
+          href="https://github.com/home-assistant/intents#language-leader"
+          target="_blank"
+        >
+          &lt;position open&gt;
+        </a>
+        {% endif %}
       </td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
This replaces the list in the README that we had to manually keep up to date.

![CleanShot 2022-12-29 at 15 14 14](https://user-images.githubusercontent.com/1444314/210006969-1a7b479a-0a7f-4f9b-8235-d38febcf15e4.png)
