### PR TITLE
More naturally occurring sentences

### DIFF
--- a/sentences/nl/homeassistant_HassTurnOn.yaml
+++ b/sentences/nl/homeassistant_HassTurnOn.yaml
@@ -20,8 +20,8 @@ intents:
           device_class: garage
           domain: cover
       - sentences:
-          - open [de | het] (gordijn[en] | vitrage[s] | jaloezie[ën] | rolluik[en] | screen[s] | luxaflex) in <area>
-          - <doe> [de | het] (gordijn[en] | vitrage[s] | jaloezie[ën] | rolluik[en] | screen[s] | luxaflex) (open in <area> | in <area> open)
+          - open [de | het] (gordijn[en] | vitrage[s] | jaloezie[ën] | rolluik[en] | screen[s] | luxaflex | scherm[en]) in <area>
+          - <doe> [de | het] (gordijn[en] | vitrage[s] | jaloezie[ën] | rolluik[en] | screen[s] | luxaflex | scherm[en]) (open in <area> | in <area> open)
         response: cover_area
         slots:
           device_class:

--- a/sentences/nl/homeassistant_HassTurnOn.yaml
+++ b/sentences/nl/homeassistant_HassTurnOn.yaml
@@ -6,25 +6,25 @@ intents:
           - <doe> <name> [<naar>] aan
       - sentences:
           - open <name>
-          - "[doe | maak] <name> open"
+          - "<doe> <name> open"
         response: cover
       - sentences:
           - open <name> in <area>
-          - "[doe | maak] <name> in <area> open"
+          - "<doe> <name> in <area> open"
         response: cover_area
       - sentences:
           - open [de] garage [deur]
-          - (mag | doe) [de] garage [deur] open
+          - (mag | <doe>) [de] garage [deur] open
         response: cover
         slots:
           device_class: garage
           domain: cover
       - sentences:
-          - open [de | het] (gordijn | gordijnen | luxaflex | rolluik | rolluiken | screen | screens) in <area>
-          - (doe | mogen) [de] (gordijnen | rolluiken | screens) open in <area>
-          - (doe | mogen) [de] (gordijnen | rolluiken | screens) in <area> open
-          - (doe | mag) [de | het] (gordijn | luxaflex | rolluik | screen) open in <area>
-          - (doe | mag) [de | het] (gordijn | luxaflex | rolluik | screen) in <area> open
+          - open [de | het] (gordijn | gordijnen | vitrage | vitrages | luxaflex | rolluik | rolluiken | screen | screens | schermen) in <area>
+          - <doe> [de] (gordijnen | vitrage | vitrages | rolluiken | screens | schermen) open in <area>
+          - <doe> [de] (gordijnen | vitrage | vitrages | rolluiken | screens | schermen) in <area> open
+          - <doe> [de | het] (gordijn | vitrage | vitrages | luxaflex | rolluik | screen | schermen) open in <area>
+          - <doe> [de | het] (gordijn | vitrage | vitrages | luxaflex | rolluik | screen | schermen) in <area> open
         response: cover_area
         slots:
           device_class:


### PR DESCRIPTION
Replaced `doe` and `(doe | mogen)` with `<doe>` expansion rules, as words such as `maak` and `zet` would likely be used in the sentences aswell. For example: `zet de gordijnen open in de keuken`. Also added `vitrage`, `vitrages` and `schermen` as synonyms for `gordijnen`.