### PR TITLE
[PL] Update cover opening sentences

### DIFF
--- a/sentences/pl/cover_HassOpenCover.yaml
+++ b/sentences/pl/cover_HassOpenCover.yaml
@@ -11,9 +11,9 @@ intents:
         slots:
           device_class: "garage_door"
       - sentences:
-          - "Rolety <area> (otwórz | rozsłoń)"
-          - "(Otwórz | Rozsłoń) rolety <area>"
-          - "(Otwórz | Rozsłoń) <area> [wszystkie] rolety"
+          - "Rolety <area> (otwórz | odsłoń)"
+          - "(Otwórz | Odsłoń) rolety <area>"
+          - "(Otwórz | Odsłoń) <area> [wszystkie] rolety"
         slots:
           device_class:
             - "blind"


### PR DESCRIPTION
`Rozsłoń` is actually an archaic form and is not used in Polish anymore. Replaced it with `Odsłoń`.