### PR TITLE
[RO] Added light-specific responses

### DIFF
--- a/sentences/ro/light_HassTurnOff.yaml
+++ b/sentences/ro/light_HassTurnOff.yaml
@@ -4,6 +4,8 @@ intents:
     data:
       - sentences:
           - "<opreste> <name>"
+        slots:
+          domain: light
         requires_context:
           domain: light
         response: light

--- a/sentences/ro/light_HassTurnOn.yaml
+++ b/sentences/ro/light_HassTurnOn.yaml
@@ -4,6 +4,8 @@ intents:
     data:
       - sentences:
           - "<porneste> <name>"
+        slots:
+          domain: light
         requires_context:
           domain: light
         response: light

--- a/tests/ro/light_HassTurnOff.yaml
+++ b/tests/ro/light_HassTurnOff.yaml
@@ -1,6 +1,14 @@
 language: ro
 tests:
   - sentences:
+      - "stinge plafoniera neagra"
+    intent:
+      name: HassTurnOff
+      slots:
+        name: plafoniera neagra
+        domain: light
+    response: "Am stins plafoniera neagra"
+  - sentences:
       - "stinge lumina din garaj"
       - "oprește lumina din garaj"
       - "stop lumina din garaj"

--- a/tests/ro/light_HassTurnOn.yaml
+++ b/tests/ro/light_HassTurnOn.yaml
@@ -1,6 +1,14 @@
 language: ro
 tests:
   - sentences:
+      - "aprinde plafoniera neagra"
+    intent:
+      name: HassTurnOn
+      slots:
+        name: plafoniera neagra
+        domain: light
+    response: "Am aprins plafoniera neagra"
+  - sentences:
       - "start lumina din garaj"
       - "pornește lumina din garaj"
       - "deschide lumina din garaj"


### PR DESCRIPTION
Using "aprinde"/"stinge" for lights instead of "porneste"/"opreste" for other things.