### PR TITLE
[PL] removed hardcoded device name

### DIFF
--- a/sentences/pl/light_HassLightSet.yaml
+++ b/sentences/pl/light_HassLightSet.yaml
@@ -12,4 +12,3 @@ intents:
       # color
       - sentences:
           - "(Ustaw | Zmień) [kolor] <name> na {color}"
-          - "Zmień kolor lampki nocnej na {color}"


### PR DESCRIPTION
Removed hardcoded entry for `Lampka nocna` (a bedside lamp) that was also a duplicate of the preceding entry.