### PR TITLE
[RU] Remove duplicated preps from <area> parts

### DIFF
--- a/sentences/ru/homeassistant_HassTurnOff.yaml
+++ b/sentences/ru/homeassistant_HassTurnOff.yaml
@@ -16,7 +16,7 @@ intents:
           domain: cover
         response: "cover"
       - sentences:
-          - "<close> (штор(ы|у)|занавеск(и|у)|жалюзи|окн(о|а)) в <area>"
+          - "<close> (штор(ы|у)|занавеск(и|у)|жалюзи|окн(о|а)) <area>"
         slots:
           device_class:
             - "window"

--- a/sentences/ru/light_HassLightSet.yaml
+++ b/sentences/ru/light_HassLightSet.yaml
@@ -6,8 +6,8 @@ intents:
           - "<set> [яркость|яркость света] <name> [на|до] <brightness>"
         response: "brightness"
       - sentences:
-          - <set> яркость [света] [в|на] <area> [на|до] <brightness>
-          - <set> [на|до] <brightness> яркость [в|на] <area>
+          - <set> яркость [света] <area> [на|до] <brightness>
+          - <set> [на|до] <brightness> яркость <area>
         slots:
           name: "all"
         response: "brightness_area"
@@ -18,9 +18,9 @@ intents:
           - "<set> <name> {color} [цвет[а]]"
         response: "color"
       - sentences:
-          - "<set> [цвет] ([в|на] <area>|[всего] света [в|на] <area>|[все[х]] светильник(и|ов) [в|на] <area>) [на] {color} [цвета]"
-          - "<set> {color} цвет ([в|на] <area>|[всего] света [в|на] <area>|[всех] светильников [в|на] <area>)"
-          - "<set> {color} ( <area>|[весь] свет [в|на] <area>|[все] светильники [в|на] <area>)"
+          - "<set> [цвет] (<area>|[всего] света <area>|[все[х]] светильник(и|ов) <area>) [на] {color} [цвета]"
+          - "<set> {color} цвет (<area>|[всего] света <area>|[всех] светильников <area>)"
+          - "<set> {color} (<area>|[весь] свет <area>|[все] светильники <area>)"
         slots:
           name: "all"
         response: "color_area"

--- a/tests/ru/climate_HassClimateGetTemperature.yaml
+++ b/tests/ru/climate_HassClimateGetTemperature.yaml
@@ -12,3 +12,9 @@ tests:
       name: "HassClimateGetTemperature"
       slots:
         area: "living_room"
+  - sentences:
+      - "Сколько градусов на кухне?"
+    intent:
+      name: "HassClimateGetTemperature"
+      slots:
+        area: "kitchen"


### PR DESCRIPTION
As I pointed in #919, preps `[в|на]` already defined in `_common.yaml` and shouldn't be duplicated in other sentences files.
