### PR TITLE
Expect tests to specify all matched slots

### DIFF
--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 from hassil import Intents, recognize
@@ -53,16 +54,16 @@ def do_test_language_sentences_file(
             assert (
                 result.intent.name == intent["name"]
             ), f"For '{sentence}' expected intent {intent['name']}, got {result.intent.name}"
+
+            matched_slots = {slot.name: slot.value for slot in result.entities.values()}
+            expected_slots = {}
             for slot_name, slot_dict in intent.get("slots", {}).items():
-                if not isinstance(slot_dict, dict):
-                    slot_dict = {"value": slot_dict}
-                assert (
-                    slot_name
-                    in
-                    # wrap it in a list to get more readable pytest assertion
-                    list(result.entities)
-                ), f"For '{sentence}' did not receive slot '{slot_name}'"
-                assert result.entities[slot_name].value == slot_dict["value"]
+                if isinstance(slot_dict, dict):
+                    expected_slots[slot_name] = slot_dict["value"]
+                else:
+                    expected_slots[slot_name] = slot_dict
+
+            assert matched_slots == expected_slots
 
 
 def gen_test(test_file: Path) -> None:

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -62,7 +62,9 @@ def do_test_language_sentences_file(
                 else:
                     expected_slots[slot_name] = slot_dict
 
-            assert matched_slots == expected_slots
+            assert (
+                matched_slots == expected_slots
+            ), f"Slots do not match for: {sentence}"
 
 
 def gen_test(test_file: Path) -> None:

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Any
 
 import pytest
 from hassil import Intents, recognize


### PR DESCRIPTION
The old behavior tested only that the slots specified in the test file were found by the matcher. This new behavior requires all matched slots to be specified in the test file. This is to ensure correctness.