### PR TITLE
Check for TODO in responses instead of directly comparing to English

### DIFF
--- a/responses/ar/HassClimateGetTemperature.yaml
+++ b/responses/ar/HassClimateGetTemperature.yaml
@@ -2,4 +2,4 @@ language: ar
 responses:
   intents:
     HassClimateGetTemperature:
-      default: "{{ state.state }} degrees"
+      default: "{{ state.state_with_unit }}"

--- a/responses/ar/HassClimateSetTemperature.yaml
+++ b/responses/ar/HassClimateSetTemperature.yaml
@@ -2,4 +2,4 @@ language: ar
 responses:
   intents:
     HassClimateSetTemperature:
-      default: Temperature set to {{ slots.temperature }} degrees
+      default: "TODO: Temperature set"

--- a/responses/ar/HassLightSet.yaml
+++ b/responses/ar/HassLightSet.yaml
@@ -2,7 +2,5 @@ language: ar
 responses:
   intents:
     HassLightSet:
-      brightness: "{{ slots.name }} brightness set to {{ slots.brightness }}"
-      brightness_area: Brightness in {{ slots.area }} set to {{ slots.brightness }}
-      color: "{{ slots.name }} color set to {{ slots.color }}"
-      color_area: Color in {{ slots.area }} set to {{ slots.color }}
+      brightness: "TODO: Brightness set"
+      color: "TODO: Color set"

--- a/responses/ar/HassTurnOff.yaml
+++ b/responses/ar/HassTurnOff.yaml
@@ -2,8 +2,8 @@ language: ar
 responses:
   intents:
     HassTurnOff:
-      default: Turned off {{ slots.name }}
-      lights_area: Turned off lights in {{ slots.area }}
-      fans_area: Turned off fans in {{ slots.area }}
-      cover: Closed {{ slots.name }}
-      cover_area: Closed {{ slots.area }}
+      default: "TODO: Turned off {{ state.domain }}"
+      lights_area: "TODO: Turned off lights"
+      fans_area: "TODO: Turned off fans"
+      cover: "TODO: Closed"
+      cover_device_class: "TODO: Closed {{ slots.device_class }}"

--- a/responses/ar/HassTurnOn.yaml
+++ b/responses/ar/HassTurnOn.yaml
@@ -2,8 +2,8 @@ language: ar
 responses:
   intents:
     HassTurnOn:
-      default: Turned on {{ slots.name }}
-      lights_area: Turned on lights in {{ slots.area }}
-      fans_area: Turned on fans in {{ slots.area }}
-      cover: Opened {{ slots.name }}
-      cover_area: Opened {{ slots.area }}
+      default: "TODO: Turned on {{ state.domain }}"
+      lights_area: "TODO: Turned on lights"
+      fans_area: "TODO: Turned on fans"
+      cover: "TODO: Opened"
+      cover_device_class: "TODO: Opened {{ slots.device_class }}"

--- a/script/intentfest/add_language.py
+++ b/script/intentfest/add_language.py
@@ -98,12 +98,12 @@ def run() -> int:
                 "language": language,
                 "responses": {
                     "errors": {
-                        "no_intent": "Sorry, I couldn't understand that",
-                        "no_area": "No area named {{ area }}",
-                        "no_domain": "{{ area }} does not contain a {{ domain }}",
-                        "no_device_class": "{{ area }} does not contain a {{ device_class }}",
-                        "no_entity": "No device or entity named {{ entity }}",
-                        "handle_error": "An unexpected error occurred while handling the intent",
+                        "no_intent": "TODO: Sorry, I couldn't understand that",
+                        "no_area": "TODO: No area named {{ area }}",
+                        "no_domain": "TODO: {{ area }} does not contain a {{ domain }}",
+                        "no_device_class": "TODO: {{ area }} does not contain a {{ device_class }}",
+                        "no_entity": "TODO: No device or entity named {{ entity }}",
+                        "handle_error": "TODO: An unexpected error occurred while handling the intent",
                     },
                 },
                 "lists": {},
@@ -182,6 +182,11 @@ def run() -> int:
         intent = english_filename.stem
         with open(english_filename, "r", encoding="utf-8") as english_file:
             responses = yaml.safe_load(english_file)["responses"]
+
+        # Mark responses as needing translation
+        for intent_responses in responses["intents"].values():
+            for response_key, response_text in intent_responses.items():
+                intent_responses[response_key] = f"TODO: {response_text}"
 
         (response_dir / english_filename.name).write_text(
             yaml_dump(

--- a/script/intentfest/website_summary.py
+++ b/script/intentfest/website_summary.py
@@ -17,15 +17,6 @@ def run() -> int:
     # Sort intent info by (domain, intent)
     intent_info = yaml.safe_load(INTENTS_FILE.read_text())
 
-    # Collect all English responses.
-    all_english_responses = {
-        intent_sentence
-        for intent_sentences in load_merged_responses("en")["responses"][
-            "intents"
-        ].values()
-        for intent_sentence in intent_sentences.values()
-    }
-
     for language in LANGUAGES:
         merged_sentences = load_merged_sentences(language)
         merged_responses = load_merged_responses(language)
@@ -55,8 +46,7 @@ def run() -> int:
                 intent_responses_translated[intent] = True
             else:
                 intent_responses_translated[intent] = all(
-                    response not in all_english_responses
-                    for response in intent_responses.values()
+                    "TODO" not in response for response in intent_responses.values()
                 )
 
         errors_translated = not any(

--- a/sentences/ar/_common.yaml
+++ b/sentences/ar/_common.yaml
@@ -1,12 +1,12 @@
 language: ar
 responses:
   errors:
-    no_intent: عفوا, لم افهم هذا
-    no_area: TODO No area named {{ area }}
-    no_domain: TODO {{ area }} does not contain a {{ domain }}
-    no_device_class: TODO {{ area }} does not contain a {{ device_class }}
-    no_entity: TODO No device or entity named {{ entity }}
-    handle_error: TODO An unexpected error occurred while handling the intent
+    no_intent: "عفوا, لم افهم هذا"
+    no_area: "TODO No area named {{ area }}"
+    no_domain: "TODO {{ area }} does not contain a {{ domain }}"
+    no_device_class: "TODO {{ area }} does not contain a {{ device_class }}"
+    no_entity: "TODO No device or entity named {{ entity }}"
+    handle_error: "TODO An unexpected error occurred while handling the intent"
 lists: {}
 expansion_rules: {}
 skip_words: []

--- a/website/script/build
+++ b/website/script/build
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Stop on errors
 set -e
 

--- a/website/script/develop
+++ b/website/script/develop
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Stop on errors
 set -e
 

--- a/website/src-11ty/_data/intentSummary.json
+++ b/website/src-11ty/_data/intentSummary.json
@@ -1,26 +1,2098 @@
 {
   "intents": {
-    "HassTestIntent": {
+    "HassTurnOn": {
       "file_name": "homeassistant_HassTurnOn.yaml"
     },
-    "HassTestIntentWithResponse": {
+    "HassTurnOff": {
       "file_name": "homeassistant_HassTurnOff.yaml"
+    },
+    "HassGetState": {
+      "file_name": "homeassistant_HassGetState.yaml"
+    },
+    "HassLightSet": {
+      "file_name": "light_HassLightSet.yaml"
+    },
+    "HassClimateSetTemperature": {
+      "file_name": "climate_HassClimateSetTemperature.yaml"
+    },
+    "HassClimateGetTemperature": {
+      "file_name": "climate_HassClimateGetTemperature.yaml"
     }
   },
   "languages": [
     {
-      "language": "nl",
-      "native_name": "Test language",
-      "leaders": ["balloob"],
+      "language": "ar",
+      "native_name": "\u0627\u0644\u0639\u0631\u0628\u064a\u0629",
+      "leaders": [
+        "Ahmed-farag36"
+      ],
       "intents": {
-        "HassTestIntent": 0,
-        "HassTestIntentWithResponse": 2
+        "HassTurnOn": 0,
+        "HassTurnOff": 0,
+        "HassGetState": 0,
+        "HassLightSet": 0,
+        "HassClimateSetTemperature": 0,
+        "HassClimateGetTemperature": 0
+      },
+      "used_responses": {
+        "HassTurnOn": 1,
+        "HassTurnOff": 1,
+        "HassGetState": 0,
+        "HassLightSet": 1,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
       },
       "responses": {
-        "HassTestIntentWithResponse": 5
+        "HassTurnOn": 5,
+        "HassTurnOff": 5,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": false,
+        "HassClimateGetTemperature": true
       },
       "errors_translated": false,
       "usable": false
+    },
+    {
+      "language": "bg",
+      "native_name": "\u0411\u044a\u043b\u0433\u0430\u0440\u0441\u043a\u0438",
+      "leaders": [
+        "hristo-atanasov"
+      ],
+      "intents": {
+        "HassTurnOn": 13,
+        "HassTurnOff": 13,
+        "HassGetState": 7,
+        "HassLightSet": 29,
+        "HassClimateSetTemperature": 5,
+        "HassClimateGetTemperature": 5
+      },
+      "used_responses": {
+        "HassTurnOn": 7,
+        "HassTurnOff": 7,
+        "HassGetState": 5,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 7,
+        "HassTurnOff": 7,
+        "HassGetState": 6,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": true
+    },
+    {
+      "language": "bn",
+      "native_name": "\u09ac\u09be\u0982\u09b2\u09be",
+      "leaders": null,
+      "intents": {
+        "HassTurnOn": 2,
+        "HassTurnOff": 2,
+        "HassGetState": 0,
+        "HassLightSet": 0,
+        "HassClimateSetTemperature": 0,
+        "HassClimateGetTemperature": 0
+      },
+      "used_responses": {
+        "HassTurnOn": 1,
+        "HassTurnOff": 1,
+        "HassGetState": 0,
+        "HassLightSet": 1,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 5,
+        "HassTurnOff": 5,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "ca",
+      "native_name": "Catal\u00e0",
+      "leaders": [
+        "duhow"
+      ],
+      "intents": {
+        "HassTurnOn": 10,
+        "HassTurnOff": 11,
+        "HassGetState": 0,
+        "HassLightSet": 2,
+        "HassClimateSetTemperature": 2,
+        "HassClimateGetTemperature": 4
+      },
+      "used_responses": {
+        "HassTurnOn": 3,
+        "HassTurnOff": 3,
+        "HassGetState": 0,
+        "HassLightSet": 1,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "cs",
+      "native_name": "\u010ce\u0161tina",
+      "leaders": [
+        "halecivo",
+        "schizza"
+      ],
+      "intents": {
+        "HassTurnOn": 14,
+        "HassTurnOff": 14,
+        "HassGetState": 8,
+        "HassLightSet": 24,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 5
+      },
+      "used_responses": {
+        "HassTurnOn": 7,
+        "HassTurnOff": 7,
+        "HassGetState": 6,
+        "HassLightSet": 8,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 8,
+        "HassTurnOff": 8,
+        "HassGetState": 8,
+        "HassLightSet": 8,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": true
+    },
+    {
+      "language": "da",
+      "native_name": "Dansk",
+      "leaders": [
+        "fadamsen",
+        "MTrab"
+      ],
+      "intents": {
+        "HassTurnOn": 14,
+        "HassTurnOff": 14,
+        "HassGetState": 0,
+        "HassLightSet": 9,
+        "HassClimateSetTemperature": 3,
+        "HassClimateGetTemperature": 5
+      },
+      "used_responses": {
+        "HassTurnOn": 3,
+        "HassTurnOff": 3,
+        "HassGetState": 0,
+        "HassLightSet": 2,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "de",
+      "native_name": "Deutsch",
+      "leaders": [
+        "Scorpoon",
+        "easterapps"
+      ],
+      "intents": {
+        "HassTurnOn": 38,
+        "HassTurnOff": 38,
+        "HassGetState": 0,
+        "HassLightSet": 14,
+        "HassClimateSetTemperature": 2,
+        "HassClimateGetTemperature": 5
+      },
+      "used_responses": {
+        "HassTurnOn": 2,
+        "HassTurnOff": 2,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 5,
+        "HassTurnOff": 5,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "de-CH",
+      "native_name": "Schwyzerd\u00fctsch",
+      "leaders": [
+        "c0ffeeca7"
+      ],
+      "intents": {
+        "HassTurnOn": 10,
+        "HassTurnOff": 11,
+        "HassGetState": 11,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 0,
+        "HassClimateGetTemperature": 4
+      },
+      "used_responses": {
+        "HassTurnOn": 5,
+        "HassTurnOff": 5,
+        "HassGetState": 6,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 2
+      },
+      "responses": {
+        "HassTurnOn": 7,
+        "HassTurnOff": 7,
+        "HassGetState": 6,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 2
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "el",
+      "native_name": "\u0395\u03bb\u03bb\u03b7\u03bd\u03b9\u03ba\u03ac",
+      "leaders": [
+        "dsimop"
+      ],
+      "intents": {
+        "HassTurnOn": 11,
+        "HassTurnOff": 12,
+        "HassGetState": 0,
+        "HassLightSet": 6,
+        "HassClimateSetTemperature": 4,
+        "HassClimateGetTemperature": 12
+      },
+      "used_responses": {
+        "HassTurnOn": 3,
+        "HassTurnOff": 3,
+        "HassGetState": 0,
+        "HassLightSet": 3,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "en",
+      "native_name": "English",
+      "leaders": null,
+      "intents": {
+        "HassTurnOn": 13,
+        "HassTurnOff": 13,
+        "HassGetState": 11,
+        "HassLightSet": 21,
+        "HassClimateSetTemperature": 2,
+        "HassClimateGetTemperature": 4
+      },
+      "used_responses": {
+        "HassTurnOn": 5,
+        "HassTurnOff": 5,
+        "HassGetState": 6,
+        "HassLightSet": 2,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 5,
+        "HassTurnOff": 5,
+        "HassGetState": 6,
+        "HassLightSet": 2,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": true
+    },
+    {
+      "language": "es",
+      "native_name": "Espa\u00f1ol",
+      "leaders": [
+        "davefx"
+      ],
+      "intents": {
+        "HassTurnOn": 10,
+        "HassTurnOff": 9,
+        "HassGetState": 0,
+        "HassLightSet": 10,
+        "HassClimateSetTemperature": 4,
+        "HassClimateGetTemperature": 4
+      },
+      "used_responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 5,
+        "HassGetState": 0,
+        "HassLightSet": 3,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "fa",
+      "native_name": "\u0641\u0627\u0631\u0633\u06cc",
+      "leaders": null,
+      "intents": {
+        "HassTurnOn": 1,
+        "HassTurnOff": 1,
+        "HassGetState": 0,
+        "HassLightSet": 0,
+        "HassClimateSetTemperature": 0,
+        "HassClimateGetTemperature": 0
+      },
+      "used_responses": {
+        "HassTurnOn": 1,
+        "HassTurnOff": 1,
+        "HassGetState": 0,
+        "HassLightSet": 1,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 5,
+        "HassTurnOff": 5,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "fi",
+      "native_name": "Suomi",
+      "leaders": [
+        "huusissa"
+      ],
+      "intents": {
+        "HassTurnOn": 2,
+        "HassTurnOff": 0,
+        "HassGetState": 0,
+        "HassLightSet": 0,
+        "HassClimateSetTemperature": 0,
+        "HassClimateGetTemperature": 1
+      },
+      "used_responses": {
+        "HassTurnOn": 1,
+        "HassTurnOff": 1,
+        "HassGetState": 0,
+        "HassLightSet": 1,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 5,
+        "HassTurnOff": 5,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "fr",
+      "native_name": "Fran\u00e7ais",
+      "leaders": [
+        "benjaminlecouteux",
+        "flexy2dd"
+      ],
+      "intents": {
+        "HassTurnOn": 11,
+        "HassTurnOff": 11,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 3,
+        "HassClimateGetTemperature": 1
+      },
+      "used_responses": {
+        "HassTurnOn": 4,
+        "HassTurnOff": 4,
+        "HassGetState": 0,
+        "HassLightSet": 2,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "fr-CA",
+      "native_name": "Fran\u00e7ais (Canada)",
+      "leaders": [
+        "charlesdagenais"
+      ],
+      "intents": {
+        "HassTurnOn": 9,
+        "HassTurnOff": 9,
+        "HassGetState": 0,
+        "HassLightSet": 8,
+        "HassClimateSetTemperature": 3,
+        "HassClimateGetTemperature": 3
+      },
+      "used_responses": {
+        "HassTurnOn": 4,
+        "HassTurnOff": 4,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "gl",
+      "native_name": "Galician",
+      "leaders": [
+        "cibernox"
+      ],
+      "intents": {
+        "HassTurnOn": 7,
+        "HassTurnOff": 7,
+        "HassGetState": 0,
+        "HassLightSet": 9,
+        "HassClimateSetTemperature": 3,
+        "HassClimateGetTemperature": 6
+      },
+      "used_responses": {
+        "HassTurnOn": 3,
+        "HassTurnOff": 3,
+        "HassGetState": 0,
+        "HassLightSet": 3,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "he",
+      "native_name": "\u05e2\u05d1\u05e8\u05d9\u05ea",
+      "leaders": [
+        "leranp",
+        "haim-b"
+      ],
+      "intents": {
+        "HassTurnOn": 13,
+        "HassTurnOff": 13,
+        "HassGetState": 0,
+        "HassLightSet": 6,
+        "HassClimateSetTemperature": 12,
+        "HassClimateGetTemperature": 2
+      },
+      "used_responses": {
+        "HassTurnOn": 3,
+        "HassTurnOff": 3,
+        "HassGetState": 0,
+        "HassLightSet": 2,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 6,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "hi",
+      "native_name": "\u0939\u093f\u0928\u094d\u0926\u0940",
+      "leaders": null,
+      "intents": {
+        "HassTurnOn": 0,
+        "HassTurnOff": 0,
+        "HassGetState": 0,
+        "HassLightSet": 0,
+        "HassClimateSetTemperature": 0,
+        "HassClimateGetTemperature": 0
+      },
+      "used_responses": {
+        "HassTurnOn": 1,
+        "HassTurnOff": 1,
+        "HassGetState": 0,
+        "HassLightSet": 1,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 5,
+        "HassTurnOff": 5,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": false,
+      "usable": false
+    },
+    {
+      "language": "hr",
+      "native_name": "Hrvatski",
+      "leaders": [
+        "spuljko"
+      ],
+      "intents": {
+        "HassTurnOn": 18,
+        "HassTurnOff": 16,
+        "HassGetState": 0,
+        "HassLightSet": 12,
+        "HassClimateSetTemperature": 3,
+        "HassClimateGetTemperature": 3
+      },
+      "used_responses": {
+        "HassTurnOn": 9,
+        "HassTurnOff": 8,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 10,
+        "HassTurnOff": 9,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "hu",
+      "native_name": "Magyar",
+      "leaders": [
+        "nagyrobi"
+      ],
+      "intents": {
+        "HassTurnOn": 17,
+        "HassTurnOff": 17,
+        "HassGetState": 0,
+        "HassLightSet": 9,
+        "HassClimateSetTemperature": 5,
+        "HassClimateGetTemperature": 4
+      },
+      "used_responses": {
+        "HassTurnOn": 4,
+        "HassTurnOff": 4,
+        "HassGetState": 0,
+        "HassLightSet": 3,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "id",
+      "native_name": "Bahasa Indonesia",
+      "leaders": null,
+      "intents": {
+        "HassTurnOn": 3,
+        "HassTurnOff": 3,
+        "HassGetState": 0,
+        "HassLightSet": 6,
+        "HassClimateSetTemperature": 0,
+        "HassClimateGetTemperature": 0
+      },
+      "used_responses": {
+        "HassTurnOn": 1,
+        "HassTurnOff": 1,
+        "HassGetState": 0,
+        "HassLightSet": 3,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 5,
+        "HassTurnOff": 5,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "is",
+      "native_name": "\u00edslenska",
+      "leaders": null,
+      "intents": {
+        "HassTurnOn": 0,
+        "HassTurnOff": 0,
+        "HassGetState": 0,
+        "HassLightSet": 0,
+        "HassClimateSetTemperature": 0,
+        "HassClimateGetTemperature": 0
+      },
+      "used_responses": {
+        "HassTurnOn": 1,
+        "HassTurnOff": 1,
+        "HassGetState": 0,
+        "HassLightSet": 1,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 5,
+        "HassTurnOff": 5,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "it",
+      "native_name": "Italiano",
+      "leaders": [
+        "auanasgheps",
+        "xraver"
+      ],
+      "intents": {
+        "HassTurnOn": 12,
+        "HassTurnOff": 12,
+        "HassGetState": 0,
+        "HassLightSet": 11,
+        "HassClimateSetTemperature": 5,
+        "HassClimateGetTemperature": 3
+      },
+      "used_responses": {
+        "HassTurnOn": 4,
+        "HassTurnOff": 4,
+        "HassGetState": 0,
+        "HassLightSet": 3,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "ka",
+      "native_name": "\u10e5\u10d0\u10e0\u10d7\u10e3\u10da\u10d8",
+      "leaders": [
+        "hertzg"
+      ],
+      "intents": {
+        "HassTurnOn": 3,
+        "HassTurnOff": 3,
+        "HassGetState": 0,
+        "HassLightSet": 0,
+        "HassClimateSetTemperature": 0,
+        "HassClimateGetTemperature": 0
+      },
+      "used_responses": {
+        "HassTurnOn": 1,
+        "HassTurnOff": 1,
+        "HassGetState": 0,
+        "HassLightSet": 1,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 5,
+        "HassTurnOff": 5,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "kn",
+      "native_name": "\u0c95\u0ca8\u0ccd\u0ca8\u0ca1",
+      "leaders": null,
+      "intents": {
+        "HassTurnOn": 0,
+        "HassTurnOff": 0,
+        "HassGetState": 0,
+        "HassLightSet": 0,
+        "HassClimateSetTemperature": 0,
+        "HassClimateGetTemperature": 0
+      },
+      "used_responses": {
+        "HassTurnOn": 1,
+        "HassTurnOff": 1,
+        "HassGetState": 0,
+        "HassLightSet": 1,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 5,
+        "HassTurnOff": 5,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": false,
+      "usable": false
+    },
+    {
+      "language": "lb",
+      "native_name": "L\u00ebtzebuergesch",
+      "leaders": [
+        "mojikosu"
+      ],
+      "intents": {
+        "HassTurnOn": 10,
+        "HassTurnOff": 10,
+        "HassGetState": 0,
+        "HassLightSet": 15,
+        "HassClimateSetTemperature": 3,
+        "HassClimateGetTemperature": 5
+      },
+      "used_responses": {
+        "HassTurnOn": 4,
+        "HassTurnOff": 4,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "lt",
+      "native_name": "Lietuvi\u0173",
+      "leaders": [
+        "ErnestStaug"
+      ],
+      "intents": {
+        "HassTurnOn": 12,
+        "HassTurnOff": 12,
+        "HassGetState": 0,
+        "HassLightSet": 8,
+        "HassClimateSetTemperature": 4,
+        "HassClimateGetTemperature": 1
+      },
+      "used_responses": {
+        "HassTurnOn": 5,
+        "HassTurnOff": 5,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "lv",
+      "native_name": "Latvie\u0161u",
+      "leaders": [
+        "makstech"
+      ],
+      "intents": {
+        "HassTurnOn": 19,
+        "HassTurnOff": 19,
+        "HassGetState": 0,
+        "HassLightSet": 15,
+        "HassClimateSetTemperature": 2,
+        "HassClimateGetTemperature": 6
+      },
+      "used_responses": {
+        "HassTurnOn": 4,
+        "HassTurnOff": 4,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "ml",
+      "native_name": "\u0d2e\u0d32\u0d2f\u0d3e\u0d33\u0d02",
+      "leaders": [
+        "arunshekher"
+      ],
+      "intents": {
+        "HassTurnOn": 13,
+        "HassTurnOff": 16,
+        "HassGetState": 0,
+        "HassLightSet": 22,
+        "HassClimateSetTemperature": 4,
+        "HassClimateGetTemperature": 3
+      },
+      "used_responses": {
+        "HassTurnOn": 4,
+        "HassTurnOff": 3,
+        "HassGetState": 0,
+        "HassLightSet": 3,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "mn",
+      "native_name": "\u043c\u043e\u043d\u0433\u043e\u043b \u0445\u044d\u043b",
+      "leaders": [
+        "chuk-a"
+      ],
+      "intents": {
+        "HassTurnOn": 0,
+        "HassTurnOff": 0,
+        "HassGetState": 0,
+        "HassLightSet": 0,
+        "HassClimateSetTemperature": 0,
+        "HassClimateGetTemperature": 0
+      },
+      "used_responses": {
+        "HassTurnOn": 1,
+        "HassTurnOff": 1,
+        "HassGetState": 0,
+        "HassLightSet": 1,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 5,
+        "HassTurnOff": 5,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "ms",
+      "native_name": "Bahasa Melayu",
+      "leaders": [
+        "zubir2k"
+      ],
+      "intents": {
+        "HassTurnOn": 7,
+        "HassTurnOff": 7,
+        "HassGetState": 0,
+        "HassLightSet": 6,
+        "HassClimateSetTemperature": 2,
+        "HassClimateGetTemperature": 2
+      },
+      "used_responses": {
+        "HassTurnOn": 2,
+        "HassTurnOff": 2,
+        "HassGetState": 0,
+        "HassLightSet": 3,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 5,
+        "HassTurnOff": 5,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "nb",
+      "native_name": "Norsk Bokm\u00e5l",
+      "leaders": [
+        "LaStrada"
+      ],
+      "intents": {
+        "HassTurnOn": 13,
+        "HassTurnOff": 12,
+        "HassGetState": 13,
+        "HassLightSet": 13,
+        "HassClimateSetTemperature": 3,
+        "HassClimateGetTemperature": 5
+      },
+      "used_responses": {
+        "HassTurnOn": 4,
+        "HassTurnOff": 4,
+        "HassGetState": 6,
+        "HassLightSet": 3,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 6,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": true
+    },
+    {
+      "language": "nl",
+      "native_name": "Nederlands",
+      "leaders": [
+        "TheFes"
+      ],
+      "intents": {
+        "HassTurnOn": 30,
+        "HassTurnOff": 25,
+        "HassGetState": 11,
+        "HassLightSet": 7,
+        "HassClimateSetTemperature": 6,
+        "HassClimateGetTemperature": 8
+      },
+      "used_responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 8,
+        "HassGetState": 6,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 8,
+        "HassTurnOff": 8,
+        "HassGetState": 6,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": true
+    },
+    {
+      "language": "pl",
+      "native_name": "Polski",
+      "leaders": [
+        "Uriziel01"
+      ],
+      "intents": {
+        "HassTurnOn": 15,
+        "HassTurnOff": 15,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 2,
+        "HassClimateGetTemperature": 1
+      },
+      "used_responses": {
+        "HassTurnOn": 7,
+        "HassTurnOff": 7,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 7,
+        "HassTurnOff": 7,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "pt",
+      "native_name": "Portugu\u00eas",
+      "leaders": [
+        "joaorgoncalves"
+      ],
+      "intents": {
+        "HassTurnOn": 8,
+        "HassTurnOff": 8,
+        "HassGetState": 0,
+        "HassLightSet": 18,
+        "HassClimateSetTemperature": 3,
+        "HassClimateGetTemperature": 3
+      },
+      "used_responses": {
+        "HassTurnOn": 3,
+        "HassTurnOff": 3,
+        "HassGetState": 0,
+        "HassLightSet": 2,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "pt-br",
+      "native_name": "portugues-brasileiro",
+      "leaders": null,
+      "intents": {
+        "HassTurnOn": 0,
+        "HassTurnOff": 0,
+        "HassGetState": 0,
+        "HassLightSet": 0,
+        "HassClimateSetTemperature": 0,
+        "HassClimateGetTemperature": 0
+      },
+      "used_responses": {
+        "HassTurnOn": 1,
+        "HassTurnOff": 1,
+        "HassGetState": 0,
+        "HassLightSet": 1,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 5,
+        "HassTurnOff": 5,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "ro",
+      "native_name": "Rom\u00e2n\u0103",
+      "leaders": [
+        "tetele",
+        "gabimarchidan"
+      ],
+      "intents": {
+        "HassTurnOn": 10,
+        "HassTurnOff": 10,
+        "HassGetState": 17,
+        "HassLightSet": 21,
+        "HassClimateSetTemperature": 8,
+        "HassClimateGetTemperature": 11
+      },
+      "used_responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 6,
+        "HassLightSet": 6,
+        "HassClimateSetTemperature": 2,
+        "HassClimateGetTemperature": 2
+      },
+      "responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 6,
+        "HassLightSet": 6,
+        "HassClimateSetTemperature": 2,
+        "HassClimateGetTemperature": 2
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": true
+    },
+    {
+      "language": "ru",
+      "native_name": "\u0420\u0443\u0441\u0441\u043a\u0438\u0439",
+      "leaders": [
+        "HepoH3"
+      ],
+      "intents": {
+        "HassTurnOn": 10,
+        "HassTurnOff": 13,
+        "HassGetState": 0,
+        "HassLightSet": 9,
+        "HassClimateSetTemperature": 4,
+        "HassClimateGetTemperature": 2
+      },
+      "used_responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "sk",
+      "native_name": "Sloven\u010dina",
+      "leaders": [
+        "LubosKadasi"
+      ],
+      "intents": {
+        "HassTurnOn": 11,
+        "HassTurnOff": 11,
+        "HassGetState": 6,
+        "HassLightSet": 12,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 4
+      },
+      "used_responses": {
+        "HassTurnOn": 9,
+        "HassTurnOff": 9,
+        "HassGetState": 6,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 10,
+        "HassTurnOff": 10,
+        "HassGetState": 6,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": true
+    },
+    {
+      "language": "sl",
+      "native_name": "Sloven\u0161\u010dina",
+      "leaders": null,
+      "intents": {
+        "HassTurnOn": 0,
+        "HassTurnOff": 0,
+        "HassGetState": 0,
+        "HassLightSet": 0,
+        "HassClimateSetTemperature": 0,
+        "HassClimateGetTemperature": 0
+      },
+      "used_responses": {
+        "HassTurnOn": 1,
+        "HassTurnOff": 1,
+        "HassGetState": 0,
+        "HassLightSet": 1,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 5,
+        "HassTurnOff": 5,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "sr",
+      "native_name": "\u0421\u0440\u043f\u0441\u043a\u0438",
+      "leaders": [
+        "cvladan"
+      ],
+      "intents": {
+        "HassTurnOn": 1,
+        "HassTurnOff": 1,
+        "HassGetState": 0,
+        "HassLightSet": 6,
+        "HassClimateSetTemperature": 0,
+        "HassClimateGetTemperature": 0
+      },
+      "used_responses": {
+        "HassTurnOn": 1,
+        "HassTurnOff": 1,
+        "HassGetState": 0,
+        "HassLightSet": 2,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 5,
+        "HassTurnOff": 5,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "sv",
+      "native_name": "Svenska",
+      "leaders": [
+        "larsdunemark"
+      ],
+      "intents": {
+        "HassTurnOn": 12,
+        "HassTurnOff": 12,
+        "HassGetState": 0,
+        "HassLightSet": 14,
+        "HassClimateSetTemperature": 4,
+        "HassClimateGetTemperature": 6
+      },
+      "used_responses": {
+        "HassTurnOn": 4,
+        "HassTurnOff": 4,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "sw",
+      "native_name": "Kiswahili",
+      "leaders": null,
+      "intents": {
+        "HassTurnOn": 0,
+        "HassTurnOff": 0,
+        "HassGetState": 0,
+        "HassLightSet": 0,
+        "HassClimateSetTemperature": 0,
+        "HassClimateGetTemperature": 0
+      },
+      "used_responses": {
+        "HassTurnOn": 1,
+        "HassTurnOff": 1,
+        "HassGetState": 0,
+        "HassLightSet": 1,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 5,
+        "HassTurnOff": 5,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": false,
+      "usable": false
+    },
+    {
+      "language": "te",
+      "native_name": "\u0c24\u0c46\u0c32\u0c41\u0c17\u0c41",
+      "leaders": null,
+      "intents": {
+        "HassTurnOn": 0,
+        "HassTurnOff": 0,
+        "HassGetState": 0,
+        "HassLightSet": 0,
+        "HassClimateSetTemperature": 0,
+        "HassClimateGetTemperature": 0
+      },
+      "used_responses": {
+        "HassTurnOn": 1,
+        "HassTurnOff": 1,
+        "HassGetState": 0,
+        "HassLightSet": 1,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 5,
+        "HassTurnOff": 5,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "tr",
+      "native_name": "T\u00fcrk\u00e7e",
+      "leaders": [
+        "alpdmrel"
+      ],
+      "intents": {
+        "HassTurnOn": 5,
+        "HassTurnOff": 5,
+        "HassGetState": 0,
+        "HassLightSet": 0,
+        "HassClimateSetTemperature": 3,
+        "HassClimateGetTemperature": 6
+      },
+      "used_responses": {
+        "HassTurnOn": 4,
+        "HassTurnOff": 4,
+        "HassGetState": 0,
+        "HassLightSet": 1,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "uk",
+      "native_name": "\u0423\u043a\u0440\u0430\u0457\u043d\u0441\u044c\u043a\u0430",
+      "leaders": [
+        "skynetua"
+      ],
+      "intents": {
+        "HassTurnOn": 13,
+        "HassTurnOff": 13,
+        "HassGetState": 0,
+        "HassLightSet": 8,
+        "HassClimateSetTemperature": 2,
+        "HassClimateGetTemperature": 3
+      },
+      "used_responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "ur",
+      "native_name": "\u0627\u064f\u0631\u062f\u064f\u0648",
+      "leaders": [
+        "AalianKhan"
+      ],
+      "intents": {
+        "HassTurnOn": 8,
+        "HassTurnOff": 8,
+        "HassGetState": 0,
+        "HassLightSet": 8,
+        "HassClimateSetTemperature": 6,
+        "HassClimateGetTemperature": 7
+      },
+      "used_responses": {
+        "HassTurnOn": 1,
+        "HassTurnOff": 1,
+        "HassGetState": 0,
+        "HassLightSet": 3,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 5,
+        "HassTurnOff": 5,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "vi",
+      "native_name": "Ti\u1ebfng Vi\u1ec7t",
+      "leaders": [
+        "dinhchinh82"
+      ],
+      "intents": {
+        "HassTurnOn": 9,
+        "HassTurnOff": 12,
+        "HassGetState": 11,
+        "HassLightSet": 10,
+        "HassClimateSetTemperature": 2,
+        "HassClimateGetTemperature": 8
+      },
+      "used_responses": {
+        "HassTurnOn": 4,
+        "HassTurnOff": 4,
+        "HassGetState": 6,
+        "HassLightSet": 3,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 10,
+        "HassTurnOff": 6,
+        "HassGetState": 6,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": true
+    },
+    {
+      "language": "zh-cn",
+      "native_name": "\u7b80\u4f53\u4e2d\u6587",
+      "leaders": [
+        "al-one"
+      ],
+      "intents": {
+        "HassTurnOn": 13,
+        "HassTurnOff": 12,
+        "HassGetState": 18,
+        "HassLightSet": 10,
+        "HassClimateSetTemperature": 2,
+        "HassClimateGetTemperature": 3
+      },
+      "used_responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 6,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 6,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": true
+    },
+    {
+      "language": "zh-hk",
+      "native_name": "\u7e41\u9ad4\u4e2d\u6587\uff08\u9999\u6e2f\uff09",
+      "leaders": null,
+      "intents": {
+        "HassTurnOn": 3,
+        "HassTurnOff": 3,
+        "HassGetState": 0,
+        "HassLightSet": 0,
+        "HassClimateSetTemperature": 2,
+        "HassClimateGetTemperature": 3
+      },
+      "used_responses": {
+        "HassTurnOn": 3,
+        "HassTurnOff": 3,
+        "HassGetState": 0,
+        "HassLightSet": 1,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 6,
+        "HassTurnOff": 6,
+        "HassGetState": 0,
+        "HassLightSet": 4,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": false
+    },
+    {
+      "language": "zh-tw",
+      "native_name": "\u7e41\u9ad4\u4e2d\u6587\uff08\u53f0\u7063\uff09",
+      "leaders": [
+        "bluefoxlee"
+      ],
+      "intents": {
+        "HassTurnOn": 13,
+        "HassTurnOff": 14,
+        "HassGetState": 13,
+        "HassLightSet": 12,
+        "HassClimateSetTemperature": 2,
+        "HassClimateGetTemperature": 4
+      },
+      "used_responses": {
+        "HassTurnOn": 5,
+        "HassTurnOff": 5,
+        "HassGetState": 6,
+        "HassLightSet": 2,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "responses": {
+        "HassTurnOn": 5,
+        "HassTurnOff": 5,
+        "HassGetState": 6,
+        "HassLightSet": 2,
+        "HassClimateSetTemperature": 1,
+        "HassClimateGetTemperature": 1
+      },
+      "intent_responses_translated": {
+        "HassLightSet": true,
+        "HassClimateSetTemperature": true,
+        "HassGetState": true,
+        "HassTurnOff": true,
+        "HassTurnOn": true,
+        "HassClimateGetTemperature": true
+      },
+      "errors_translated": true,
+      "usable": true
     }
   ]
 }


### PR DESCRIPTION
With abbreviated responses + templates, there are several responses that now exactly match the English "translations". For example, `{{ state.state_with_unit }}` as a response to `HassGetTemperature`

For the website summary, I am now looking for a "TODO" in the response to indicate it is not yet translated. This is added automatically by `add_language.py`.