### PR TITLE
[EN] Use cleaner syntax for min/max brightness

### DIFF
--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -24,6 +24,12 @@ lists:
       type: "percentage"
       from: 0
       to: 100
+  brightness_level:
+    values:
+      - in: (max | maximum | highest)
+        out: 100
+      - in: ( minimum | lowest)
+        out: 1
   temperature:
     range:
       type: "temperature"

--- a/sentences/en/light_HassLightSet.yaml
+++ b/sentences/en/light_HassLightSet.yaml
@@ -18,36 +18,18 @@ intents:
           name: "all"
       # Max/Min brightness
       - sentences:
-          - "set <name> brightness to [the] (max | maximum | highest)"
-          - "set [the] brightness of <name> to [the] (max | maximum | highest)"
-          - "set <name> to [the] (max | maximum | highest) brightness"
-        slots:
-          brightness: 100
+          - "set <name> brightness to [the] {brightness_level:brightness} "
+          - "set [the] brightness of <name> to [the] {brightness_level:brightness} "
+          - "set <name> to [the] {brightness_level:brightness}  brightness"
 
       - sentences:
-          - "set <name> brightness to [the] ( minimum | lowest)"
-          - "set [the] brightness of <name> to [the] ( minimum | lowest)"
-          - "set <name> to [the] ( minimum | lowest) brightness"
-        slots:
-          brightness: 1
-
-      - sentences:
-          - "set [the] brightness in <area> to [the] (max | maximum | highest)"
-          - "set [the] brightness of <area> to [the] (max | maximum | highest)"
-          - "set <area> brightness to [the] (max | maximum | highest)"
-          - "set <area> to [the] (max | maximum | highest) brightness"
+          - "set [the] brightness in <area> to [the] {brightness_level:brightness} "
+          - "set [the] brightness of <area> to [the] {brightness_level:brightness} "
+          - "set <area> brightness to [the] {brightness_level:brightness} "
+          - "set <area> to [the] {brightness_level:brightness}  brightness"
         slots:
           name: "all"
-          brightness: 100
 
-      - sentences:
-          - "set [the] brightness in <area> to [the] ( minimum | lowest)"
-          - "set [the] brightness of <area> to [the] ( minimum | lowest)"
-          - "set <area> brightness to [the] ( minimum | lowest)"
-          - "set <area> to [the] ( minimum | lowest) brightness"
-        slots:
-          name: "all"
-          brightness: 1
       # color
       - sentences:
           - "(set | change) <name> [color] to {color}"


### PR DESCRIPTION
Uses the cleaner syntax for max/min brightness discussed here: https://github.com/home-assistant/intents/pull/487#discussion_r1071547128