### PR TITLE
Validate non domain files

### DIFF
--- a/sentences/fr/homeassistant_HassTurnOff.yaml
+++ b/sentences/fr/homeassistant_HassTurnOff.yaml
@@ -3,15 +3,5 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "<eteins> toutes (<lumiere> | <lumieres>) [dans|du|de] <area>"
-        slots:
-          domain: "light"
-          name: "all"
-      - sentences:
-          - "<eteins> tous (<ventilateur> | <ventilateurs>) [dans|du|de] <area>"
-        slots:
-          domain: "fan"
-          name: "all"
-      - sentences:
           - "<eteins> <name> [dans|du|de] <area>"
           - "<eteins> <name>"

--- a/sentences/fr/homeassistant_HassTurnOn.yaml
+++ b/sentences/fr/homeassistant_HassTurnOn.yaml
@@ -3,15 +3,5 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "<allume> [toutes] (<lumiere> | <lumieres>) (dans|du|de) <area>"
-        slots:
-          domain: "light"
-          name: "all"
-      - sentences:
-          - "<allume> [tous] (<ventilateur> | <ventilateurs>) (dans|du|de) <area>"
-        slots:
-          domain: "fan"
-          name: "all"
-      - sentences:
           - "<allume> <name>"
           - "<allume> <name> [dans|du|de] <area>"

--- a/sentences/fr/light_HassLightSet.yaml
+++ b/sentences/fr/light_HassLightSet.yaml
@@ -5,15 +5,12 @@ intents:
       - sentences:
           - "<regle> [toutes] <lumieres> de <area> à <brightness>"
         slots:
-          domain: "light"
           name: "all"
       - sentences:
           - "<regle> <name> [dans|du|de] <area> à <brightness>"
       - sentences:
           - "<regle> [la couleur] [de | des] [toutes] <lumieres> de <area> [avec la couleur | de couleur | en] {color}"
         slots:
-          domain: "light"
           name: "all"
       - sentences:
           - "<regle> [la couleur de] <name> [dans|du|de] <area> [avec la couleur | de couleur | en] {color}"
-

--- a/tests/ca/homeassistant_HassTurnOff.yaml
+++ b/tests/ca/homeassistant_HassTurnOff.yaml
@@ -8,14 +8,6 @@ tests:
     slots:
       name: switch.kitchen
 - sentences:
-    - apaga la llum del dormitori
-    - apaga la llum al dormitori
-  intent:
-    name: HassTurnOff
-    slots:
-      domain: light
-      area: bedroom
-- sentences:
     - apaga el ventilador sostre
   intent:
     name: HassTurnOff

--- a/tests/ca/light_HassTurnOff.yaml
+++ b/tests/ca/light_HassTurnOff.yaml
@@ -25,3 +25,11 @@ tests:
       domain: light
       name: all
       area: kitchen
+- sentences:
+    - apaga la llum del dormitori
+    - apaga la llum al dormitori
+  intent:
+    name: HassTurnOff
+    slots:
+      domain: light
+      area: bedroom

--- a/tests/fr/homeassistant_HassTurnOff.yaml
+++ b/tests/fr/homeassistant_HassTurnOff.yaml
@@ -10,13 +10,6 @@ tests:
         name: "light.bedroom_lamp"
         area: "bedroom"
   - sentences:
-      - "éteins toutes les lumières de la chambre"
-    intent:
-      name: "HassTurnOff"
-      slots:
-        domain: "light"
-        area: "bedroom"
-  - sentences:
       - "éteins le ventilateur de plafond"
       - "arrête le ventilateur de plafond"
     intent:

--- a/tests/fr/homeassistant_HassTurnOn.yaml
+++ b/tests/fr/homeassistant_HassTurnOn.yaml
@@ -1,14 +1,6 @@
 language: fr
 tests:
   - sentences:
-      - "allume toutes les lumières de la chambre"
-    intent:
-      name: "HassTurnOn"
-      slots:
-        domain: "light"
-        name: "all"
-        area: "bedroom"
-  - sentences:
       - "allume le ventilateur de plafond"
     intent:
       name: "HassTurnOn"

--- a/tests/fr/light_HassLightSet.yaml
+++ b/tests/fr/light_HassLightSet.yaml
@@ -54,6 +54,5 @@ tests:
       name: "HassLightSet"
       slots:
         area: "bedroom"
-        domain: "light"
         color: "red"
         name: "all"

--- a/tests/fr/light_HassTurnOn.yaml
+++ b/tests/fr/light_HassTurnOn.yaml
@@ -10,7 +10,6 @@ tests:
       slots:
         area: living_room
         domain: light
-        name: all
   - sentences:
       - "Allume la lumière dans l'entrée"
       - "Allume les lumières dans l'entrée"
@@ -21,7 +20,6 @@ tests:
       slots:
         area: hall
         domain: light
-        name: all
   - sentences:
       - "Allume la lumière de la chambre"
       - "Allume les lumières dans la chambre"
@@ -32,4 +30,3 @@ tests:
       slots:
         area: bedroom
         domain: light
-        name: all

--- a/tests/test_language_intents.py
+++ b/tests/test_language_intents.py
@@ -73,9 +73,16 @@ def do_test_language_sentences(
         slot_combinations = intent_schema.get("slot_combinations")
 
         for data in intent.data:
+            if not data.sentences:
+                continue
+
             # Domain specific files (ie light_HassTurnOn.yaml) should only match
             # sentences for the light domain.
-            if data.sentences and intent_schemas[file_intent]["domain"] != file_domain:
+            if intent_schemas[file_intent]["domain"] == file_domain:
+                assert (
+                    "domain" not in data.slots
+                ), f"File {file_name} should only have sentences without a domain slot"
+            else:
                 assert (
                     data.slots.get("domain") == file_domain
                 ), f"File {file_name} should only have sentences with a domain slot set to {file_domain}"

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -44,14 +44,18 @@ def do_test_language_sentences_file(
             intent["name"] == testing_intent
         ), f"File {test_file} should only test for intent {testing_intent}"
 
+        if not test["sentences"]:
+            continue
+
         # Domain specific files (ie light_HassTurnOn.yaml) should only test
         # sentences for the light domain.
-        if (
-            test["sentences"]
-            and intent_schemas[testing_intent]["domain"] != testing_domain
-        ):
-            assert (
-                "domain" in intent["slots"]
+        if intent_schemas[testing_intent]["domain"] == testing_domain:
+            assert "domain" not in intent.get(
+                "slots", {}
+            ), f"File {test_file} should not have a domain slot"
+        else:
+            assert "domain" in intent.get(
+                "slots", {}
             ), f"File {test_file} should have a domain slot"
 
         for sentence in test["sentences"]:


### PR DESCRIPTION
Make sure that files like `homeassistant_HassTurnOff.yaml` do not test for sentences defined in `light_HassTurnOff.yaml`.