### PR TITLE
Update homeassistant_HassTurnOff.yaml

### DIFF
--- a/sentences/pt/homeassistant_HassTurnOff.yaml
+++ b/sentences/pt/homeassistant_HassTurnOff.yaml
@@ -3,5 +3,5 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "(desligue | desliga) [(o | a)] <nome>"
-          - "(desligue | desliga) [(o | a)] <nome> <na_zona>"
+          - "(desligue | desliga | desligar) [(o | a)] <name>"
+          - "(desligue | desliga | desligar) [(o | a)] <name> <area>"


### PR DESCRIPTION
fixed variable names <name> and <area> (which should remain in English). Added one more verb variation.