### PR TITLE
[NB] Shorter response according to style guide

### DIFF
--- a/responses/nb/HassTurnOff.yaml
+++ b/responses/nb/HassTurnOff.yaml
@@ -2,9 +2,9 @@ language: nb
 responses:
   intents:
     HassTurnOff:
-      default: "{{ slots.name }} ble slått av"
-      lights_area: Lysene i {{ slots.area }} ble slått av
-      fans_area: Viftene i {{ slots.area }} ble slått av
-      cover: "{{ slots.name }} ble lukket"
+      default: Slo av {{ state.domain }}
+      lights_area: Slo av lys
+      fans_area: Slo av vifter
+      cover: Lukket
       cover_area: Lukket {{ slots.area }}
-      cover_device_class: "{{ slots.device_class }} ble lukket"
+      cover_device_class: Lukket {{ slots.device_class }}

--- a/responses/nb/HassTurnOn.yaml
+++ b/responses/nb/HassTurnOn.yaml
@@ -2,9 +2,9 @@ language: nb
 responses:
   intents:
     HassTurnOn:
-      default: "{{ slots.name }} ble slått på"
-      lights_area: Lysene i {{ slots.area }} ble slått på
-      fans_area: Viftene i {{ slots.area }} ble slått på
-      cover: "{{ slots.name }} ble åpnet"
+      default: Slo på {{ state.domain }}
+      lights_area: Slo på lys
+      fans_area: Slo på vifter
+      cover: Åpnet
       cover_area: Åpnet {{ slots.area }}
-      cover_device_class: "{{ slots.device_class }} ble åpnet"
+      cover_device_class: Åpnet {{ slots.device_class }}

--- a/tests/nb/cover_HassTurnOff.yaml
+++ b/tests/nb/cover_HassTurnOff.yaml
@@ -8,7 +8,7 @@ tests:
       slots:
         domain: cover
         device_class: garage
-    response: garage ble lukket
+    response: Lukket garage
   - sentences:
       - lukk igjen takvinduet på kjøkkenet
       - steng takvinduet i kjøkkenet

--- a/tests/nb/cover_HassTurnOn.yaml
+++ b/tests/nb/cover_HassTurnOn.yaml
@@ -8,7 +8,7 @@ tests:
       slots:
         domain: cover
         device_class: garage
-    response: garage ble åpnet
+    response: Åpnet garage
   - sentences:
       - åpne opp takvinduet på kjøkkenet
       - åpne takvinduet i kjøkkenet

--- a/tests/nb/homeassistant_HassTurnOff.yaml
+++ b/tests/nb/homeassistant_HassTurnOff.yaml
@@ -15,7 +15,7 @@ tests:
       name: HassTurnOff
       slots:
         name: Venstre gardin
-    response: "venstre gardin ble lukket"
+    response: Lukket
   - sentences:
       - Lukk venstre gardin i stuen
     intent:
@@ -23,7 +23,7 @@ tests:
       slots:
         name: Venstre gardin
         area: Stue
-    response: "venstre gardin ble lukket"
+    response: Lukket
   - sentences:
       - Lukk garasje
       - Lukk garasjeportene

--- a/tests/nb/homeassistant_HassTurnOn.yaml
+++ b/tests/nb/homeassistant_HassTurnOn.yaml
@@ -15,7 +15,7 @@ tests:
       name: HassTurnOn
       slots:
         name: Venstre gardin
-    response: "venstre gardin ble åpnet"
+    response: Åpnet
   - sentences:
       - Åpne venstre gardin i stuen
     intent:
@@ -23,7 +23,7 @@ tests:
       slots:
         name: Venstre gardin
         area: Stue
-    response: "venstre gardin ble åpnet"
+    response: Åpnet
   - sentences:
       - Åpne garasje
       - Åpne garasjeportene


### PR DESCRIPTION
Ref https://developers.home-assistant.io/docs/voice/intent-recognition/style-guide/ and [EN] example and proposal on Discord.

Please consider the following carefully in reviewing this PR. I considered a few different responses to meet the shorter and more accurate feedback to actions. 

We are advised not to repeat slots.name/slots.area, and to give a concise answer in the present tense and active voice. By removing slots.name / slots area, I am not certain whether it is correct to answer "It's on" or "It's on". The [ENG] example not not fully meet the style guide, but is my preferred example to follow. Here we have several options (this PR reflects the last one):

    HassTurnOn: (keep slots.name/area to ease grammar challenges)
      default: {{ slots.name }} er slått på
      lights_area: Lys i {{ slots.area }} er slått på
      fans_area: Vifte i {{ slots.area }} er slått på
      cover: {{ slots.name }} er åpnet
      cover_area: Åpnet {{ slots.area }}
      cover_device_class: "{{ slots.device_class }} er åpnet"

    HassTurnOn: (most similar to style guide)
      default: Den er på
      lights_area: Lys er på
      fans_area: Vifte er på
      cover: Den er åpnet
      cover_area: Åpnet {{ slots.area }}
      cover_device_class: "{{ slots.device_class }} er åpnet"

    HassTurnOn: (example from EN)
      default: Slo på {{ state.domain }}
      lights_area: Slo på lys
      fans_area: Slo på vifte
      cover: Åpnet
      cover_area: Åpnet {{ slots.area }}
      cover_device_class: Åpnet {{ slots.device_class }}