### PR TITLE
Run Actions only in main repository

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -24,6 +24,7 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'home-assistant/intents' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -15,6 +15,7 @@ jobs:
   nightly:
     name: Nightly
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'home-assistant/intents' }}
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
There are multiple forks of the project, and each of them will run Actions by default.
Unless explicit confirmation or change from the user, I expect that these jobs should run only in here.

Confirm that this is not blocking anyone from the team, feel free to close if not needed.