### PR TITLE
Added graag to skip words and make doe optional

### DIFF
--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -64,3 +64,5 @@ skip_words:
   - alstublieft
   - alsjeblieft
   - aub
+  - graag
+  

--- a/sentences/nl/homeassistant_HassTurnOff.yaml
+++ b/sentences/nl/homeassistant_HassTurnOff.yaml
@@ -3,7 +3,7 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - <doe> <name> [<naar>] uit
+          - [<doe>] <name> [<naar>] uit
           - <name> uit
       - sentences:
           - sluit <name>

--- a/sentences/nl/homeassistant_HassTurnOff.yaml
+++ b/sentences/nl/homeassistant_HassTurnOff.yaml
@@ -4,7 +4,6 @@ intents:
     data:
       - sentences:
           - [<doe>] <name> [<naar>] uit
-          - <name> uit
       - sentences:
           - sluit <name>
           - "<doe> <name> dicht"

--- a/sentences/nl/homeassistant_HassTurnOff.yaml
+++ b/sentences/nl/homeassistant_HassTurnOff.yaml
@@ -4,6 +4,7 @@ intents:
     data:
       - sentences:
           - <doe> <name> [<naar>] uit
+          - <name> uit
       - sentences:
           - sluit <name>
           - "<doe> <name> dicht"

--- a/sentences/nl/homeassistant_HassTurnOff.yaml
+++ b/sentences/nl/homeassistant_HassTurnOff.yaml
@@ -3,7 +3,7 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - [<doe>] <name> [<naar>] uit
+          - "[<doe>] <name> [<naar>] uit"
       - sentences:
           - sluit <name>
           - "<doe> <name> dicht"

--- a/sentences/nl/homeassistant_HassTurnOn.yaml
+++ b/sentences/nl/homeassistant_HassTurnOn.yaml
@@ -4,6 +4,7 @@ intents:
     data:
       - sentences:
           - <doe> <name> [<naar>] aan
+          - <name> [<naar>] aan
       - sentences:
           - open <name>
           - "<doe> <name> open"

--- a/sentences/nl/homeassistant_HassTurnOn.yaml
+++ b/sentences/nl/homeassistant_HassTurnOn.yaml
@@ -3,8 +3,7 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - <doe> <name> [<naar>] aan
-          - <name> [<naar>] aan
+          - [<doe>] <name> [<naar>] aan
       - sentences:
           - open <name>
           - "<doe> <name> open"

--- a/sentences/nl/homeassistant_HassTurnOn.yaml
+++ b/sentences/nl/homeassistant_HassTurnOn.yaml
@@ -3,7 +3,7 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - [<doe>] <name> [<naar>] aan
+          - "[<doe>] <name> [<naar>] aan"
       - sentences:
           - open <name>
           - "<doe> <name> open"

--- a/tests/nl/homeassistant_HassTurnOff.yaml
+++ b/tests/nl/homeassistant_HassTurnOff.yaml
@@ -3,6 +3,7 @@ tests:
   - sentences:
       - Mag de slaapkamerlamp uit?
       - Doe de slaapkamerlamp uit
+      - Slaapkamerlamp uit
     intent:
       name: HassTurnOff
       slots:

--- a/tests/nl/homeassistant_HassTurnOn.yaml
+++ b/tests/nl/homeassistant_HassTurnOn.yaml
@@ -3,6 +3,7 @@ tests:
   - sentences:
       - Mag de slaapkamerlamp aan?
       - Doe de slaapkamerlamp aan
+      - Slaapkamerlamp aan
     intent:
       name: HassTurnOn
       slots:


### PR DESCRIPTION
It's polite to say 'graag' when interacting with an assistant. I believe this should be added to the skip words.

Also: it's currently not possible to say something like: plafondlamp woonkamer aan without saying 'doe' first. Sso I added that to the turnOn and turnOff files. I'm not sure if I did this correct, so please decline if it's not how it should be.