### PR TITLE
[SV] Streamline language of fixtures

### DIFF
--- a/sentences/sv/_common.yaml
+++ b/sentences/sv/_common.yaml
@@ -47,8 +47,8 @@ lists:
       - in: "f"
         out: "fahrenheit"
 expansion_rules:
-  name: "{name}"
-  area: "{area}"
+  name: "{name}[s | n | ns | en ]"
+  area: "{area}[e | me][t | ts | n | ns ]"
   vad: "(vad är | vad är det | vad är det för | vilken)"
   är: "(är det | är)"
   brightness: "{brightness} [percent]"

--- a/tests/sv/_fixtures.yaml
+++ b/tests/sv/_fixtures.yaml
@@ -1,39 +1,33 @@
 language: sv
 areas:
-  - name: Köket
-    id: koket
-  - name: Vardagsrummet
-    id: vardagsrummet
-  - name: Sovrummet
-    id: sovrummet
-  - name: Garaget
-    id: garaget
   - name: Kök
     id: kitchen
+  - name: Vardagsrum
+    id: livingroom
   - name: Sovrum
     id: bedroom
   - name: Garage
     id: garage
-  - name: Bastun
+  - name: Bastu
     id: sauna
 entities:
   - name: garagelampa
-    id: light.garagelampa
+    id: light.garage_light
     area: garage
   - name: Sänglampan
-    id: light.sanglampan
-    area: sovrummet
+    id: light.bed_lamp
+    area: bedroom
   - name: Köksknappen
-    id: switch.koksknappen
-    area: koket
+    id: switch.kitchen_switch
+    area: kitchen
   - name: Takfläkten
-    id: fan.takflakten
-    area: vardagsrummet
+    id: fan.ceiling_fan
+    area: livingroom
   - name: Sovrumslampa
     id: light.bedroom_lamp
     area: bedroom
   - name: Strömbrytare Kök
-    id: switch.kitchen
+    id: switch.kitchen_switch
     area: kitchen
   - name: Bastun
     id: climate.sauna

--- a/tests/sv/climate_HassClimateGetTemperature.yaml
+++ b/tests/sv/climate_HassClimateGetTemperature.yaml
@@ -11,7 +11,7 @@ tests:
     intent:
       name: HassClimateGetTemperature
       slots:
-        area: "vardagsrummet"
+        area: "livingroom"
   - sentences:
       - "hur varmt är det i bastun?"
     intent:
@@ -24,4 +24,3 @@ tests:
       name: HassClimateGetTemperature
       slots:
         name: "climate.sauna"
-

--- a/tests/sv/fan_HassTurnOn.yaml
+++ b/tests/sv/fan_HassTurnOn.yaml
@@ -5,6 +5,6 @@ tests:
     intent:
       name: HassTurnOn
       slots:
-        area: "vardagsrummet"
+        area: "livingroom"
         domain: "fan"
         name: "all"

--- a/tests/sv/homeassistant_HassTurnOff.yaml
+++ b/tests/sv/homeassistant_HassTurnOff.yaml
@@ -6,4 +6,4 @@ tests:
     intent:
       name: HassTurnOff
       slots:
-        name: "light.sanglampan"
+        name: "light.bed_lamp"

--- a/tests/sv/homeassistant_HassTurnOn.yaml
+++ b/tests/sv/homeassistant_HassTurnOn.yaml
@@ -1,9 +1,9 @@
 language: sv
 tests:
-- sentences:
-    - "sätt på takfläkten"
-    - "sätt på takfläkten tack"
-  intent:
-    name: HassTurnOn
-    slots:
-      name: "fan.takflakten"
+  - sentences:
+      - "sätt på takfläkten"
+      - "sätt på takfläkten tack"
+    intent:
+      name: HassTurnOn
+      slots:
+        name: "fan.ceiling_fan"

--- a/tests/sv/light_HassLightSet.yaml
+++ b/tests/sv/light_HassLightSet.yaml
@@ -20,7 +20,7 @@ tests:
       name: HassLightSet
       slots:
         brightness: 50
-        name: light.garagelampa
+        name: light.garage_light
 
   - sentences:
       - "alla lampor i garaget till 50%"

--- a/tests/sv/light_HassTurnOff.yaml
+++ b/tests/sv/light_HassTurnOff.yaml
@@ -1,16 +1,16 @@
 language: sv
 tests:
-- sentences:
-    - "släck ljuset i köket"
-    - "stäng av all belysning i köket"
-    - "stäng av belysningen i köket"
-    - "släck belysningen i köket"
-    - "släck all belysning i köket"
-    - "släck alla lampor i köket"
-    - "släck alla lamporna i köket"
-    - "släck belysningen i köket tack"
-  intent:
-    name: HassTurnOff
-    slots:
-      area: kitchen
-      domain: light
+  - sentences:
+      - "släck ljuset i köket"
+      - "stäng av all belysning i köket"
+      - "stäng av belysningen i köket"
+      - "släck belysningen i köket"
+      - "släck all belysning i köket"
+      - "släck alla lampor i köket"
+      - "släck alla lamporna i köket"
+      - "släck belysningen i köket tack"
+    intent:
+      name: HassTurnOff
+      slots:
+        area: "kitchen"
+        domain: light


### PR DESCRIPTION
Fixed overlapping area names lik kök and köket to only one per room and using the shortest form for the room name (to allow testing of room name expantions  like rum->rummet garage->garagets kök->kökets)

Entity id's where a mix of swedish and english, converted all these to english. As it feels more natural to have "variable" names in english for me.

Updated all tests to run with the new fixtures and the test runs.