### PR TITLE
Bump hassil to 1.0.2 (skip words can ignore whitespace)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hassil==1.0.1
+hassil==1.0.2
 PyYAML==6.0
 voluptuous==0.13.1
 regex==2022.10.31


### PR DESCRIPTION
Fixes a bug in skip words, where `ignore_whitespace` was not being respected.