### PR TITLE
Re-organize tests for Polish

### DIFF
--- a/tests/pl/homeassistant_HassTurnOff.yaml
+++ b/tests/pl/homeassistant_HassTurnOff.yaml
@@ -14,3 +14,10 @@ tests:
       name: "HassTurnOff"
       slots:
         name: "fan.ceiling"
+  - sentences:
+      - "Zgaś lampka nocna"
+      - "Wyłącz lampka nocna"
+    intent:
+      name: "HassTurnOff"
+      slots:
+        name: "light.bedroom_lamp"

--- a/tests/pl/homeassistant_HassTurnOn.yaml
+++ b/tests/pl/homeassistant_HassTurnOn.yaml
@@ -7,3 +7,10 @@ tests:
       name: "HassTurnOn"
       slots:
         name: "fan.ceiling"
+  - sentences:
+      - "Zapal lampka nocna"
+      - "Włącz lampka nocna"
+    intent:
+      name: "HassTurnOn"
+      slots:
+        name: "light.bedroom_lamp"

--- a/tests/pl/light_HassTurnOff.yaml
+++ b/tests/pl/light_HassTurnOff.yaml
@@ -1,13 +1,6 @@
 language: pl
 tests:
   - sentences:
-      - "Zgaś lampka nocna"
-      - "Wyłącz lampka nocna"
-    intent:
-      name: "HassTurnOff"
-      slots:
-        name: "light.bedroom_lamp"
-  - sentences:
       - "Zgaś światła w kuchni"
       - "Wyłącz światło w kuchni"
     intent:

--- a/tests/pl/light_HassTurnOn.yaml
+++ b/tests/pl/light_HassTurnOn.yaml
@@ -1,13 +1,6 @@
 language: pl
 tests:
   - sentences:
-      - "Zapal lampka nocna"
-      - "Włącz lampka nocna"
-    intent:
-      name: "HassTurnOn"
-      slots:
-        name: "light.bedroom_lamp"
-  - sentences:
       - "Zapal światło w kuchni"
       - "Zapal światła w kuchni"
     intent:


### PR DESCRIPTION
Sentence files like `light_HassTurnOn.yaml` should only contain sentences that map to a hardcoded domain `light`. This PR makes sure that the test sentences match these. 

Found by #335.