### PR TITLE
[NB] Correct translation of autogenerated cover tests

### DIFF
--- a/tests/nb/cover_HassTurnOff.yaml
+++ b/tests/nb/cover_HassTurnOff.yaml
@@ -2,6 +2,7 @@ language: nb
 tests:
   - sentences:
       - lukk igjen garasjedøren
+      - steng garasjen
     intent:
       name: HassTurnOff
       slots:
@@ -9,7 +10,8 @@ tests:
         device_class: garage
     response: garage ble lukket
   - sentences:
-      - lukk igjen takvinduet i kjøkkenns
+      - lukk igjen takvinduet på kjøkkenet
+      - steng takvinduet i kjøkkenet
     intent:
       name: HassTurnOff
       slots:
@@ -22,7 +24,8 @@ tests:
           - shutter
     response: Lukket kjøkken
   - sentences:
-      - lukk igjen kjøkkennss takvinduet
+      - lukk igjen kjøkkenets takvindu
+      - steng kjøkkentakvinduet
     intent:
       name: HassTurnOff
       slots:

--- a/tests/nb/cover_HassTurnOn.yaml
+++ b/tests/nb/cover_HassTurnOn.yaml
@@ -2,6 +2,7 @@ language: nb
 tests:
   - sentences:
       - åpne opp garasjedøren
+      - rull opp garasjen
     intent:
       name: HassTurnOn
       slots:
@@ -9,7 +10,8 @@ tests:
         device_class: garage
     response: garage ble åpnet
   - sentences:
-      - åpne opp takvinduet i kjøkkenns
+      - åpne opp takvinduet på kjøkkenet
+      - åpne takvinduet i kjøkkenet
     intent:
       name: HassTurnOn
       slots:
@@ -22,7 +24,8 @@ tests:
           - shutter
     response: Åpnet kjøkken
   - sentences:
-      - åpne opp kjøkkennss takvinduet
+      - åpne opp kjøkkenets takvindu
+      - åpne kjøkkentakvinduet
     intent:
       name: HassTurnOn
       slots:


### PR DESCRIPTION
Note that device class "garage" has not yet been translated by the system and will show as "garage ble lukket". I assume the live environment will use the translated version.