### PR TITLE
Add Kannada correctly under kn

### DIFF
--- a/languages.yaml
+++ b/languages.yaml
@@ -57,9 +57,9 @@ it:
     - auanasgheps
     - xraver
 ka:
-  nativeName: ಕನ್ನಡ
-kn:
   nativeName: ქართული
+kn:
+  nativeName: ಕನ್ನಡ
 lt:
   nativeName: Lietuvių
   leaders:

--- a/languages.yaml
+++ b/languages.yaml
@@ -58,6 +58,8 @@ it:
     - xraver
 ka:
   nativeName: ಕನ್ನಡ
+kn:
+  nativeName: ಕನ್ನಡ
 lt:
   nativeName: Lietuvių
   leaders:

--- a/responses/kn/HassClimateGetTemperature.yaml
+++ b/responses/kn/HassClimateGetTemperature.yaml
@@ -1,0 +1,5 @@
+language: kn
+responses:
+  intents:
+    HassClimateGetTemperature:
+      success: []

--- a/sentences/kn/_common.yaml
+++ b/sentences/kn/_common.yaml
@@ -1,0 +1,12 @@
+language: kn
+responses:
+  errors:
+    no_intent: TODO Sorry, I couldn't understand that
+    no_area: TODO No area named {{ area }}
+    no_domain: TODO {{ area }} does not contain a {{ domain }}
+    no_device_class: TODO {{ area }} does not contain a {{ device_class }}
+    no_entity: TODO No device or entity named {{ entity }}
+    handle_error: TODO An unexpected error occurred while handling the intent
+lists: {}
+expansion_rules: {}
+skip_words: []

--- a/sentences/kn/climate_HassClimateGetTemperature.yaml
+++ b/sentences/kn/climate_HassClimateGetTemperature.yaml
@@ -1,0 +1,5 @@
+language: kn
+intents:
+  HassClimateGetTemperature:
+    data:
+      - sentences: []

--- a/sentences/kn/climate_HassClimateSetTemperature.yaml
+++ b/sentences/kn/climate_HassClimateSetTemperature.yaml
@@ -1,0 +1,5 @@
+language: kn
+intents:
+  HassClimateSetTemperature:
+    data:
+      - sentences: []

--- a/sentences/kn/cover_HassCloseCover.yaml
+++ b/sentences/kn/cover_HassCloseCover.yaml
@@ -1,0 +1,5 @@
+language: kn
+intents:
+  HassCloseCover:
+    data:
+      - sentences: []

--- a/sentences/kn/cover_HassOpenCover.yaml
+++ b/sentences/kn/cover_HassOpenCover.yaml
@@ -1,0 +1,5 @@
+language: kn
+intents:
+  HassOpenCover:
+    data:
+      - sentences: []

--- a/sentences/kn/fan_HassTurnOff.yaml
+++ b/sentences/kn/fan_HassTurnOff.yaml
@@ -1,0 +1,8 @@
+language: kn
+intents:
+  HassTurnOff:
+    data:
+      - sentences: []
+        slots:
+          domain: fan
+          name: all

--- a/sentences/kn/fan_HassTurnOn.yaml
+++ b/sentences/kn/fan_HassTurnOn.yaml
@@ -1,0 +1,8 @@
+language: kn
+intents:
+  HassTurnOn:
+    data:
+      - sentences: []
+        slots:
+          domain: fan
+          name: all

--- a/sentences/kn/homeassistant_HassTurnOff.yaml
+++ b/sentences/kn/homeassistant_HassTurnOff.yaml
@@ -1,0 +1,5 @@
+language: kn
+intents:
+  HassTurnOff:
+    data:
+      - sentences: []

--- a/sentences/kn/homeassistant_HassTurnOn.yaml
+++ b/sentences/kn/homeassistant_HassTurnOn.yaml
@@ -1,0 +1,5 @@
+language: kn
+intents:
+  HassTurnOn:
+    data:
+      - sentences: []

--- a/sentences/kn/light_HassLightSet.yaml
+++ b/sentences/kn/light_HassLightSet.yaml
@@ -1,0 +1,5 @@
+language: kn
+intents:
+  HassLightSet:
+    data:
+      - sentences: []

--- a/sentences/kn/light_HassTurnOff.yaml
+++ b/sentences/kn/light_HassTurnOff.yaml
@@ -1,0 +1,8 @@
+language: kn
+intents:
+  HassTurnOff:
+    data:
+      - sentences: []
+        slots:
+          domain: light
+          name: all

--- a/sentences/kn/light_HassTurnOn.yaml
+++ b/sentences/kn/light_HassTurnOn.yaml
@@ -1,0 +1,8 @@
+language: kn
+intents:
+  HassTurnOn:
+    data:
+      - sentences: []
+        slots:
+          domain: light
+          name: all

--- a/tests/kn/_fixtures.yaml
+++ b/tests/kn/_fixtures.yaml
@@ -1,0 +1,20 @@
+language: kn
+areas:
+  - name: Kitchen
+    id: kitchen
+  - name: Living Room
+    id: living_room
+  - name: Bedroom
+    id: bedroom
+  - name: Garage
+    id: garage
+entities:
+  - name: Bedroom Lamp
+    id: light.bedroom_lamp
+    area: bedroom
+  - name: Kitchen Switch
+    id: switch.kitchen
+    area: kitchen
+  - name: Ceiling Fan
+    id: fan.ceiling
+    area: living_room

--- a/tests/kn/climate_HassClimateGetTemperature.yaml
+++ b/tests/kn/climate_HassClimateGetTemperature.yaml
@@ -1,0 +1,6 @@
+language: kn
+tests:
+  - sentences: []
+    intent:
+      name: HassClimateGetTemperature
+      slots: {}

--- a/tests/kn/climate_HassClimateSetTemperature.yaml
+++ b/tests/kn/climate_HassClimateSetTemperature.yaml
@@ -1,0 +1,6 @@
+language: kn
+tests:
+  - sentences: []
+    intent:
+      name: HassClimateSetTemperature
+      slots: {}

--- a/tests/kn/cover_HassCloseCover.yaml
+++ b/tests/kn/cover_HassCloseCover.yaml
@@ -1,0 +1,6 @@
+language: kn
+tests:
+  - sentences: []
+    intent:
+      name: HassCloseCover
+      slots: {}

--- a/tests/kn/cover_HassOpenCover.yaml
+++ b/tests/kn/cover_HassOpenCover.yaml
@@ -1,0 +1,6 @@
+language: kn
+tests:
+  - sentences: []
+    intent:
+      name: HassOpenCover
+      slots: {}

--- a/tests/kn/fan_HassTurnOff.yaml
+++ b/tests/kn/fan_HassTurnOff.yaml
@@ -1,0 +1,8 @@
+language: kn
+tests:
+  - sentences: []
+    intent:
+      name: HassTurnOff
+      slots:
+        domain: fan
+        name: all

--- a/tests/kn/fan_HassTurnOn.yaml
+++ b/tests/kn/fan_HassTurnOn.yaml
@@ -1,0 +1,8 @@
+language: kn
+tests:
+  - sentences: []
+    intent:
+      name: HassTurnOn
+      slots:
+        domain: fan
+        name: all

--- a/tests/kn/homeassistant_HassTurnOff.yaml
+++ b/tests/kn/homeassistant_HassTurnOff.yaml
@@ -1,0 +1,6 @@
+language: kn
+tests:
+  - sentences: []
+    intent:
+      name: HassTurnOff
+      slots: {}

--- a/tests/kn/homeassistant_HassTurnOn.yaml
+++ b/tests/kn/homeassistant_HassTurnOn.yaml
@@ -1,0 +1,6 @@
+language: kn
+tests:
+  - sentences: []
+    intent:
+      name: HassTurnOn
+      slots: {}

--- a/tests/kn/light_HassLightSet.yaml
+++ b/tests/kn/light_HassLightSet.yaml
@@ -1,0 +1,6 @@
+language: kn
+tests:
+  - sentences: []
+    intent:
+      name: HassLightSet
+      slots: {}

--- a/tests/kn/light_HassTurnOff.yaml
+++ b/tests/kn/light_HassTurnOff.yaml
@@ -1,0 +1,8 @@
+language: kn
+tests:
+  - sentences: []
+    intent:
+      name: HassTurnOff
+      slots:
+        domain: light
+        name: all

--- a/tests/kn/light_HassTurnOn.yaml
+++ b/tests/kn/light_HassTurnOn.yaml
@@ -1,0 +1,8 @@
+language: kn
+tests:
+  - sentences: []
+    intent:
+      name: HassTurnOn
+      slots:
+        domain: light
+        name: all


### PR DESCRIPTION
In #195 we accidentally added the Kannada language under ka, which is the code for Georgia. In #486 we repurposed ka again for Georgian, so this PR adds Kannada back as kn.