### PR TITLE
[en] Add sentence variant for climate, including contraction for "is"

### DIFF
--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -41,6 +41,8 @@ expansion_rules:
   name: "[the] {name}"
   area: "[the] {area}"
   what_is: "(what's | whats | what is)"
+  # Allows for contracted "is", e.g. "how warm's the kitchen"
+  is: "(is | 's)"
   brightness: "{brightness} [percent]"
   turn: "(turn | switch)"
   temp: "(temp | temperature)"

--- a/sentences/en/climate_HassClimateGetTemperature.yaml
+++ b/sentences/en/climate_HassClimateGetTemperature.yaml
@@ -4,6 +4,6 @@ intents:
     data:
       - sentences:
           - "<what_is> [the] <temp> [in <area>]"
-          - "how (hot | cold | warm | cool) is it [in <area>]"
+          - "how (hot | cold | warm | cool) <is> [[it in] <area>]"
           - "is it (hot | cold | warm | cool) [in <area>]"
           - "<what_is> <area> <temp>"

--- a/tests/en/climate_HassClimateGetTemperature.yaml
+++ b/tests/en/climate_HassClimateGetTemperature.yaml
@@ -15,6 +15,8 @@ tests:
       - "what's the living room temperature?"
       - "what's the temp in the living room?"
       - "what's the living room temp?"
+      - "how warm's the living room?"
+      - "how warm's it in the living room?"
     intent:
       name: "HassClimateGetTemperature"
       slots:


### PR DESCRIPTION
Added a couple of sentences that I felt were missing as an English native speaker.

Plus added the option to have `'s` as a contraction for `is`, since it can be used in a lot of places in English.
Even although I guess we end up with a space between the word and the contraction (e.g. `how warm 's it`) in the sentence, the tests seem happy with it.