### PR TITLE
Fix area responses to use slots.area

### DIFF
--- a/responses/ar/HassTurnOff.yaml
+++ b/responses/ar/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/bg/HassTurnOff.yaml
+++ b/responses/bg/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Изключих {{ slots.name }}
-      lights_area: Изгасих лампите в {{ slots.name }}
-      fans_area: Изключих вентилаторите в {{ slots.name }}
+      lights_area: Изгасих лампите в {{ slots.area }}
+      fans_area: Изключих вентилаторите в {{ slots.area }}
       cover: Затворих {{ slots.name }}
       cover_area: Затворих {{ slots.area }}

--- a/responses/bn/HassTurnOff.yaml
+++ b/responses/bn/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/ca/HassTurnOff.yaml
+++ b/responses/ca/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/da/HassTurnOff.yaml
+++ b/responses/da/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/de/HassTurnOff.yaml
+++ b/responses/de/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: "{{ slots.name }} ausgeschaltet"
-      lights_area: "Die Lampen in {{ slots.name }} sind ausgeschaltet"
-      fans_area: "Die Ventilatoren in {{ slots.name }} sind ausgeschaltet"
+      lights_area: "Die Lampen in {{ slots.area }} sind ausgeschaltet"
+      fans_area: "Die Ventilatoren in {{ slots.area }} sind ausgeschaltet"
       cover: "{{ slots.name }} geschlossen"
       cover_area: "{{ slots.area }} geschlossen"

--- a/responses/el/HassTurnOff.yaml
+++ b/responses/el/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/es/HassTurnOff.yaml
+++ b/responses/es/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Apagado de {{ slots.name }} realizado
-      lights_area: Luces en {{ slots.name }} apagadas
-      fans_area: Ventiladores en {{ slots.name }} apagados
+      lights_area: Luces en {{ slots.area }} apagadas
+      fans_area: Ventiladores en {{ slots.area }} apagados
       cover: Cierre de {{ slots.name }} completado
       cover_area: Cierre en {{ slots.area }} completado

--- a/responses/fa/HassTurnOff.yaml
+++ b/responses/fa/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/fi/HassTurnOff.yaml
+++ b/responses/fi/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/gl/HassTurnOff.yaml
+++ b/responses/gl/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/he/HassTurnOff.yaml
+++ b/responses/he/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: מכבה {{ slots.name }}
-      lights_area: מכבה את האורות ב {{ slots.name }}
-      fans_area: מכבה מאווררים ב {{ slots.name }}
+      lights_area: מכבה את האורות ב {{ slots.area }}
+      fans_area: מכבה מאווררים ב {{ slots.area }}
       cover: סוגר {{ slots.name }}
       cover_area: סוגר {{ slots.area }}

--- a/responses/hi/HassTurnOff.yaml
+++ b/responses/hi/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/hr/HassTurnOff.yaml
+++ b/responses/hr/HassTurnOff.yaml
@@ -3,8 +3,8 @@ responses:
   intents:
     HassTurnOff:
       default: Ugašen je uređaj {{ slots.name }}
-      lights_area: Ugašena su svjetla u prostoriji {{ slots.name }}
-      fans_area: Ugašen je ventrilator {{ slots.name }}
+      lights_area: Ugašena su svjetla u prostoriji {{ slots.area }}
+      fans_area: Ugašen je ventrilator {{ slots.area }}
       #TODO: better  phrase for plurals and acusative
       cover: "Sjenilo {{ slots.name }} je zatvoreno"
       cover_area: "Sjenila u prostoriji {{ slots.area }} su zatvorena"

--- a/responses/hr/HassTurnOn.yaml
+++ b/responses/hr/HassTurnOn.yaml
@@ -3,8 +3,8 @@ responses:
   intents:
     HassTurnOn:
       default: Upaljen je uređaj {{ slots.name }}
-      lights_area: Upaljena su svjetla u prostoriji {{ slots.name }}
-      fans_area: Upaljen je ventrilator {{ slots.name }}
+      lights_area: Upaljena su svjetla u prostoriji {{ slots.area }}
+      fans_area: Upaljen je ventrilator {{ slots.area }}
       cover: "Sjenilo {{ slots.name }} je otvoreno"
       cover_area: "Sjenila u prostoriji {{ slots.area }} su otvorena"
       windows_area: "Prozori su otvorena u prostoriji {{ slots.area }}"

--- a/responses/hu/HassTurnOff.yaml
+++ b/responses/hu/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/id/HassTurnOff.yaml
+++ b/responses/id/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/is/HassTurnOff.yaml
+++ b/responses/is/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/it/HassTurnOff.yaml
+++ b/responses/it/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: spento {{ slots.name }}
-      lights_area: luci spente in {{ slots.name }}
-      fans_area: ventilazione spenta in {{ slots.name }}
+      lights_area: luci spente in {{ slots.area }}
+      fans_area: ventilazione spenta in {{ slots.area }}
       cover: chiuso {{ slots.name }}
       cover_area: chiuso {{ slots.area }}

--- a/responses/ka/HassTurnOff.yaml
+++ b/responses/ka/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/kn/HassTurnOff.yaml
+++ b/responses/kn/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/lb/HassTurnOff.yaml
+++ b/responses/lb/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/lt/HassTurnOff.yaml
+++ b/responses/lt/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: "Išjungtas {{ slots.name }}"
-      lights_area: "Visa šviesa išjungta {{ slots.name }}"
-      fans_area: "Visi ventilatoriai išjungti {{ slots.name }}"
+      lights_area: "Visa šviesa išjungta {{ slots.area }}"
+      fans_area: "Visi ventilatoriai išjungti {{ slots.area }}"
       cover: "Uždarytas {{ slots.name }}"
       cover_area: "Viskas uždaryta {{ slots.area }}"

--- a/responses/lt/HassTurnOn.yaml
+++ b/responses/lt/HassTurnOn.yaml
@@ -3,8 +3,8 @@ responses:
   intents:
     HassTurnOn:
       default: "Įjungtas {{ slots.name }}"
-      lights_area: "Visa šviesa įjungta {{ slots.name }}"
-      fans_area: "Visi ventilatoriai įjungti {{ slots.name }}"
+      lights_area: "Visa šviesa įjungta {{ slots.area }}"
+      fans_area: "Visi ventilatoriai įjungti {{ slots.area }}"
       cover: "Atidarytas {{ slots.name }}"
       cover_area: "Viskas atidaryta {{ slots.area }}"
 

--- a/responses/lv/HassTurnOff.yaml
+++ b/responses/lv/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/mn/HassTurnOff.yaml
+++ b/responses/mn/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/ms/HassTurnOff.yaml
+++ b/responses/ms/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: '{{ slots.name }} telah dimatikan'
-      lights_area: Semua lampu [di] {{ slots.name }} telah dipadamkan
-      fans_area: Semua kipas [di] {{ slots.name }} telah dimatikan
+      lights_area: Semua lampu [di] {{ slots.area }} telah dipadamkan
+      fans_area: Semua kipas [di] {{ slots.area }} telah dimatikan
       cover: '{{ slots.name }} telah ditutupkan'
       cover_area: Kawasan {{ slots.area }} telah ditutupkan

--- a/responses/ms/HassTurnOn.yaml
+++ b/responses/ms/HassTurnOn.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOn:
       default: '{{ slots.name }} telah dihidupkan'
-      lights_area: Semua lampu [di] {{ slots.name }} telah dinyalakan
-      fans_area: Semua kipas [di] {{ slots.name }} telah dihidupkan
+      lights_area: Semua lampu [di] {{ slots.area }} telah dinyalakan
+      fans_area: Semua kipas [di] {{ slots.area }} telah dihidupkan
       cover: '{{ slots.name }} telah dibuka'
       cover_area: Kawasan {{ slots.area }} telah dibuka

--- a/responses/nb/HassTurnOff.yaml
+++ b/responses/nb/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/nl/HassTurnOff.yaml
+++ b/responses/nl/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: "{{ slots.name }} uitgezet"
-      lights_area: De lampen in {{ slots.name }} zijn uitgezet
-      fans_area: De ventilatoren in {{ slots.name }} zijn uitgezet
+      lights_area: De lampen in {{ slots.area }} zijn uitgezet
+      fans_area: De ventilatoren in {{ slots.area }} zijn uitgezet
       cover: "{{ slots.name }} gesloten"
       cover_area: "{{ slots.area }} gesloten"

--- a/responses/pl/HassTurnOff.yaml
+++ b/responses/pl/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/pt/HassTurnOff.yaml
+++ b/responses/pt/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/ru/HassTurnOff.yaml
+++ b/responses/ru/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: "{{ slots.name }} выключен"
-      lights_area: "Выключен свет в {{ slots.name }}"
-      fans_area: "Вентиляторы выключены в {{ slots.name }}"
+      lights_area: "Выключен свет в {{ slots.area }}"
+      fans_area: "Вентиляторы выключены в {{ slots.area }}"
       cover: "Закрыто {{ slots.name }}"
       cover_area: "Закрыто {{ slots.area }}"

--- a/responses/sk/HassTurnOff.yaml
+++ b/responses/sk/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/sl/HassTurnOff.yaml
+++ b/responses/sl/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/sr/HassTurnOff.yaml
+++ b/responses/sr/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/sv/HassTurnOff.yaml
+++ b/responses/sv/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/sw/HassTurnOff.yaml
+++ b/responses/sw/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/te/HassTurnOff.yaml
+++ b/responses/te/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/tr/HassTurnOff.yaml
+++ b/responses/tr/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/ur/HassTurnOff.yaml
+++ b/responses/ur/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/vi/HassTurnOff.yaml
+++ b/responses/vi/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/zh-cn/HassTurnOff.yaml
+++ b/responses/zh-cn/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/zh-hk/HassTurnOff.yaml
+++ b/responses/zh-hk/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}

--- a/responses/zh-tw/HassTurnOff.yaml
+++ b/responses/zh-tw/HassTurnOff.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassTurnOff:
       default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.name }}
-      fans_area: Turned off fans in {{ slots.name }}
+      lights_area: Turned off lights in {{ slots.area }}
+      fans_area: Turned off fans in {{ slots.area }}
       cover: Closed {{ slots.name }}
       cover_area: Closed {{ slots.area }}


### PR DESCRIPTION
I mistakenly used `slots.name` in some area responses.