### PR TITLE
[IT] Fan intents consistent with responses

### DIFF
--- a/sentences/it/_common.yaml
+++ b/sentences/it/_common.yaml
@@ -62,7 +62,7 @@ expansion_rules:
   set: "(impost(a | are) | cambi(a | are) | mett(i | ere) | modific(a | are))"
   temp: "[la] (temperatura)"
   temperature: "{temperature} [gradi] [{temperature_unit}]"
-  fan: "(ventol(a | e) | ventilator(e | i) | climatizzator(e | i) | condizionator(e | i))"
+  fan: "(ventol(a | e) | ventilator(e | i) | ventilazione | climatizzator(e | i) | condizionator(e | i))"
 skip_words:
   - "per favore"
   - "potresti"


### PR DESCRIPTION
Having used the generic term `"ventilazione"` for `fans_area` in responses (#746), I'm afraid the user may pick up the response and use the same term as the assistant in formulating the intent. That's why this PR adds `"ventilazione"` as a synonym in `<fan>`.