### PR TITLE
Validate that domain tests only test domain sentences

### DIFF
--- a/tests/test_language_intents.py
+++ b/tests/test_language_intents.py
@@ -47,6 +47,8 @@ def do_test_language_sentences(
     language_sentences_common: Intents,
 ) -> None:
     """Ensure all language sentences contain valid slots, lists, rules, etc."""
+    file_domain, file_intent = file_name.split(".")[0].split("_", 1)
+
     parsed_sentences_without_common = Intents.from_dict(
         language_sentences_yaml[file_name]
     )
@@ -62,11 +64,22 @@ def do_test_language_sentences(
 
     # Lint sentences
     for intent_name, intent in language_sentences.intents.items():
+        assert (
+            file_intent == intent_name
+        ), f"File {file_name} should only contain sentences for intent {file_intent}"
+
         intent_schema = intent_schemas[intent_name]
         slot_schema = intent_schema["slots"]
         slot_combinations = intent_schema.get("slot_combinations")
 
         for data in intent.data:
+            # Domain specific files (ie light_HassTurnOn.yaml) should only match
+            # sentences for the light domain.
+            if data.sentences and intent_schemas[file_intent]["domain"] != file_domain:
+                assert (
+                    data.slots.get("domain") == file_domain
+                ), f"File {file_name} should only have sentences with a domain slot set to {file_domain}"
+
             for sentence in data.sentences:
                 found_slots: set[str] = set()
                 for expression in _flatten(sentence):

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 from hassil import Intents, recognize
@@ -28,11 +29,12 @@ def slot_lists_fixture(language: str) -> dict[str, SlotList]:
 def do_test_language_sentences_file(
     language: str,
     test_file: str,
+    intent_schemas: dict[str, Any],
     slot_lists: dict[str, SlotList],
     language_sentences: Intents,
 ) -> None:
     """Tests recognition all of the test sentences for a language"""
-    _testing_domain, testing_intent = test_file.split("_", 1)
+    testing_domain, testing_intent = test_file.split("_", 1)
 
     seen_sentences = set()
 
@@ -41,6 +43,16 @@ def do_test_language_sentences_file(
         assert (
             intent["name"] == testing_intent
         ), f"File {test_file} should only test for intent {testing_intent}"
+
+        # Domain specific files (ie light_HassTurnOn.yaml) should only test
+        # sentences for the light domain.
+        if (
+            test["sentences"]
+            and intent_schemas[testing_intent]["domain"] != testing_domain
+        ):
+            assert (
+                "domain" in intent["slots"]
+            ), f"File {test_file} should have a domain slot"
 
         for sentence in test["sentences"]:
             assert (
@@ -70,11 +82,16 @@ def do_test_language_sentences_file(
 def gen_test(test_file: Path) -> None:
     def test_func(
         language: str,
+        intent_schemas: dict[str, Any],
         slot_lists: dict[str, SlotList],
         language_sentences: Intents,
     ) -> None:
         do_test_language_sentences_file(
-            language, test_file.stem, slot_lists, language_sentences
+            language,
+            test_file.stem,
+            intent_schemas,
+            slot_lists,
+            language_sentences,
         )
 
     test_func.__name__ = f"test_{test_file.stem}"


### PR DESCRIPTION
Sentence files like `fan_HassTurnOn.yaml` should only contain sentences that map to a hardcoded domain `fan`. This PR makes sure that the test sentences also expect the domain to be set to `fan`.