### PR TITLE
[NL] Remove "de" from GetTemperature

### DIFF
--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -49,7 +49,7 @@ lists:
       - in: "f"
         out: "fahrenheit"
 expansion_rules:
-  lamp: "[(de | het)] (lamp  | lampen | licht | lichten | verlichting)"
+  lamp: "[de | het] (lamp  | lampen | licht | lichten | verlichting)"
   ventilator: "[de] (ventilator | ventilators | ventilatoren)"
   name: "[de | het] {name}"
   area: "[de | het] {area}"

--- a/sentences/nl/climate_HassClimateGetTemperature.yaml
+++ b/sentences/nl/climate_HassClimateGetTemperature.yaml
@@ -8,5 +8,5 @@ intents:
           - "hoe <warm> is [het in] <area>"
           - "Wat is de temperatuur in <area>"
           - "Wat is <area> temperatuur"
-          - "Hoe <warm> staat de <name> [ingesteld]"
-          - "Op hoeveel graden staat de <name> [ingesteld]"
+          - "Hoe <warm> staat <name> [ingesteld]"
+          - "Op hoeveel graden staat <name> [ingesteld]"


### PR DESCRIPTION
`de` should not have been included in these sentences, this is already included in the expansion_rule.

Also removed the parentheses in the `lamp` expansion rule