### PR TITLE
Omit sentences for unsupported intents from merged output

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -79,6 +79,7 @@ HassLightSet:
 # -----------------------------------------------------------------------------
 
 HassClimateSetTemperature:
+  supported: false
   domain: climate
   description: "Sets the desired temperature of a climate device or entity"
   slots:
@@ -96,6 +97,7 @@ HassClimateSetTemperature:
       required: false
 
 HassClimateGetTemperature:
+  supported: false
   domain: climate
   description: "Gets the current temperature of a climate device or entity"
   slots:

--- a/script/intentfest/merged_output.py
+++ b/script/intentfest/merged_output.py
@@ -25,9 +25,9 @@ def run() -> int:
     intent_info = yaml.safe_load(INTENTS_FILE.read_text())
     intent_by_domain: dict[str, list] = {}
     for intent, info in intent_info.items():
+        if not info.get("supported", True):
+            continue
         intent_by_domain.setdefault(info["domain"], []).append(intent)
-    for intents in intent_by_domain.values():
-        intents.sort()
 
     for domain in intent_by_domain:
         (target / domain).mkdir(parents=True, exist_ok=True)

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -84,6 +84,7 @@ LANGUAGES_SCHEMA = vol.Schema(
 INTENTS_SCHEMA = vol.Schema(
     {
         str: {
+            vol.Optional("supported"): bool,
             vol.Required("domain"): str,
             vol.Required("description"): str,
             vol.Optional("slots"): {


### PR DESCRIPTION
Do not include temperature sentences, as we don't support those intents. This is causing users to get "intent not supported" errors instead of "I don't understand"