### PR TITLE
Add 've' option to area in Czech.

### DIFF
--- a/sentences/cs/_common.yaml
+++ b/sentences/cs/_common.yaml
@@ -57,7 +57,7 @@ lists:
       - in: "(f|fahrenhait[a])"
         out: fahrenheita
 expansion_rules:
-  area: "[(na|v)] {area}"
+  area: "[(na|v|ve)] {area}"
   zapnout: "(zapni|zapnout)"
   vypnout: "(vypni|vypnout|zastavit|zastav)"
   rozsvitit: "(rozsviť|rozsvítit|rožn[i|out])" #some dialect to be served for users :)


### PR DESCRIPTION
To allow 'zhasni ve sklepě'.