### PR TITLE
Re-organize tests for Catalan

### DIFF
--- a/sentences/ca/fan_HassTurnOff.yaml
+++ b/sentences/ca/fan_HassTurnOff.yaml
@@ -3,7 +3,6 @@ intents:
   HassTurnOff:
     data:
     - sentences:
-        - "<apaga> el ventilador <name>"
         - "<apaga> el[s] ventilador[s] <area>"
       slots:
         domain: fan

--- a/sentences/ca/fan_HassTurnOn.yaml
+++ b/sentences/ca/fan_HassTurnOn.yaml
@@ -3,7 +3,6 @@ intents:
   HassTurnOn:
     data:
     - sentences:
-        - "<engega> el ventilador <name> [en marxa]"
         - "<engega> el[s] ventilador[s] <area> [en marxa]"
       slots:
         domain: fan

--- a/tests/ca/fan_HassTurnOff.yaml
+++ b/tests/ca/fan_HassTurnOff.yaml
@@ -1,12 +1,6 @@
 language: ca
 tests:
 - sentences:
-    - apaga el ventilador sostre
-  intent:
-    name: HassTurnOff
-    slots:
-      name: fan.ceiling
-- sentences:
     - atura el ventilador del menjador
   intent:
     name: HassTurnOff

--- a/tests/ca/fan_HassTurnOn.yaml
+++ b/tests/ca/fan_HassTurnOn.yaml
@@ -14,9 +14,3 @@ tests:
     slots:
       domain: fan
       name: all
-- sentences:
-    - engega el ventilador sostre 
-  intent:
-    name: HassTurnOn
-    slots:
-      name: fan.ceiling

--- a/tests/ca/homeassistant_HassTurnOff.yaml
+++ b/tests/ca/homeassistant_HassTurnOff.yaml
@@ -15,3 +15,9 @@ tests:
     slots:
       domain: light
       area: bedroom
+- sentences:
+    - apaga el ventilador sostre
+  intent:
+    name: HassTurnOff
+    slots:
+      name: fan.ceiling

--- a/tests/ca/homeassistant_HassTurnOn.yaml
+++ b/tests/ca/homeassistant_HassTurnOn.yaml
@@ -8,3 +8,15 @@ tests:
     name: HassTurnOn
     slots:
       name: light.bedroom_lamp
+- sentences:
+    - engega el ventilador sostre 
+  intent:
+    name: HassTurnOn
+    slots:
+      name: fan.ceiling
+- sentences:
+    - engega el llum dormitori
+  intent:
+    name: HassTurnOn
+    slots:
+      name: light.bedroom_lamp

--- a/tests/ca/light_HassTurnOn.yaml
+++ b/tests/ca/light_HassTurnOn.yaml
@@ -1,12 +1,6 @@
 language: ca
 tests:
 - sentences:
-    - engega el llum dormitori
-  intent:
-    name: HassTurnOn
-    slots:
-      name: light.bedroom_lamp
-- sentences:
     - encén la llum del menjador
   intent:
     name: HassTurnOn


### PR DESCRIPTION
Catalan was testing some sentences in the wrong files. Move them to the correct place. I've removed 2 sentences that didn't make sense: "Turn on ventilator <name>" would match sentence "Turn on ventilator left ventilator"

Found by #335.