### PR TITLE
Allow colon in sentence matcher

### DIFF
--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -112,7 +112,7 @@ INTENT_ERRORS = {
 }
 
 SENTENCE_MATCHER = vol.All(
-    match_unicode_regex(r"^[\w\p{M} '\|\(\)\[\]\{\}\<\>]+$"),
+    match_unicode_regex(r"^[\w\p{M} '\|\(\)\[\]\{\}\<\>\:]+$"),
     msg="Sentences should only contain words and matching syntax. They should not contain punctuation.",
 )
 


### PR DESCRIPTION
Allows the precense of a colon in sentences to allow better handling of min/max intents. I dont know if this is enougth to allow the colon or a more complex regexp is wantet that only accepts it between brackets.

See https://github.com/home-assistant/intents/issues/670 for more info.