### PR TITLE
Update _common.yaml

### DIFF
--- a/sentences/hu/_common.yaml
+++ b/sentences/hu/_common.yaml
@@ -3,7 +3,7 @@ responses:
   errors:
     no_intent: Elnézést, ezt nem értettem
     no_area: "{{ area }} terület nem található"
-    no_domain: "{{ area }} nem található {{ domain }}(ban | ben)"
+    no_domain: "{{ area }} (ban | ben) nem található {{ domain }}"
     no_device_class: "{{ area }} (ban | ben) nem található {{ device_class }}"
     no_entity: "{{ entity }} nem található"
     handle_error: Váratlan hiba történt.


### PR DESCRIPTION
the en version: no_domain: "{{ area }} does not contain a {{ domain }}"
It is rather no_domain: "{{ area }} (ban | ben) nem található {{ domain }}" than no_domain: "{{ area }} nem található {{ domain }}(ban | ben)" -> the logic is reverse 
(this version is similar to no_device_class)