### PR TITLE
Add description of HassGetState intent

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -53,6 +53,30 @@ HassTurnOff:
       description: "Device class of devices/entities in an area"
       required: false
 
+HassGetState:
+  supported: false
+  domain: homeassistant
+  description: "Gets or checks the state of an entity"
+  slots:
+    name:
+      description: "Name of a device or entity"
+      required: false
+    area:
+      description: "Name of an area"
+      required: false
+    domain:
+      description: "Domain of devices/entities in an area"
+      required: false
+    device_class:
+      description: "Device class of devices/entities in an area"
+      required: false
+    state:
+      description: "Device class of devices/entities in an area"
+      required: false
+  response_variables:
+    state:
+      description: "State of the first entity matched"
+
 # -----------------------------------------------------------------------------
 # light
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Add `HassGetState` to `intents.yaml`. This intent is currently being worked on in Home Assistant.