### PR TITLE
Fix typo in `test_file`

### DIFF
--- a/script/test_file
+++ b/script/test_file
@@ -11,7 +11,7 @@ from pathlib import Path
 
 def main():
     if len(sys.argv) < 2:
-        print("Usage: scrip/test_file <path> [--select-language]")
+        print("Usage: script/test_file <path> [--select-language]")
         sys.exit(1)
 
     target_path = Path(sys.argv[1])


### PR DESCRIPTION
Tried copying the output, and noticed that it didn't work. Fixing the typo (missing a `t`).