### PR TITLE
Re-organize tests for German

### DIFF
--- a/tests/de/homeassistant_HassTurnOn.yaml
+++ b/tests/de/homeassistant_HassTurnOn.yaml
@@ -2,6 +2,7 @@ language: de
 tests:
   - sentences:
       - "schalte den Deckenventilator ein"
+      - "schalte den Deckenventilator an"
       - "starte den Deckenventilator"
     intent:
       name: "HassTurnOn"

--- a/tests/de/light_HassTurnOff.yaml
+++ b/tests/de/light_HassTurnOff.yaml
@@ -1,14 +1,6 @@
 language: de
 tests:
   - sentences:
-      - "Schalte die Schlafzimmerlampe ab"
-      - "Schalte die Schlafzimmerlampe aus"
-    intent:
-      name: "HassTurnOff"
-      slots:
-        name: "light.bedroom_lamp"
-
-  - sentences:
       - "Schalte das Licht in der Küche aus"
       - "Schalte die Lichter in der Küche aus"
       - "Schalte alle Lichter in der Küche aus"

--- a/tests/de/light_HassTurnOn.yaml
+++ b/tests/de/light_HassTurnOn.yaml
@@ -1,14 +1,6 @@
 language: de
 tests:
   - sentences:
-      - "Schalte die Schlafzimmerlampe an"
-      - "Schalte die Schlafzimmerlampe ein"
-    intent:
-      name: "HassTurnOn"
-      slots:
-        name: "light.bedroom_lamp"
-
-  - sentences:
       - "Schalte das Licht in der Küche an"
       - "Schalte die Lichter in der Küche an"
       - "Schalte alle Lichter in der Küche an"


### PR DESCRIPTION
Sentence files like `light_HassTurnOn.yaml` should only contain sentences that map to a hardcoded domain `light`. This PR makes sure that the test sentences match these. 

Found by #335.