### PR TITLE
Merging treatment of "gate", "garage_door" and "door" device classes

### DIFF
--- a/sentences/es/cover_HassCloseCover.yaml
+++ b/sentences/es/cover_HassCloseCover.yaml
@@ -5,13 +5,12 @@ intents:
       - sentences:
           - "<cierra> <name> [<area>]"
       - sentences:
-          - "<cierra> <puerta> [(del|de|de la)] (garaje|cochera)"
-        slots:
-          device_class: "garage_door"
-      - sentences:
           - "<cierra> <puerta> [<area>]"
         slots:
-          device_class: "gate"
+          device_class:
+            - "gate"
+            - "garage_door"
+            - "door"
       - sentences:
           - "<cierra> [ la | las ] (cortinas|persianas) [<area>]"
         slots:

--- a/sentences/es/cover_HassOpenCover.yaml
+++ b/sentences/es/cover_HassOpenCover.yaml
@@ -6,7 +6,8 @@ intents:
           - "<abre> <name>"
           - "<abre> <name> <area>"
       - sentences:
-          - "<abre> <puerta> [<area>]"
+          - "<abre> <puerta>"
+          - "<abre> <puerta> <area>"
         slots:
           device_class:
             - "gate"

--- a/sentences/es/cover_HassOpenCover.yaml
+++ b/sentences/es/cover_HassOpenCover.yaml
@@ -6,8 +6,7 @@ intents:
           - "<abre> <name>"
           - "<abre> <name> <area>"
       - sentences:
-          - "<abre> <puerta>"
-          - "<abre> <puerta> <area>"
+          - "<abre> <puerta> [<area>]"
         slots:
           device_class:
             - "gate"

--- a/sentences/es/cover_HassOpenCover.yaml
+++ b/sentences/es/cover_HassOpenCover.yaml
@@ -6,13 +6,12 @@ intents:
           - "<abre> <name>"
           - "<abre> <name> <area>"
       - sentences:
-          - "<abre> <puerta> [(del|de|de la)] (garaje|cochera)"
-        slots:
-          device_class: "garage_door"
-      - sentences:
           - "<abre> <puerta> [<area>]"
         slots:
-          device_class: "gate"
+          device_class:
+            - "gate"
+            - "garage_door"
+            - "door"
       - sentences:
           - "<abre> [la | las] (cortinas | persianas) <area>"
         slots:

--- a/tests/es/cover_HassCloseCover.yaml
+++ b/tests/es/cover_HassCloseCover.yaml
@@ -16,7 +16,7 @@ tests:
         name: cover.cortina_izquierda
         area: salon
 
-  # Gates
+  # Gates, Doors and Garage Doors
   - sentences:
       - "cierra la puerta"
       - "cerrar la puerta"
@@ -33,7 +33,10 @@ tests:
     intent:
       name: "HassCloseCover"
       slots:
-        device_class: "gate"
+        device_class:
+          - "gate"
+          - "garage_door"
+          - "door"
   - sentences:
       - "cierra la puerta del jardín"
       - "cerrar la puerta del jardín"
@@ -50,18 +53,26 @@ tests:
     intent:
       name: "HassCloseCover"
       slots:
-        device_class: "gate"
+        device_class:
+          - "gate"
+          - "garage_door"
+          - "door"
         area: "jardin"
-
   - sentences:
       - "cierra la puerta del garaje"
-      - "cerrar puerta de la cochera"
-      - "baja puerta de garaje"
-      - "bajar puerta de la cochera"
+      - "cerrar el portón del garaje"
+      - "baja la cancela del garaje"
+      - "bajar verja garaje"
     intent:
       name: "HassCloseCover"
       slots:
-        device_class: "garage_door"
+        device_class:
+          - "gate"
+          - "garage_door"
+          - "door"
+        area: "garaje"
+
+# Blinds
   - sentences:
       - "cierra las cortinas del dormitorio"
       - "cerrar cortinas en el dormitorio"

--- a/tests/es/cover_HassOpenCover.yaml
+++ b/tests/es/cover_HassOpenCover.yaml
@@ -54,6 +54,16 @@ tests:
       - "abrir la compuerta del jardín"
       - "sube la cancela del jardín"
       - "subir la cancela del jardín"
+    intent:
+      name: "HassOpenCover"
+      slots:
+        device_class:
+          - "gate"
+          - "garage_door"
+          - "door"
+        area:
+          - "jardin"
+  - sentences:
       - "abre la puerta del garaje"
       - "abrir el portón del garaje"
       - "sube la cancela del garaje"
@@ -66,8 +76,8 @@ tests:
           - "garage_door"
           - "door"
         area:
-          - "jardin"
           - "garaje"
+
 
   # Blinds
   - sentences:

--- a/tests/es/cover_HassOpenCover.yaml
+++ b/tests/es/cover_HassOpenCover.yaml
@@ -20,7 +20,7 @@ tests:
         name: cover.cortina_izquierda
         area: salon
 
-  # Gates
+  # Gates, Doors and Garage Doors
   - sentences:
       - "abre la puerta"
       - "abrir la puerta"
@@ -37,7 +37,10 @@ tests:
     intent:
       name: "HassOpenCover"
       slots:
-        device_class: "gate"
+        device_class:
+          - "gate"
+          - "garage_door"
+          - "door"
   - sentences:
       - "abre la puerta del jardín"
       - "abrir la puerta del jardín"
@@ -51,22 +54,20 @@ tests:
       - "abrir la compuerta del jardín"
       - "sube la cancela del jardín"
       - "subir la cancela del jardín"
-    intent:
-      name: "HassOpenCover"
-      slots:
-        device_class: "gate"
-        area: "jardin"
-
-  # Garage door
-  - sentences:
       - "abre la puerta del garaje"
-      - "abrir la puerta de la cochera"
-      - "sube puerta de garaje"
-      - "subir puerta de la cochera"
+      - "abrir el portón del garaje"
+      - "sube la cancela del garaje"
+      - "subir verja garaje"
     intent:
       name: "HassOpenCover"
       slots:
-        device_class: "garage_door"
+        device_class:
+          - "gate"
+          - "garage_door"
+          - "door"
+        area:
+          - "jardin"
+          - "garaje"
 
   # Blinds
   - sentences:

--- a/tests/es/cover_HassOpenCover.yaml
+++ b/tests/es/cover_HassOpenCover.yaml
@@ -61,8 +61,7 @@ tests:
           - "gate"
           - "garage_door"
           - "door"
-        area:
-          - "jardin"
+        area: "jardin"
   - sentences:
       - "abre la puerta del garaje"
       - "abrir el portón del garaje"
@@ -75,8 +74,7 @@ tests:
           - "gate"
           - "garage_door"
           - "door"
-        area:
-          - "garaje"
+        area: "garaje"
 
 
   # Blinds


### PR DESCRIPTION
I feel that the device classes "gate" and "garage-door" should be handled the same way, along with device class 'door'. Right now, the the only difference is the addition of 'garaje' or 'cochera' at the end of the sentence for device class 'garage_door'. Frankly, I think 'garaje' or 'cochera' are the names of areas, and they should be treated as such.