### PR TITLE
[RO] Updated responses and sentences for lights

### DIFF
--- a/responses/ro/HassTurnOff.yaml
+++ b/responses/ro/HassTurnOff.yaml
@@ -3,7 +3,8 @@ responses:
   intents:
     HassTurnOff:
       default: "Am oprit {{ slots.name }}"
-      lights_area: "Am oprit luminile din {{ slots.area }}"
+      light: "Am stins {{ slots.name }}"
+      lights_area: "Am stins luminile din {{ slots.area }}"
       fans_area: "Am oprit ventilatoarele din {{ slots.area }}"
       cover: "Am închis {{ slots.name }}"
       covers_area: "Am acoperit în {{ slots.area }}"

--- a/responses/ro/HassTurnOn.yaml
+++ b/responses/ro/HassTurnOn.yaml
@@ -3,8 +3,8 @@ responses:
   intents:
     HassTurnOn:
       default: "Am pornit {{ slots.name }}"
-      light: "Am stins {{ slots.name }}"
-      lights_area: "Am stins luminile din {{ slots.area }}"
+      light: "Am aprins {{ slots.name }}"
+      lights_area: "Am aprins luminile din {{ slots.area }}"
       fans_area: "Am pornit ventilatoarele din {{ slots.area }}"
       cover: "Am deschis {{ slots.name }}"
       covers_area: "Am deschis în {{ slots.area }}"

--- a/responses/ro/HassTurnOn.yaml
+++ b/responses/ro/HassTurnOn.yaml
@@ -3,7 +3,8 @@ responses:
   intents:
     HassTurnOn:
       default: "Am pornit {{ slots.name }}"
-      lights_area: "Am pornit luminile din {{ slots.area }}"
+      light: "Am stins {{ slots.name }}"
+      lights_area: "Am stins luminile din {{ slots.area }}"
       fans_area: "Am pornit ventilatoarele din {{ slots.area }}"
       cover: "Am deschis {{ slots.name }}"
       covers_area: "Am deschis în {{ slots.area }}"

--- a/sentences/ro/homeassistant_HassTurnOff.yaml
+++ b/sentences/ro/homeassistant_HassTurnOff.yaml
@@ -42,3 +42,8 @@ intents:
           device_class: gate
           domain: cover
         response: gates_area
+      - sentences:
+          - "<opreste> <name>"
+        slots:
+          domain: light
+        response: light

--- a/sentences/ro/homeassistant_HassTurnOn.yaml
+++ b/sentences/ro/homeassistant_HassTurnOn.yaml
@@ -42,3 +42,8 @@ intents:
           device_class: gate
           domain: cover
         response: gates_area
+      - sentences:
+          - "<porneste> <name>"
+        slots:
+          domain: light
+        response: light


### PR DESCRIPTION
Cred totuși că sună mai ok ”am aprins lumina” și ”am stins lumina”  decât ”am pornit lumina” și ”am oprit lumina” mai ales că s-a alocat intent special pentru lumini. Si așa cum pentru ”cover” s-au pus răspunsuri personalizate ”am deschis” și ”am închis” tot așa ar fi bine și pentru lumini.