### PR TITLE
[NL] Add expansion rule words

### DIFF
--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -62,7 +62,7 @@ expansion_rules:
   temperature: "{temperature}[°|graden] [{temperature_unit}]"
   warm: "(warm|heet|koud|koel)"
   open: "(open[en]|omhoog|naar boven|opwaarts)"
-  dicht: "(dicht|omlaag|naar beneden|sluiten)"
+  dicht: "(dicht|omlaag|naar beneden|sluiten|neerwaarts)"
 skip_words:
   - "alstublieft"
   - "alsjeblieft"

--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -50,7 +50,7 @@ lists:
         out: "fahrenheit"
 expansion_rules:
   lamp: "[de|het] (lamp[en]|licht[en]|verlichting)"
-  ventilator: "[de] (ventilator[s|en])"
+  ventilator: "[de] (ventilator[s|en]|fan[s])"
   afdekking: "[de|het] (gordijn[en]|vitrage[s]|jaloezie[ën]|rolluik[en]|screen[s]|luxaflex|scherm[en])"
   name: "[de|het] {name}"
   area: "[de|het] {area}"

--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -57,11 +57,11 @@ expansion_rules:
   doe: "(zet[ten]|mag|mogen|doe[n]|verander[en]|maak|maken|schakel[en])"
   zou: "(kan|kun[t]|zal|zou) (je|jij|u)"
   naar: "(naar|op)"
-  helderheid: "[de] (helderheid|felheid|intensiteit)"
+  helderheid: "[de] (helderheid|felheid|intensiteit|lichtsterkte)"
   brightness: "{brightness}[%|procent]"
   temperature: "{temperature}[°|graden] [{temperature_unit}]"
   warm: "(warm|heet|koud|koel)"
-  open: "(open[en]|omhoog|naar boven)"
+  open: "(open[en]|omhoog|naar boven|opwaarts)"
   dicht: "(dicht|omlaag|naar beneden|sluiten)"
 skip_words:
   - "alstublieft"


### PR DESCRIPTION
Even though fan is not a Dutch word, it's still being used often in a Dutch sentence. Can we add fan[s] to the ventilator expansion rule?
Also, I'd like to add `lichtsterkte` for the helderheid expansion rule and `opwaarts` for the open expansion rule.