### PR TITLE
Fix some dependencies regarding context

### DIFF
--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -189,6 +189,9 @@ TESTS_SCHEMA = vol.Schema(
                         # this will allow us to add more keys in the future.
                         str: match_anything_but_dict,
                     },
+                    vol.Optional("context"): {
+                        str: match_anything_but_dict,
+                    },
                 },
                 vol.Optional("response"): vol.Any(str, [str]),
             }

--- a/tests/test_language_intents.py
+++ b/tests/test_language_intents.py
@@ -102,6 +102,8 @@ def do_test_language_sentences(
 
                 # Add inferred slots
                 found_slots.update(data.slots)
+                if data.requires_context:
+                    found_slots.update(data.requires_context)
 
                 # Check required slots
                 for slot_name, slot_info in slot_schema.items():


### PR DESCRIPTION
Allow tests.intent.context in test schema - `python3 -m script.intentfest validate --language ro` produces errors if context is given in tests as per https://github.com/home-assistant/intents/pull/626

Required context should be inferred in tests, so that `slot_combinations` is met.