### PR TITLE
Generate entity/area aliases from fixture templates

### DIFF
--- a/responses/gu/HassClimateGetTemperature.yaml
+++ b/responses/gu/HassClimateGetTemperature.yaml
@@ -2,4 +2,4 @@ language: gu
 responses:
   intents:
     HassClimateGetTemperature:
-      default: '{{ state.state }} degrees'
+      default: "{{ state.state }} degrees"

--- a/responses/gu/HassGetState.yaml
+++ b/responses/gu/HassGetState.yaml
@@ -1,0 +1,4 @@
+language: gu
+responses:
+  intents:
+    HassGetState: {}

--- a/responses/gu/HassLightSet.yaml
+++ b/responses/gu/HassLightSet.yaml
@@ -2,7 +2,7 @@ language: gu
 responses:
   intents:
     HassLightSet:
-      brightness: '{{ slots.name }} brightness set to {{ slots.brightness }}'
+      brightness: "{{ slots.name }} brightness set to {{ slots.brightness }}"
       brightness_area: Brightness in {{ slots.area }} set to {{ slots.brightness }}
-      color: '{{ slots.name }} color set to {{ slots.color }}'
+      color: "{{ slots.name }} color set to {{ slots.color }}"
       color_area: Color in {{ slots.area }} set to {{ slots.color }}

--- a/sentences/gu/cover_HassGetState.yaml
+++ b/sentences/gu/cover_HassGetState.yaml
@@ -1,0 +1,8 @@
+language: gu
+intents:
+  HassGetState:
+    data:
+      - sentences: []
+        slots:
+          domain: cover
+          name: all

--- a/sentences/gu/cover_HassTurnOff.yaml
+++ b/sentences/gu/cover_HassTurnOff.yaml
@@ -1,0 +1,8 @@
+language: gu
+intents:
+  HassTurnOff:
+    data:
+      - sentences: []
+        slots:
+          domain: cover
+          name: all

--- a/sentences/gu/cover_HassTurnOn.yaml
+++ b/sentences/gu/cover_HassTurnOn.yaml
@@ -1,0 +1,8 @@
+language: gu
+intents:
+  HassTurnOn:
+    data:
+      - sentences: []
+        slots:
+          domain: cover
+          name: all

--- a/sentences/gu/homeassistant_HassGetState.yaml
+++ b/sentences/gu/homeassistant_HassGetState.yaml
@@ -1,0 +1,5 @@
+language: gu
+intents:
+  HassGetState:
+    data:
+      - sentences: []

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -1,6 +1,5 @@
-import itertools
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional, List, Tuple
+from typing import Any, Dict, Optional, List, Set, Tuple
 
 from hassil import parse_sentence
 from hassil.intents import SlotList, TextSlotList, is_template
@@ -19,6 +18,7 @@ class State:
     attributes: Dict[str, Any] = field(default_factory=dict)
     area_id: Optional[str] = None
     human_state: Optional[str] = None
+    aliases: Set[str] = field(default_factory=set)
     _domain: Optional[str] = None
 
     @property
@@ -50,13 +50,13 @@ class AreaEntry:
 
     id: str
     name: str
+    aliases: Set[str] = field(default_factory=set)
 
 
 def get_matched_states(
     states: List[State], areas: List[AreaEntry], result: RecognizeResult
 ) -> Tuple[List[State], List[State]]:
     """Split states into matched/unmatched."""
-
     if result.intent.name in ("HassClimateGetTemperature", "HassClimateSetTemperature"):
         # Match climate entities only
         states = [state for state in states if state.domain == "climate"]
@@ -87,18 +87,35 @@ def get_matched_states(
     if state_entity is not None:
         state_name = state_entity.value
 
-    area_ids = {_normalize_name(area.name): area.id for area in areas}
+    # name -> id
+    area_ids: Dict[str, str] = {}
+    for area in areas:
+        area_ids[_normalize_name(area.name)] = area.id
+        for area_alias in area.aliases:
+            area_ids[_normalize_name(area_alias)] = area.id
+
     matched: List[State] = []
     unmatched: List[State] = []
 
     for state in states:
-        if (entity_name is not None) and (_normalize_name(state.name) != entity_name):
-            # Filter by entity name
-            continue
+        if entity_name is not None:
+            name_match = _normalize_name(state.name) != entity_name
+
+            if not name_match:
+                # Check aliases
+                for state_alias in state.aliases:
+                    if _normalize_name(state_alias) == entity_name:
+                        name_match = True
+                        break
+
+            if not name_match:
+                # Filter by entity name
+                continue
 
         if (area_name is not None) and (state.area_id != area_ids.get(area_name)):
             # Filter by area
             continue
+
         if (domain_name is not None) and (domain_name != state.domain):
             # Filter by domain
             continue
@@ -222,10 +239,21 @@ def get_states(fixtures: dict[str, Any]) -> List[State]:
             human_state = entity_state["in"]
             hass_state = entity_state["out"]
 
+        entity_names: List[str] = []
+        entity_name = entity["name"]
+        if is_template(entity_name):
+            entity_names.extend(
+                entity_name.strip()
+                for entity_name in sample_expression(parse_sentence(entity_name))
+            )
+        else:
+            entity_names.append(entity_name.strip())
+
         states.append(
             State(
                 entity_id=entity["id"],
-                name=entity["name"],
+                name=entity_names[0],
+                aliases=set(entity_names[1:]),
                 hass_state=hass_state,
                 human_state=human_state,
                 area_id=entity.get("area"),
@@ -239,10 +267,17 @@ def get_areas(fixtures: dict[str, Any]) -> List[AreaEntry]:
     """Load areas from test fixtures."""
     areas: List[AreaEntry] = []
     for area in fixtures.get("areas", []):
-        areas.append(
-            AreaEntry(
-                id=area["id"],
-                name=area["name"],
+        area_names: List[str] = []
+        area_name = area["name"]
+        if is_template(area_name):
+            area_names.extend(
+                area_name.strip()
+                for area_name in sample_expression(parse_sentence(area_name))
             )
+        else:
+            area_names.append(area_name.strip())
+
+        areas.append(
+            AreaEntry(id=area["id"], name=area_names[0], aliases=set(area_names[1:]))
         )
     return areas

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -99,7 +99,7 @@ def get_matched_states(
 
     for state in states:
         if entity_name is not None:
-            name_match = _normalize_name(state.name) != entity_name
+            name_match = _normalize_name(state.name) == entity_name
 
             if not name_match:
                 # Check aliases

--- a/tests/bg/cover_HassGetState.yaml
+++ b/tests/bg/cover_HassGetState.yaml
@@ -20,7 +20,7 @@ tests:
         area: "хола"
         device_class: curtain
         state: "open"
-    response: "Не"
+    response: "Да, лявата завеса"
 
   - sentences:
       - "Всички завеси ли са отворени в хола?"
@@ -31,7 +31,7 @@ tests:
         area: "хола"
         device_class: curtain
         state: "open"
-    response: "Да"
+    response: "Не, дясната завеса не е"
 
   - sentences:
       - "Кои завеси са затворени?"

--- a/tests/cs/cover_HassGetState.yaml
+++ b/tests/cs/cover_HassGetState.yaml
@@ -67,7 +67,7 @@ tests:
         device_class: blind
         domain: cover
         state: open
-    response: "Přední rolet(a|u|y) je otevřená"
+    response: "Přední roleta je otevřená"
 
   - sentences:
       - "kolik rolet se zavírá"

--- a/tests/gu/cover_HassGetState.yaml
+++ b/tests/gu/cover_HassGetState.yaml
@@ -1,0 +1,8 @@
+language: gu
+tests:
+  - sentences: []
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        name: all

--- a/tests/gu/cover_HassTurnOff.yaml
+++ b/tests/gu/cover_HassTurnOff.yaml
@@ -1,0 +1,8 @@
+language: gu
+tests:
+  - sentences: []
+    intent:
+      name: HassTurnOff
+      slots:
+        domain: cover
+        name: all

--- a/tests/gu/cover_HassTurnOn.yaml
+++ b/tests/gu/cover_HassTurnOn.yaml
@@ -1,0 +1,8 @@
+language: gu
+tests:
+  - sentences: []
+    intent:
+      name: HassTurnOn
+      slots:
+        domain: cover
+        name: all

--- a/tests/gu/homeassistant_HassGetState.yaml
+++ b/tests/gu/homeassistant_HassGetState.yaml
@@ -1,0 +1,5 @@
+language: gu
+tests:
+  - sentences: []
+    intent:
+      name: HassGetState


### PR DESCRIPTION
Fixture names can be templates, and the different combinations were only being generated for the slot lists. Entity and area aliases are now generated from fixture templates for filtering after an intent match.