### PR TITLE
Add domain context to test entities and allow requires/excludes context

### DIFF
--- a/script/intentfest/parse.py
+++ b/script/intentfest/parse.py
@@ -7,12 +7,12 @@ import sys
 from typing import Any, Dict
 
 import yaml
-from hassil.intents import Intents, SlotList, TextSlotList
+from hassil.intents import Intents
 from hassil.recognize import recognize
 from hassil.util import merge_dict
 
 from .const import LANGUAGES, SENTENCE_DIR, TESTS_DIR
-from .util import get_base_arg_parser
+from .util import get_base_arg_parser, get_slot_lists
 
 
 def get_arguments() -> argparse.Namespace:
@@ -43,15 +43,7 @@ def run() -> int:
 
     # Load test areas and entities for language
     test_names = yaml.safe_load((tests_dir / "_fixtures.yaml").read_text())
-
-    slot_lists: Dict[str, SlotList] = {
-        "area": TextSlotList.from_tuples(
-            (area["name"], area["id"]) for area in test_names["areas"]
-        ),
-        "name": TextSlotList.from_tuples(
-            (entity["name"], entity["id"]) for entity in test_names["entities"]
-        ),
-    }
+    slot_lists = get_slot_lists(test_names)
 
     # Load intents
     intents_dict: Dict[str, Any] = {}

--- a/script/intentfest/sample.py
+++ b/script/intentfest/sample.py
@@ -7,12 +7,12 @@ import sys
 from typing import Any, Dict
 
 import yaml
-from hassil.intents import Intents, SlotList, TextSlotList
+from hassil.intents import Intents
 from hassil.sample import sample_intents
 from hassil.util import merge_dict
 
 from .const import LANGUAGES, SENTENCE_DIR, TESTS_DIR
-from .util import get_base_arg_parser
+from .util import get_base_arg_parser, get_slot_lists
 
 
 def get_arguments() -> argparse.Namespace:
@@ -45,15 +45,7 @@ def run() -> int:
 
     # Load test areas and entities for language
     test_names = yaml.safe_load((tests_dir / "_fixtures.yaml").read_text())
-
-    slot_lists: Dict[str, SlotList] = {
-        "area": TextSlotList.from_tuples(
-            (area["name"], area["id"]) for area in test_names["areas"]
-        ),
-        "name": TextSlotList.from_tuples(
-            (entity["name"], entity["id"]) for entity in test_names["entities"]
-        ),
-    }
+    slot_lists = get_slot_lists(test_names)
 
     # Load intents
     intents_dict: Dict[str, Any] = {}

--- a/script/intentfest/util.py
+++ b/script/intentfest/util.py
@@ -1,7 +1,9 @@
 """Translation utils."""
 import argparse
+from typing import Any, Dict
 
 import yaml
+from hassil.intents import SlotList, TextSlotList
 from hassil.util import merge_dict
 
 from .const import RESPONSE_DIR, SENTENCE_DIR
@@ -49,3 +51,20 @@ def load_merged_responses(language: str) -> dict:
     for response_file in (RESPONSE_DIR / language).iterdir():
         merge_dict(merged_responses, yaml.safe_load(response_file.read_text()))
     return merged_responses
+
+
+def get_slot_lists(test_names: Dict[str, Any]) -> Dict[str, SlotList]:
+    # Load test areas and entities for language
+    return {
+        "area": TextSlotList.from_tuples(
+            (area["name"], area["id"]) for area in test_names["areas"]
+        ),
+        "name": TextSlotList.from_tuples(
+            (
+                entity["name"],
+                entity["id"],
+                {"domain": entity["id"].split(".", maxsplit=1)[0]},
+            )
+            for entity in test_names["entities"]
+        ),
+    }

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -114,6 +114,8 @@ SENTENCE_SCHEMA = vol.Schema(
                         vol.Optional("slots"): {
                             str: match_anything,
                         },
+                        vol.Optional("requires_context"): {str: match_anything},
+                        vol.Optional("excludes_context"): {str: match_anything},
                     }
                 ]
             }

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -21,9 +21,17 @@ def slot_lists_fixture(language: str) -> dict[str, SlotList]:
             (area["name"], area["id"]) for area in fixtures["areas"]
         ),
         "name": TextSlotList.from_tuples(
-            (entity["name"], entity["id"]) for entity in fixtures["entities"]
+            (entity["name"], entity["id"], _entity_context(entity))
+            for entity in fixtures["entities"]
         ),
     }
+
+
+def _entity_context(entity: dict[str, Any]) -> dict[str, Any]:
+    """Extract matching context from test fixture entity."""
+    entity_id = entity["id"]
+    domain = entity_id.split(".", maxsplit=1)[0]
+    return {"domain": domain}
 
 
 def do_test_language_sentences_file(


### PR DESCRIPTION
Allows `requires_context` and `excludes_context` to be used in intents. These can be used to prevent general intents (e.g., `HassTurnOn`) from matching cases where specific intents are desired (e.g., `HassOpenCover`).

See: https://github.com/home-assistant/intents/issues/574#issuecomment-1379426746