### PR TITLE
Slot values no dict

### DIFF
--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -166,10 +166,10 @@ TESTS_SCHEMA = vol.Schema(
                 vol.Required("intent"): {
                     vol.Required("name"): str,
                     vol.Optional("slots"): {
-                        str: vol.Any(
-                            {vol.Required("value"): match_anything},
-                            match_anything_but_dict,
-                        ),
+                        # In the future, if we want to allowa dictionary,
+                        # we should wrap it in a dictionary with {"value": ...}
+                        # this will allow us to add more keys in the future.
+                        str: match_anything_but_dict,
                     },
                 },
             }

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -166,7 +166,7 @@ TESTS_SCHEMA = vol.Schema(
                 vol.Required("intent"): {
                     vol.Required("name"): str,
                     vol.Optional("slots"): {
-                        # In the future, if we want to allowa dictionary,
+                        # In the future, if we want to allow a dictionary,
                         # we should wrap it in a dictionary with {"value": ...}
                         # this will allow us to add more keys in the future.
                         str: match_anything_but_dict,

--- a/tests/ca/cover_HassOpenCover.yaml
+++ b/tests/ca/cover_HassOpenCover.yaml
@@ -26,9 +26,8 @@ tests:
       slots:
         area: bedroom
         device_class:
-          value:
-            - blind
-            - shutter
+          - blind
+          - shutter
   - sentences:
       - Obre la cortina de la cuina
     intent:

--- a/tests/en/cover_HassCloseCover.yaml
+++ b/tests/en/cover_HassCloseCover.yaml
@@ -29,7 +29,6 @@ tests:
       slots:
         area: "bedroom"
         device_class:
-          value:
-            - "blind"
-            - "curtain"
-            - "shutter"
+          - "blind"
+          - "curtain"
+          - "shutter"

--- a/tests/en/cover_HassOpenCover.yaml
+++ b/tests/en/cover_HassOpenCover.yaml
@@ -30,7 +30,6 @@ tests:
       slots:
         area: "kitchen"
         device_class:
-          value:
-            - "blind"
-            - "curtain"
-            - "shutter"
+          - "blind"
+          - "curtain"
+          - "shutter"

--- a/tests/es/cover_HassCloseCover.yaml
+++ b/tests/es/cover_HassCloseCover.yaml
@@ -27,8 +27,7 @@ tests:
       slots:
         area: "dormitorio"
         device_class:
-          value:
-            - "blind"
-            - "curtain"
-            - "shutter"
+          - "blind"
+          - "curtain"
+          - "shutter"
         name: "cover.cortina_dormitorio"

--- a/tests/es/cover_HassOpenCover.yaml
+++ b/tests/es/cover_HassOpenCover.yaml
@@ -30,7 +30,6 @@ tests:
       slots:
         area: "cocina"
         device_class:
-          value:
-            - "blind"
-            - "curtain"
-            - "shutter"
+          - "blind"
+          - "curtain"
+          - "shutter"

--- a/tests/fr/cover_HassCloseCover.yaml
+++ b/tests/fr/cover_HassCloseCover.yaml
@@ -32,7 +32,6 @@ tests:
       slots:
         area: "bedroom"
         device_class:
-          value:
-            - "blind"
-            - "curtain"
-            - "shutter"
+          - "blind"
+          - "curtain"
+          - "shutter"

--- a/tests/fr/cover_HassOpenCover.yaml
+++ b/tests/fr/cover_HassOpenCover.yaml
@@ -30,7 +30,6 @@ tests:
       slots:
         area: "kitchen"
         device_class:
-          value:
-            - "blind"
-            - "curtain"
-            - "shutter"
+          - "blind"
+          - "curtain"
+          - "shutter"

--- a/tests/hu/cover_HassOpenCover.yaml
+++ b/tests/hu/cover_HassOpenCover.yaml
@@ -35,10 +35,9 @@ tests:
       slots:
         area: "bedroom"
         device_class:
-          value:
-            - "blind"
-            - "curtain"
-            - "shade"
+          - "blind"
+          - "curtain"
+          - "shade"
 
   - sentences:
       - "árnyékoló terasz nyit"
@@ -48,10 +47,9 @@ tests:
       slots:
         area: "terrace"
         device_class:
-          value:
-            - "blind"
-            - "curtain"
-            - "shade"
+          - "blind"
+          - "curtain"
+          - "shade"
   - sentences:
       - "árnyékolók terasz utcafront nyit"
       - "terasz utcafront árnyékolók nyit"

--- a/tests/pl/cover_HassCloseCover.yaml
+++ b/tests/pl/cover_HassCloseCover.yaml
@@ -31,7 +31,6 @@ tests:
       slots:
         area: "bedroom"
         device_class:
-          value:
-            - "blind"
-            - "curtain"
-            - "shutter"
+          - "blind"
+          - "curtain"
+          - "shutter"

--- a/tests/pl/cover_HassOpenCover.yaml
+++ b/tests/pl/cover_HassOpenCover.yaml
@@ -31,7 +31,6 @@ tests:
       slots:
         area: "kitchen"
         device_class:
-          value:
-            - "blind"
-            - "curtain"
-            - "shutter"
+          - "blind"
+          - "curtain"
+          - "shutter"

--- a/tests/pt/cover_HassCloseCover.yaml
+++ b/tests/pt/cover_HassCloseCover.yaml
@@ -30,7 +30,6 @@ tests:
       slots:
         area: "cozinha"
         device_class:
-          value:
-            - "blind"
-            - "curtain"
-            - "shutter"
+          - "blind"
+          - "curtain"
+          - "shutter"

--- a/tests/pt/cover_HassOpenCover.yaml
+++ b/tests/pt/cover_HassOpenCover.yaml
@@ -30,7 +30,6 @@ tests:
       slots:
         area: "cozinha"
         device_class:
-          value:
-            - "blind"
-            - "curtain"
-            - "shutter"
+          - "blind"
+          - "curtain"
+          - "shutter"

--- a/tests/ru/cover_HassCloseCover.yaml
+++ b/tests/ru/cover_HassCloseCover.yaml
@@ -29,7 +29,6 @@ tests:
       slots:
         area: "bedroom"
         device_class:
-          value:
-            - "blind"
-            - "curtain"
-            - "shutter"
+          - "blind"
+          - "curtain"
+          - "shutter"

--- a/tests/ru/cover_HassOpenCover.yaml
+++ b/tests/ru/cover_HassOpenCover.yaml
@@ -31,7 +31,6 @@ tests:
       slots:
         area: "kitchen"
         device_class:
-          value:
-            - "blind"
-            - "curtain"
-            - "shutter"
+          - "blind"
+          - "curtain"
+          - "shutter"

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -71,15 +71,9 @@ def do_test_language_sentences_file(
             ), f"For '{sentence}' expected intent {intent['name']}, got {result.intent.name}"
 
             matched_slots = {slot.name: slot.value for slot in result.entities.values()}
-            expected_slots = {}
-            for slot_name, slot_dict in intent.get("slots", {}).items():
-                if isinstance(slot_dict, dict):
-                    expected_slots[slot_name] = slot_dict["value"]
-                else:
-                    expected_slots[slot_name] = slot_dict
 
-            assert (
-                matched_slots == expected_slots
+            assert matched_slots == intent.get(
+                "slots", {}
             ), f"Slots do not match for: {sentence}"
 
 

--- a/tests/uk/cover_HassCloseCover.yaml
+++ b/tests/uk/cover_HassCloseCover.yaml
@@ -33,17 +33,15 @@ tests:
       slots:
         area: "kitchen"
         device_class:
-          value:
-            - "blind"
-            - "curtain"
-            - "shutter"
+          - "blind"
+          - "curtain"
+          - "shutter"
   - sentences:
       - "закрий всі штори"
     intent:
       name: "HassCloseCover"
       slots:
         device_class:
-          value:
-            - "blind"
-            - "curtain"
-            - "shutter"
+          - "blind"
+          - "curtain"
+          - "shutter"

--- a/tests/uk/cover_HassOpenCover.yaml
+++ b/tests/uk/cover_HassOpenCover.yaml
@@ -32,17 +32,15 @@ tests:
       slots:
         area: "kitchen"
         device_class:
-          value:
-            - "blind"
-            - "curtain"
-            - "shutter"
+          - "blind"
+          - "curtain"
+          - "shutter"
   - sentences:
       - "розкрий всі вікна"
     intent:
       name: "HassOpenCover"
       slots:
         device_class:
-          value:
-            - "blind"
-            - "curtain"
-            - "shutter"
+          - "blind"
+          - "curtain"
+          - "shutter"


### PR DESCRIPTION
We allowed both a value or a dictionary containing a `value` key for expected slot values. In practice, we don't support any other keys but `value` so we could just always use the shortcut.

This updates our validation to enforce shortcuts and converts all test files to shortcuts.