### PR TITLE
[NL] Add more variations to sentences

### DIFF
--- a/sentences/nl/fan_HassTurnOff.yaml
+++ b/sentences/nl/fan_HassTurnOff.yaml
@@ -10,12 +10,7 @@ intents:
         slots:
           domain: "fan"
           name: "all"
-      - sentences:
-          - "[<doe>|<zou>] <name>[ ]<ventilator> [<naar>] uit [willen|kunnen] [<doe>]"
-        requires_context:
-          domain: "fan"
-        slots:
-          domain: "fan"
+
       - sentences:
           - "[<doe>|<zou>] [(overal|alle)] <ventilator> [overal] uit [willen|kunnen] [<doe>]"
         response: "fan_all"

--- a/sentences/nl/fan_HassTurnOn.yaml
+++ b/sentences/nl/fan_HassTurnOn.yaml
@@ -13,10 +13,3 @@ intents:
         slots:
           domain: "fan"
           name: "all"
-      - sentences:
-          - "[<doe>|<zou>] <name>[ ]<ventilator> [<naar>] aan [willen|kunnen] [<doe>]"
-          - "Schakel <name>[ ]<ventilator> [<naar>] in"
-        requires_context:
-          domain: "fan"
-        slots:
-          domain: "fan"

--- a/sentences/nl/homeassistant_HassTurnOff.yaml
+++ b/sentences/nl/homeassistant_HassTurnOff.yaml
@@ -3,23 +3,28 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "[<doe>|<zou>] <name> [<naar>] uit [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] <name>[ ][<type>] [<naar>] uit [willen|kunnen] [<doe>]"
+          - "[<zou>] <name>[ ][<type>] [willen|kunnen] (uit[ ]zetten|uitschakelen)"
+
       - sentences:
           - "sluit <name>"
           - "[<doe>|<zou>] <name> <dicht> [willen|kunnen] [<doe>]"
         response: "cover"
+
       - sentences:
           - sluit <name> [in|op] <area>
           - "[<doe>|<zou>] <name> (<dicht> [in|op] <area>|[in|op] <area> <dicht>) [willen|kunnen] [<doe>]"
           - "<zou> <name> [in|op] <area> (willen|kunnen) [<dicht>]"
         response: "cover_area"
+
       - sentences:
-          - "sluit [de] garage [deur]"
-          - "[<doe>|<zou>] [de] garage [deur] dicht [willen|kunnen] [<doe>]"
+          - "sluit [de] garage[ ][deur]"
+          - "[<doe>|<zou>] [de] garage[ ][deur] dicht [willen|kunnen] [<doe>]"
         response: "cover"
         slots:
           device_class: "garage"
           domain: "cover"
+
       - sentences:
           - "sluit <afdekking> [in|op] <area>"
           - "[<doe>|<zou>] <afdekking> (<dicht> [in|op] <area>|[in|op] <area> <dicht>) [willen|kunnen] [<doe>]"

--- a/sentences/nl/homeassistant_HassTurnOn.yaml
+++ b/sentences/nl/homeassistant_HassTurnOn.yaml
@@ -3,24 +3,29 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "[<doe>|<zou>] <name> [<naar>] aan [willen|kunnen] [<doe>]"
-          - "schakel <name> [<naar>] in"
+          - "[<doe>|<zou>] <name>[ ][<type>] [<naar>] (aan|in) [willen|kunnen] [<doe>]"
+          - "schakel <name>[ ][<type>] [<naar>] in"
+          - "[<zou>] <name>[ ][<type>] [willen|kunnen] (aan[ ]zetten|inschakelen)"
+
       - sentences:
           - "open <name>"
           - "[<doe>|<zou>] <name> <open> [willen|kunnen] [<doe>]"
         response: "cover"
+
       - sentences:
           - "open <name> [in|op] <area>"
           - "[<doe> |<zou> ]<name> (<open> [in|op] <area>|[in|op] <area> <open>) [willen|kunnen] [<doe>]"
           - "<zou> <name> [in|op] <area> (willen|kunnen) <open>"
         response: "cover_area"
+
       - sentences:
-          - "open [de] garage [deur]"
-          - "[<doe>|<zou>] [de] garage [deur] [<open>] [willen|kunnen] [<doe>]"
+          - "open [de] garage[ ][deur]"
+          - "[<doe>|<zou>] [de] garage[ ][deur] [<open>] [willen|kunnen] [<doe>]"
         response: "cover"
         slots:
           device_class: garage
           domain: cover
+
       - sentences:
           - "open <afdekking> [in|op] <area>"
           - "[<doe>|<zou>] <afdekking> (<open> [in|op] <area>|[in|op] <area> <open>) [willen|kunnen] [<doe>]"

--- a/sentences/nl/light_HassLightSet.yaml
+++ b/sentences/nl/light_HassLightSet.yaml
@@ -6,16 +6,19 @@ intents:
           - "[<doe>|<zou>] <name>[ ][<helderheid>] [<naar>] <brightness> [willen|kunnen] [<doe>]"
           - "[<doe>|<zou>] <helderheid> [van] <name> [<naar>] <brightness> [willen|kunnen] [<doe>]"
         response: "brightness"
+
       - sentences:
           - "[<doe>|<zou>] [<helderheid>] [in|op] <area>[[ ]<lamp>] [<naar>] <brightness> [willen|kunnen] [<doe>]"
           - "[<doe>|<zou>] <area>[ ][<helderheid>|lamp] [<naar>] <brightness> [willen|kunnen] [<doe>]"
         slots:
           name: "all"
         response: "brightness_area"
+
       - sentences:
           - "[<doe>|<zou>] <name>[ ][kleur] [<naar>] {color} [willen|kunnen] [<doe>]"
           - "[<doe>|<zou>] [[de] kleur van] <name> [<naar>] {color} [willen|kunnen] [<doe>]"
         response: "color"
+
       - sentences:
           - "[<doe>|<zou>] [[de] kleur van] [[alle] <lamp>] [in|van] <area>[[ ]<lamp>] [<naar>] {color} [willen|kunnen] [<doe>]"
         response: "color_area"

--- a/sentences/nl/light_HassTurnOff.yaml
+++ b/sentences/nl/light_HassTurnOff.yaml
@@ -10,12 +10,7 @@ intents:
         slots:
           domain: "light"
           name: "all"
-      - sentences:
-          - "[<doe>|<zou>] <name>[ ]<lamp> [<naar>] uit [willen|kunnen] [<doe>]"
-        requires_context:
-          domain: "light"
-        slots:
-          domain: "light"
+
       - sentences:
           - "[<doe>|<zou>] [(overal|alle)] <lamp> [overal] uit [willen|kunnen] [<doe>]"
         response: "light_all"

--- a/sentences/nl/light_HassTurnOn.yaml
+++ b/sentences/nl/light_HassTurnOn.yaml
@@ -13,10 +13,3 @@ intents:
         slots:
           domain: "light"
           name: "all"
-      - sentences:
-          - "[<doe>|<zou>] <name>[ ]<lamp> [<naar>] aan [willen|kunnen] [<doe>]"
-          - "Schakel <name>[ ]<lamp> [<naar>] in"
-        requires_context:
-          domain: "light"
-        slots:
-          domain: "light"

--- a/tests/nl/_fixtures.yaml
+++ b/tests/nl/_fixtures.yaml
@@ -34,6 +34,13 @@ entities:
       in: "aan"
       out: "on"
 
+  - name: Waterkoker
+    id: switch.waterkoker
+    area: keuken
+    state:
+      in: "uit"
+      out: "off"
+
   - name: Keukenschakelaar
     id: switch.keuken_schakelaar
     area: keuken

--- a/tests/nl/climate_HassClimateGetTemperature.yaml
+++ b/tests/nl/climate_HassClimateGetTemperature.yaml
@@ -6,6 +6,7 @@ tests:
       - Wat is de temperatuur?
     intent:
       name: HassClimateGetTemperature
+
   - sentences:
       - Hoe warm is het in de woonkamer?
       - Hoe koel is het in de woonkamer?
@@ -15,6 +16,7 @@ tests:
       name: HassClimateGetTemperature
       slots:
         area: Woonkamer
+
   - sentences:
       - Hoe koud staat de woonkamerthermostaat?
       - Op hoeveel graden staat de woonkamerthermostaat ingesteld?

--- a/tests/nl/climate_HassClimateSetTemperature.yaml
+++ b/tests/nl/climate_HassClimateSetTemperature.yaml
@@ -8,6 +8,7 @@ tests:
       name: HassClimateSetTemperature
       slots:
         temperature: 19
+
   - sentences:
       - Verander de temperatuur naar 19 graden in de woonkamer
       - Zet de woonkamer temperatuur op 19
@@ -17,6 +18,7 @@ tests:
       slots:
         temperature: 19
         area: Woonkamer
+
   - sentences:
       - Zet woonkamerthermostaat op 19 graden
       - Verander woonkamerthermostaat naar 19 graden

--- a/tests/nl/fan_HassTurnOff.yaml
+++ b/tests/nl/fan_HassTurnOff.yaml
@@ -24,17 +24,7 @@ tests:
         area: Woonkamer
         domain: fan
         name: all
-  - sentences:
-      - Doe speelhoek ventilator uit
-      - Doe de speelhoekventilator uit
-      - Schakel speelhoek ventilator uit
-      - Zet speelhoek ventilator naar uit
-      - Speelhoek ventilator uit
-    intent:
-      name: HassTurnOff
-      slots:
-        domain: fan
-        name: Speelhoek
+
   - sentences:
       - Doe overal de ventilator uit
       - Mogen alle ventilatoren uit?

--- a/tests/nl/fan_HassTurnOn.yaml
+++ b/tests/nl/fan_HassTurnOn.yaml
@@ -25,14 +25,3 @@ tests:
         area: Woonkamer
         domain: fan
         name: all
-  - sentences:
-      - Doe speelhoek ventilator aan
-      - Schakel speelhoek ventilator in
-      - Schakel de speelhoekventilator in
-      - Zet speelhoek ventilator naar aan
-      - Speelhoek ventilator aan
-    intent:
-      name: HassTurnOn
-      slots:
-        domain: fan
-        name: Speelhoek

--- a/tests/nl/homeassistant_HassGetState.yaml
+++ b/tests/nl/homeassistant_HassGetState.yaml
@@ -67,7 +67,7 @@ tests:
       slots:
         domain: "switch"
         state: "on"
-    response: "Nee, Slaapkamerschakelaar niet"
+    response: "Nee, Slaapkamerschakelaar en Waterkoker niet"
 
   - sentences:
       - "Zijn alle lampen uit?"

--- a/tests/nl/homeassistant_HassTurnOff.yaml
+++ b/tests/nl/homeassistant_HassTurnOff.yaml
@@ -9,6 +9,42 @@ tests:
       name: HassTurnOff
       slots:
         name: Slaapkamerlamp
+
+  - sentences:
+      - Doe werkbank lamp uit
+      - Schakel werkbank verlichting uit
+      - Schakel de werkbankverlichting uit
+      - Zet het werkbank licht naar uit
+      - Werkbank licht uit
+      - Zal je werkbank licht uit willen zetten?
+      - Zou de werkbank lamp uit mogen?
+    intent:
+      name: HassTurnOff
+      slots:
+        name: Werkbank
+
+  - sentences:
+      - Zet waterkokerswitch uit
+      - Zet waterkokerschakelaar uit
+      - Zou de waterkoker switch uit mogen?
+      - Zou je de waterkokerschakelaar willen uitzetten?
+      - Zou u de waterkoker switch uit willen schakelen?
+    intent:
+      name: HassTurnOff
+      slots:
+        name: Waterkoker
+
+  - sentences:
+      - Doe speelhoek ventilator uit
+      - Doe de speelhoekventilator uit
+      - Schakel speelhoek ventilator uit
+      - Zet speelhoek ventilator naar uit
+      - Speelhoek ventilator uit
+    intent:
+      name: HassTurnOff
+      slots:
+        name: Speelhoek
+
   - sentences:
       - Sluit de garage
       - Doe de garage dicht

--- a/tests/nl/homeassistant_HassTurnOn.yaml
+++ b/tests/nl/homeassistant_HassTurnOn.yaml
@@ -9,6 +9,42 @@ tests:
       name: HassTurnOn
       slots:
         name: Slaapkamerlamp
+
+  - sentences:
+      - Doe werkbank lamp aan
+      - Schakel werkbank verlichting in
+      - Zet werkbank licht naar aan
+      - Zet de werkbanklamp naar aan
+      - Werkbankverlichting aan
+      - Zal je werkbank licht aan willen zetten?
+      - Zou de werkbank lamp aan mogen?
+    intent:
+      name: HassTurnOn
+      slots:
+        name: Werkbank
+
+  - sentences:
+      - Zet waterkokerswitch aan
+      - Zet waterkokerschakelaar aan
+      - Zou de waterkoker switch aan mogen?
+      - Zou je de waterkokerschakelaar willen aanzetten?
+      - Zou u de waterkoker switch in willen schakelen?
+    intent:
+      name: HassTurnOn
+      slots:
+        name: Waterkoker
+
+  - sentences:
+      - Doe speelhoek ventilator aan
+      - Schakel speelhoekfan in
+      - Schakel de speelhoekventilator in
+      - Zet speelhoek ventilator naar aan
+      - Speelhoek fan aan
+    intent:
+      name: HassTurnOn
+      slots:
+        name: Speelhoek
+
   - sentences:
       - Open gordijn links
       - Doe het gordijn links open
@@ -18,6 +54,7 @@ tests:
       name: HassTurnOn
       slots:
         name: Gordijn Links
+
   - sentences:
       - Doe het rolluik achterdeur omhoog
       - Doe rolluik achterdeur naar boven
@@ -27,6 +64,7 @@ tests:
       name: HassTurnOn
       slots:
         name: Rolluik Achterdeur
+
   - sentences:
       - Open gordijn links in de woonkamer
       - Doe gordijn links in de woonkamer open
@@ -40,6 +78,7 @@ tests:
       slots:
         name: Gordijn Links
         area: Woonkamer
+
   - sentences:
       - Open rolluik achterdeur in de keuken
       - Doe rolluik achterdeur in de keuken omhoog
@@ -51,6 +90,7 @@ tests:
       slots:
         name: Rolluik Achterdeur
         area: Keuken
+
   - sentences:
       - Open de garage
       - Doe de garage open
@@ -60,6 +100,7 @@ tests:
       slots:
         device_class: garage
         domain: cover
+
   - sentences:
       - Open het gordijn in de woonkamer
       - Vitrage woonkamer open

--- a/tests/nl/light_HassLightSet.yaml
+++ b/tests/nl/light_HassLightSet.yaml
@@ -13,6 +13,7 @@ tests:
       slots:
         brightness: 50
         name: Slaapkamerlamp
+
   - sentences:
       - verander de felheid in de slaapkamer naar 75 procent
       - maak de slaapkamer helderheid 75%
@@ -28,6 +29,7 @@ tests:
         brightness: 75
         area: Slaapkamer
         name: all
+
   - sentences:
       - Maak slaapkamerlamp blauw
       - Doe de slaapkamerlamp naar blauw
@@ -41,6 +43,7 @@ tests:
       slots:
         color: blue
         name: Slaapkamerlamp
+
   - sentences:
       - Maak slaapkamer blauw
       - Doe alle lampen in de slaapkamer naar blauw

--- a/tests/nl/light_HassTurnOff.yaml
+++ b/tests/nl/light_HassTurnOff.yaml
@@ -27,19 +27,7 @@ tests:
         domain: light
         area: Keuken
         name: all
-  - sentences:
-      - Doe werkbank lamp uit
-      - Schakel werkbank verlichting uit
-      - Schakel de werkbankverlichting uit
-      - Zet het werkbank licht naar uit
-      - Werkbank licht uit
-      - Zal je werkbank licht uit willen zetten?
-      - Zou de werkbank lamp uit mogen?
-    intent:
-      name: HassTurnOff
-      slots:
-        domain: light
-        name: Werkbank
+
   - sentences:
       - Doe overal de verlichting uit
       - Mogen alle lampen uit?

--- a/tests/nl/light_HassTurnOn.yaml
+++ b/tests/nl/light_HassTurnOn.yaml
@@ -30,16 +30,4 @@ tests:
         domain: light
         area: Keuken
         name: all
-  - sentences:
-      - Doe werkbank lamp aan
-      - Schakel werkbank verlichting in
-      - Zet werkbank licht naar aan
-      - Zet de werkbanklamp naar aan
-      - Werkbankverlichting aan
-      - Zal je werkbank licht aan willen zetten?
-      - Zou de werkbank lamp aan mogen?
-    intent:
-      name: HassTurnOn
-      slots:
-        domain: light
-        name: Werkbank
+


### PR DESCRIPTION
* Remove the domain specific intents with the optional type added, and created one generic one supporting all (by use of the expansion rule `<type>`)
* Added some more basic variations like `<name> aanzetten` en `<name> inschakelen` 
* Added blank lines between all sentences and tests for readability