### PR TITLE
[RO] Grammar fixes

### DIFF
--- a/responses/ro/HassGetState.yaml
+++ b/responses/ro/HassGetState.yaml
@@ -3,12 +3,14 @@ responses:
   intents:
     HassGetState:
       one: "{{ slots.name | capitalize }} este {{ state.state_with_unit }}"
+
       one_yesno: |
         {% if query.matched: %}
         Da
         {% else: %}
-        Nu, {{ slots.name }} este {{ state.state_with_unit }}
+        Nu, este {{ state.state_with_unit }}
         {% endif %}
+
       any: |
         {% if query.matched %}
           {% set match = query.matched | map(attribute="name") | sort | list %}

--- a/responses/ro/HassLightSet.yaml
+++ b/responses/ro/HassLightSet.yaml
@@ -2,9 +2,8 @@ language: ro
 responses:
   intents:
     HassLightSet:
-      brightness: "Luminozitatea pentru {{ slots.name }} a fost modificată la {{ slots.brightness }} la sută"
-      brightness_area: "Luminozitatea în {{ slots.area }} a fost modificată la {{ slots.brightness }} la sută"
-      brightness_min_max: "Luminozitatea pentru {{ slots.name }} a fost modificată la {{ '100%' if 'max' in slots.brightness else '1%' if 'min' in slots.brightness else '50%' }}"
-      brightness_min_max_area: "Luminozitatea în {{ slots.area }} a fost modificată la {{ '100%' if 'max' in slots.brightness else '1%' if 'min' in slots.brightness else '50%' }}"
-      color: "Culoarea pentru {{ slots.name }} a fost modificată în {{ slots.color }}"
-      color_area: "Culoarea luminilor din {{ slots.area }} a fost modificată în {{ slots.color }}"
+      brightness: "Luminozitatea a fost modificată"
+      brightness_area: "Luminozitatea a fost modificată"
+      brightness_min_max: "Luminozitatea a fost modificată la {{ '100%' if 'max' in slots.brightness else '1%' if 'min' in slots.brightness else '50%' }}"
+      brightness_min_max_area: "Luminozitatea a fost modificată la {{ '100%' if 'max' in slots.brightness else '1%' if 'min' in slots.brightness else '50%' }}"
+      color: "Culoarea a fost modificată"

--- a/responses/ro/HassTurnOff.yaml
+++ b/responses/ro/HassTurnOff.yaml
@@ -3,8 +3,8 @@ responses:
   intents:
     HassTurnOff:
       default: "Am oprit {{ slots.name }}"
-      light: "Am stins {{ slots.name }}"
-      lights_area: "Am stins luminile de la {{ slots.area }}"
-      fans_area: "Am oprit ventilatoarele de la {{ slots.area }}"
-      cover: "Am închis {{ slots.name }}"
-      covers_area: "Am închis {{ slots.device_class }} de la {{ slots.area }}"
+      light: "Am stins lumina"
+      lights_area: "Am stins luminile"
+      fans_area: "Am oprit ventilatoarele"
+      cover: "Am închis"
+      covers_area: "Am închis {{ slots.device_class }}"

--- a/responses/ro/HassTurnOn.yaml
+++ b/responses/ro/HassTurnOn.yaml
@@ -3,8 +3,8 @@ responses:
   intents:
     HassTurnOn:
       default: "Am pornit {{ slots.name }}"
-      light: "Am aprins {{ slots.name }}"
-      lights_area: "Am aprins luminile de la {{ slots.area }}"
-      fans_area: "Am pornit ventilatoarele de la {{ slots.area }}"
-      cover: "Am deschis {{ slots.name }}"
-      covers_area: "Am deschis {{ slots.device_class }} de la {{ slots.area }}"
+      light: "Am aprins lumina"
+      lights_area: "Am aprins luminile"
+      fans_area: "Am pornit ventilatoarele"
+      cover: "Am deschis"
+      covers_area: "Am deschis {{ slots.device_class }}"

--- a/sentences/ro/_common.yaml
+++ b/sentences/ro/_common.yaml
@@ -54,13 +54,19 @@ lists:
       - "fahrenheit"
       - in: "f"
         out: "fahrenheit"
-  on_off_states:
+  on_off_states_singular:
     values:
       - in: "<pornit>"
         out: "on"
       - in: "<oprit>"
         out: "off"
-  on_off_domains:
+  on_off_states_plural:
+    values:
+      - in: "<pornite>"
+        out: "on"
+      - in: "<oprite>"
+        out: "off"
+  on_off_domains_singular:
     values:
       - in: "<lumina>"
         out: "light"
@@ -68,70 +74,139 @@ lists:
         out: "fan"
       - in: "<intrerupatorul>"
         out: "switch"
-  cover_states:
+  on_off_domains_plural:
+    values:
+      - in: "<luminile>"
+        out: "light"
+      - in: "<ventilatoarele>"
+        out: "fan"
+      - in: "<intrerupatoarele>"
+        out: "switch"
+  cover_states_singular:
     values:
       - in: "<deschis>"
         out: "open"
       - in: "<inchis>"
         out: "closed"
-      - in: "(î|i)n curs de <deschide>re"
+      - in: "(î|i)n curs de (deschidere | ridicare)"
         out: "opening"
-      - in: "(î|i)n curs de <inchide>re"
+      - in: "(î|i)n curs de (inchidere | coborâre)"
         out: "closing"
-  cover_classes:
+  cover_states_plural:
     values:
-      - in: "copertin(ă|a|e)"
+      - in: "<deschise>"
+        out: "open"
+      - in: "<inchise>"
+        out: "closed"
+      - in: "(î|i)n curs de (deschidere | ridicare)"
+        out: "opening"
+      - in: "(î|i)n curs de (inchidere | coborâre)"
+        out: "closing"
+  cover_classes_singular:
+    values:
+      - in: "copertin(ă|a)"
         out: "awning"
-      - in: "jaluze(a[ua]|le[le])"
+      - in: "jaluzea[ua]"
         out: "blind"
-      - in: "perde(a[ua]|le[le])"
+      - in: "perdea[ua]"
         out: "curtain"
       - in: "<usa>"
         out: "door"
-      - in: "<usa> (de la garaj | garajului)"
+      - in: "u(ș|s)a (de la garaj | garajului)"
         out: "garage"
       - in: "<poarta>"
         out: "gate"
-      - in: "(jaluzea[ua] | jaluzele[le] | draperi(e|a) | draperii[le])"
+      - in: "draperi(e|a)"
         out: "shade"
-      - in: "(rulou[l] | rulouri[le] | oblon[ul] | obloane[le])"
+      - in: "(rulou[l] | oblon[ul])"
         out: "shutter"
       - in: "<fereastra>"
         out: "window"
+  cover_classes_plural:
+    values:
+      - in: "copertine[le]"
+        out: "awning"
+      - in: "jaluzele[le]"
+        out: "blind"
+      - in: "perdele[le]"
+        out: "curtain"
+      - in: "<usile>"
+        out: "door"
+      - in: "u(ș|s)ile (de la garaj | garajului)"
+        out: "garage"
+      - in: "<portile>"
+        out: "gate"
+      - in: "draperii[le]"
+        out: "shade"
+      - in: "(rulouri[le] | obloane[le])"
+        out: "shutter"
+      - in: "<ferestrele>"
+        out: "window"
 expansion_rules:
-  area: "[(zona | regiunea )] {area}"
-  brightness: "{brightness} [(la sut(ă|a) | % | [de] procente)]"
-  brightness_percent: "{brightness} (la sut(ă|a) | % | [de] procente)"
-  temperature: "{temperature} [[de] grad[e]] [{temperature_unit}]"
-  name: "({name}[(ul|a)])"
+  # Placeholders
+  area: "[(zona | regiunea | spa(ț|t)iul)] {area}"
+  brightness: "{brightness}[ ][(% | la sut(ă|a) | [de ]procente)]"
+  brightness_percent: "{brightness}[ ](% | la sut(ă|a) | [de] procente)"
+  temperature: "{temperature}[ ][[de ]grad[e]][[ ]{temperature_unit}]"
+  name: "({name})"
+
+  # Quantities
   maximum: "(maxim[(ă|a|um)] [posibil[(ă|a)]])"
   jumatate: "(jum(ă|a)tate | jumate)"
   minimum: "(minim[(ă|a|um)] [posibil[(ă|a)]])"
+
+  # Verbs
   este: "(e | este | sunt)"
-  cate: "(c(â|a|î|i)te | c(â|a|î|i)(ț|t)i)"
-  cat: "(c(â|a|î|i)t[e] | cum)"
-  in: "((î|i)n)"
-  din: "(din | (î|i)n | pentru | [de] la | [de] pe | de)"
-  vreun: "(vre(o|un))"
   porneste: "(start | porne(ș|s)te | deschide | aprinde | activeaz(ă|a))"
-  pornit: "(pornit[(ă|a|e)] | deschis[(ă|a|e)]) | aprins[(ă|a|e)] | activat[(ă|a|e)]"
   opreste: "(stop | opre(ș|s)te | (î|i)nchide | stinge | dezactiveaz(ă|a))"
-  oprit: "(oprit[(ă|a|e)] | (î|i)nchis[(ă|a|e)] | stins[(ă|a|e)] | dezactivat[(ă|a|e)])"
   seteaza: "(seteaz(ă|a) | pune | a[d]justeaz(ă|a) | schimb(ă|a) | modific(ă|a))"
-  lumina: "(lumini[le] | lumin(ă|a) | bec[ul] | becuri[le])"
+  deschide: "(deschide | ridic(ă|a))"
+  inchide: "((î|i)nchide | coboar(ă|a))"
+
+  # Questions
+  cate: "(c(â|a)te | c(â|a)(ț|t)i)"
+  cat_quant: "(c(â|a)t)"
+  cat: "(<cat_quant> | cum)"
+  care: "(care | ce)"
+
+  # Prepositions
+  in: "((î|i)n)"
+  din: "(din | (î|i)n | pentru | [de] la | [de] pe | de)" # used particularly for areas
+
+  # Adjectives
+  pornit: "(pornit[(ă|a)] | deschis[(ă|a)]) | aprins[(ă|a)] | activat[(ă|a)]"
+  pornite: "(pornite | deschise | aprinse | activate)"
+  oprit: "(oprit[(ă|a)] | (î|i)nchis[(ă|a)] | stins[(ă|a)] | dezactivat[(ă|a)])"
+  oprite: "(oprite | (î|i)nchise | stinse | dezactivate)"
+  deschis: "(deschis[(ă|a)] | ridicat[(ă|a)])"
+  deschise: "(deschise | ridicate)"
+  inchis: "((î|i)nchis[(ă|a)] | coboar(â|a)t[(ă|a)])"
+  inchise: "((î|i)nchise | coboar(â|a)te)"
+  cald_frig: "(cald | frig | rece | r(ă|a)coare)"
+
+  # Domains
+  lumina: "(lumin(ă|a) | bec[ul])"
+  luminile: "(lumini[le] | becuri[le])"
+  ventilatorul: "(ventilator[ul] | aerisire[a])"
+  ventilatoarele: "(ventilatoare[le] | aerisiri[le])"
+  intrerupatorul: "((î|i)ntrerup(ă|a)tor[ul] | comutator[ul])"
+  intrerupatoarele: "((î|i)ntrerup(ă|a)toare[le] | comutatoare[le])"
+
+  # Attributes
   luminozitatea: "(luminozitate[a])"
   culoarea: "(culoare[a])"
   temperatura: "(temperatur(ă|a))"
-  deschide: "(deschide | ridic(ă|a))"
-  deschis: "(deschis[(ă|a|e)] | ridicat[(ă|a|e)])"
-  inchide: "((î|i)nchide | coboar(ă|a))"
-  inchis: "((î|i)nchis[(ă|a|e)] | coboar(â|a)t[(ă|a|e)])"
-  fereastra: "(fereastr(ă|a) | ferestre[le] | geam[ul] | geamuri[le])"
-  usa: "(u(ș|s)(ă|a) | u(ș|s)i[le])"
-  jaluzelele: "(jaluzea[ua] | jaluzele[le] | draperi(e|a) | draperii[le] | perdea[ua] | perdele[le] | rulou[l] | rulouri[le] | oblon[ul] | obloane[le])"
-  poarta: "(poart(ă|a) | por(ț|t)i[le] | gard[ul])"
-  ventilatorul: "(ventilator[ul] | ventilatoare[le] | aerisire[a] | aerisiri[le])"
-  intrerupatorul: "((î|i)ntrerup(ă|a)tor[ul] | (î|i)ntrerup(ă|a)toare[le] | comutator[ul] | comutatoare[le])"
+
+  # Device classes
+  fereastra: "(fereastr(ă|a) | geam[ul])"
+  ferestrele: "(ferestre[le] | geamuri[le])"
+  usa: "u(ș|s)(ă|a)"
+  usile: "u(ș|s)i[le]"
+  poarta: "poart(ă|a)"
+  portile: "por(ț|t)i[le]"
+
+  # Other
+  vreun: "(vre(o|un))"
 skip_words:
   - "mulțumesc"
   - "multumesc"

--- a/sentences/ro/climate_HassClimateGetTemperature.yaml
+++ b/sentences/ro/climate_HassClimateGetTemperature.yaml
@@ -3,18 +3,18 @@ intents:
   HassClimateGetTemperature:
     data:
       - sentences:
-          - "ce <temperatura> <este> [<in>] <area>"
-          - "(care | <cat>) <este> <temperatura> [<din>] <area>"
-          - "<cat> grade sunt [<in>] <area>"
-          - "<cat> de (cald | frig | rece | r(ă|a)coare) <este> [<in>] <area>"
-          - "<cat> <este> de (cald | frig | rece | r(ă|a)coare) [<in>] <area>"
-          - "<este> (cald | frig | rece | r(ă|a)coare) [<in>] <area>"
+          - "ce <temperatura> e[ste] <in> <area>"
+          - "(care | <cat>) e[ste] <temperatura> <din> <area>"
+          - "<cate> grade sunt <in> <area>"
+          - "<cat_quant> de <cald_frig> e[ste] <in> <area>"
+          - "<cat_quant> e[ste] de <cald_frig> <in> <area>"
+          - "e[ste] <cald_frig> <in> <area>"
         response: temp_area
       - sentences:
-          - "ce <temperatura> <este>"
-          - "(care | <cat>) <este> <temperatura>"
-          - "<cat> grade sunt"
-          - "<cat> de (cald | frig | rece | r(ă|a)coare) <este>"
-          - "<cat> <este> de (cald | frig | rece | r(ă|a)coare)"
+          - "ce <temperatura> e[ste]"
+          - "(care | <cat>) e[ste] <temperatura>"
+          - "<cate> grade sunt"
+          - "<cat_quant> de <cald_frig> e[ste]"
+          - "<cat_quant> e[ste] de <cald_frig>"
         requires_context:
           area:

--- a/sentences/ro/climate_HassClimateSetTemperature.yaml
+++ b/sentences/ro/climate_HassClimateSetTemperature.yaml
@@ -3,15 +3,15 @@ intents:
   HassClimateSetTemperature:
     data:
       - sentences:
-          - "<seteaza> [<temperatura>] [aerului] [<din>] <area> [[p(â|a)n(ă|a)] la] <temperature>"
-          - "<seteaza> [[p(â|a)n(ă|a)] la] <temperature> (<temperatura> [aerului] [<din>] | <in>) <area>"
-          - "((î|i)nc(ă|a)lze(ș|s)te | r(ă|a)ce(ș|s)te) [(<temperatura> aerului [<din>] | aerul [<din>] | [<temperatura>] <in>)] <area> [[p(â|a)n(ă|a)] la] <temperature>"
-          - "((î|i)nc(ă|a)lze(ș|s)te | r(ă|a)ce(ș|s)te) [p(â|a)n(ă|a)] la <temperature> [(<temperatura> aerului [<din>] | aerul [<din>] | [<temperatura>] <in>)] <area>"
+          - "<seteaza> [temperatura [aerului]] [<din>] <area> [[p(â|a)n(ă|a)] la] <temperature>"
+          - "<seteaza> [[p(â|a)n(ă|a)] la] <temperature> (temperatura [aerului] [<din>] | <in>) <area>"
+          - "((î|i)nc(ă|a)lze(ș|s)te | r(ă|a)ce(ș|s)te) [(temperatura aerului [<din>] | aerul [<din>] | [temperatura] <in>)] <area> [[p(â|a)n(ă|a)] la] <temperature>"
+          - "((î|i)nc(ă|a)lze(ș|s)te | r(ă|a)ce(ș|s)te) [p(â|a)n(ă|a)] la <temperature> [(temperatura aerului [<din>] | aerul [<din>] | [temperatura] <in>)] <area>"
         response: temp_area
       - sentences:
-          - "<seteaza> [<temperatura>] [aerului] [[p(â|a)n(ă|a)] la] <temperature>"
-          - "<seteaza> [[p(â|a)n(ă|a)] la] <temperature> (<temperatura> [aerului])"
-          - "((î|i)nc(ă|a)lze(ș|s)te | r(ă|a)ce(ș|s)te) [(<temperatura> [aerului] | aerul)] [[p(â|a)n(ă|a)] la] <temperature>"
-          - "((î|i)nc(ă|a)lze(ș|s)te | r(ă|a)ce(ș|s)te) [p(â|a)n(ă|a)] la <temperature> [(<temperatura> [aerului] | aerul)]"
+          - "<seteaza> [temperatura [aerului]] [[p(â|a)n(ă|a)] la] <temperature>"
+          - "<seteaza> [[p(â|a)n(ă|a)] la] <temperature> (temperatura [aerului])"
+          - "((î|i)nc(ă|a)lze(ș|s)te | r(ă|a)ce(ș|s)te) [(temperatura [aerului] | aerul)] [[p(â|a)n(ă|a)] la] <temperature>"
+          - "((î|i)nc(ă|a)lze(ș|s)te | r(ă|a)ce(ș|s)te) [p(â|a)n(ă|a)] la <temperature> [(temperatura [aerului] | aerul)]"
         requires_context:
           area:

--- a/sentences/ro/cover_HassGetState.yaml
+++ b/sentences/ro/cover_HassGetState.yaml
@@ -3,33 +3,36 @@ intents:
   HassGetState:
     data:
       - sentences:
-          - "<name> [<din> <area>] <este> {cover_states:state}"
-          - "<este> {cover_states:state} <name> [<din> <area>]"
+          - "<name> [<din> <area>] e[ste] {cover_states_singular:state}"
+          - "e[ste] {cover_states_singular:state} <name> [<din> <area>]"
         response: one_yesno
         requires_context:
           domain: cover
 
       - sentences:
-          - "(<este> | exist(ă|a)) [<vreun>] {cover_classes:device_class} {cover_states:state} [<in> <area>]"
+          - "(e[ste] | exist(ă|a)) [<vreun>] {cover_classes_singular:device_class} {cover_states_singular:state} [<in> <area>]"
+          - "(sunt | exist(ă|a)) {cover_classes_plural:device_class} {cover_states_plural:state} [<in> <area>]"
         response: any
         requires_context:
           domain: cover
 
       - sentences:
-          - "sunt (to(ț|t)i | toate) {cover_classes:device_class} {cover_states:state} [<in> <area>]"
-          - "(to(ț|t)i | toate) {cover_classes:device_class} sunt {cover_states:state} [<in> <area>]"
+          # every cover class is either feminine or neutral, so "toate" is the only option for plural
+          - "sunt toate {cover_classes_plural:device_class} {cover_states_plural:state} [<in> <area>]"
+          - "toate {cover_classes_plural:device_class} sunt {cover_states_plural:state} [<in> <area>]"
         response: all
         requires_context:
           domain: cover
 
       - sentences:
-          - "care {cover_classes:device_class} <este> {cover_states:state} [<in> <area>]"
+          - "<care> {cover_classes_singular:device_class} e[ste] {cover_states_singular:state} [<in> <area>]"
+          - "(<care> {cover_classes_plural:device_class} sunt {cover_states_plural:state} [<in> <area>]"
         response: which
         requires_context:
           domain: cover
 
       - sentences:
-          - "<cate> {cover_classes:device_class} <este> {cover_states:state} [<in> <area>]"
+          - "<cate> {cover_classes_plural:device_class} sunt {cover_states_plural:state} [<in> <area>]"
         response: how_many
         requires_context:
           domain: cover

--- a/sentences/ro/cover_HassGetState.yaml
+++ b/sentences/ro/cover_HassGetState.yaml
@@ -26,7 +26,7 @@ intents:
 
       - sentences:
           - "<care> {cover_classes_singular:device_class} e[ste] {cover_states_singular:state} [<in> <area>]"
-          - "(<care> {cover_classes_plural:device_class} sunt {cover_states_plural:state} [<in> <area>]"
+          - "<care> {cover_classes_plural:device_class} sunt {cover_states_plural:state} [<in> <area>]"
         response: which
         requires_context:
           domain: cover

--- a/sentences/ro/cover_HassTurnOff.yaml
+++ b/sentences/ro/cover_HassTurnOff.yaml
@@ -8,7 +8,7 @@ intents:
           domain: cover
         response: cover
       - sentences:
-          - "<inchide> [toate] {cover_classes:device_class} [<din>] <area>"
+          - "<inchide> ({cover_classes_singular:device_class} | [toate] {cover_classes_plural:device_class}) [<din>] <area>"
         slots:
           domain: cover
         response: covers_area

--- a/sentences/ro/cover_HassTurnOn.yaml
+++ b/sentences/ro/cover_HassTurnOn.yaml
@@ -8,7 +8,7 @@ intents:
           domain: cover
         response: cover
       - sentences:
-          - "<deschide> [toate] {cover_classes:device_class} [<din>] <area>"
+          - "<deschide> ({cover_classes_singular:device_class} | [toate] {cover_classes_plural:device_class}) [<din>] <area>"
         slots:
           domain: cover
         response: covers_area

--- a/sentences/ro/fan_HassTurnOff.yaml
+++ b/sentences/ro/fan_HassTurnOff.yaml
@@ -3,13 +3,13 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "<opreste> [toate] <ventilatorul> [<din>] <area>"
-          - "<opreste> [<din>] <area> [toate] <ventilatorul>"
+          - "<opreste> (<ventilatorul> | [toate] <ventilatoarele>) [<din>] <area>"
+          - "<opreste> [<din>] <area> (<ventilatorul> | [toate] <ventilatoarele>)"
         slots:
           domain: fan
         response: fans_area
       - sentences:
-          - "<opreste> [toate] <ventilatorul>"
+          - "<opreste> (<ventilatorul> | [toate] <ventilatoarele>)"
         slots:
           domain: fan
         requires_context:

--- a/sentences/ro/fan_HassTurnOn.yaml
+++ b/sentences/ro/fan_HassTurnOn.yaml
@@ -3,13 +3,13 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "<porneste> [toate] <ventilatorul> [<din>] <area>"
-          - "<porneste> [<din>] <area> [toate] <ventilatorul>"
+          - "<porneste> (<ventilatorul> | [toate] <ventilatoarele>) <din> <area>"
+          - "<porneste> <din> <area> (<ventilatorul> | [toate] <ventilatoarele>)"
         slots:
           domain: fan
         response: fans_area
       - sentences:
-          - "<porneste> [toate] <ventilatorul>"
+          - "<porneste> (<ventilatorul> | [toate] <ventilatoarele>)"
         slots:
           domain: fan
         requires_context:

--- a/sentences/ro/homeassistant_HassGetState.yaml
+++ b/sentences/ro/homeassistant_HassGetState.yaml
@@ -3,32 +3,35 @@ intents:
   HassGetState:
     data:
       - sentences:
-          - "<cat> <este> <name> [<din> <area>]"
-          - "(ce stare are|(î|i)n ce stare <este>) <name> [<din> <area>]"
+          - "<cat> e[ste] <name> [<din> <area>]"
+          - "(ce stare are|(î|i)n ce stare e[ste]) <name> [<din> <area>]"
         response: one
 
       - sentences:
-          - "<name> [<din> <area>] <este> {on_off_states:state}"
-          - "<este> {on_off_states:state} <name> [<din> <area>]"
+          - "<name> [<din> <area>] e[ste] {on_off_states_singular:state}"
+          - "e[ste] {on_off_states_singular:state} <name> [<din> <area>]"
         response: one_yesno
         excludes_context:
           domain:
             - cover
 
       - sentences:
-          - "(<este> | exist(ă|a)) [<vreun>] {on_off_domains:domain} {on_off_states:state} [<in> <area>]"
+          - "(e[ste] | exist(ă|a)) [<vreun>] {on_off_domains_singular:domain} {on_off_states_singular:state} [<in> <area>]"
+          - "(sunt | exist(ă|a)) {on_off_domains_plural:domain} {on_off_states_plural:state} [<in> <area>]"
         response: any
 
       - sentences:
-          - "sunt (to(ț|t)i | toate) {on_off_domains:domain} {on_off_states:state} [<in> <area>]"
-          - "sunt {on_off_states:state} (to(ț|t)i | toate) {on_off_domains:domain} [<in> <area>]"
-          - "(to(ț|t)i | toate) {on_off_domains:domain} sunt {on_off_states:state} [<in> <area>]"
+          # every on/off domain is either feminine or neutral, so "toate" is the only option for plural
+          - "sunt toate {on_off_domains_plural:domain} {on_off_states_plural:state} [<in> <area>]"
+          - "sunt {on_off_states_plural:state} toate {on_off_domains_plural:domain} [<in> <area>]"
+          - "toate {on_off_domains_plural:domain} sunt {on_off_states_plural:state} [<in> <area>]"
         response: all
 
       - sentences:
-          - "(care | ce) {on_off_domains:domain} <este> {on_off_states:state} [<in> <area>]"
+          - "<care> {on_off_domains_singular:domain} e[ste] {on_off_states_singular:state} [<in> <area>]"
+          - "<care> {on_off_domains_plural:domain} sunt {on_off_states_plural:state} [<in> <area>]"
         response: which
 
       - sentences:
-          - "<cate> {on_off_domains:domain} <este> {on_off_states:state} [<in> <area>]"
+          - "<cate> {on_off_domains_plural:domain} sunt {on_off_states_plural:state} [<in> <area>]"
         response: how_many

--- a/sentences/ro/light_HassGetState.yaml
+++ b/sentences/ro/light_HassGetState.yaml
@@ -1,0 +1,38 @@
+language: ro
+intents:
+  HassGetState:
+    data:
+      - sentences:
+          - "<name> [<din> <area>] e[ste] {on_off_states_singular:state}"
+          - "e[ste] {on_off_states_singular:state} <name> [<din> <area>]"
+        response: one_yesno
+        requires_context:
+          domain: light
+
+      - sentences:
+          - "(e[ste] | exist(ă|a)) [<vreun>] <lumina> {on_off_states_singular:state} [<in> <area>]"
+          - "(sunt | exist(ă|a)) <luminile> {on_off_states_plural:state} [<in> <area>]"
+        response: any
+        requires_context:
+          domain: light
+
+      - sentences:
+          # every light domain alias is either feminine or neutral, so "toate" is the only option for plural
+          - "sunt toate <luminile> {on_off_states_plural:state} [<in> <area>]"
+          - "toate <luminile> sunt {on_off_states_plural:state} [<in> <area>]"
+        response: all
+        requires_context:
+          domain: light
+
+      - sentences:
+          - "<care> <lumina> e[ste] {on_off_states_singular:state} [<in> <area>]"
+          - "<care> <luminile> sunt {on_off_states_plural:state} [<in> <area>]"
+        response: which
+        requires_context:
+          domain: light
+
+      - sentences:
+          - "<cate> <luminile> sunt {on_off_states_plural:state} [<in> <area>]"
+        response: how_many
+        requires_context:
+          domain: light

--- a/sentences/ro/light_HassLightSet.yaml
+++ b/sentences/ro/light_HassLightSet.yaml
@@ -51,4 +51,4 @@ intents:
           - "[<seteaza>] [<culoarea>] [<din>] <area> [<in> | la] [<culoarea>] {color}"
           - "[<seteaza>] <culoarea> [<in> | la] {color} [<din>] <area>"
           - "[<seteaza>] [<in> | la] {color} [<culoarea>] [<din>] <area>"
-        response: color_area
+        response: color

--- a/sentences/ro/light_HassTurnOff.yaml
+++ b/sentences/ro/light_HassTurnOff.yaml
@@ -10,13 +10,13 @@ intents:
           domain: light
         response: light
       - sentences:
-          - "<opreste> [toate] <lumina> [<din>] <area>"
-          - "<opreste> [<din>] <area> [toate] <lumina>"
+          - "<opreste> (<lumina> | [toate] <luminile>) [<din>] <area>"
+          - "<opreste> [<din>] <area> (<lumina> | [toate] <luminile>)"
         slots:
           domain: light
         response: lights_area
       - sentences:
-          - "<opreste> [toate] <lumina>"
+          - "<opreste> (<lumina> | [toate] <luminile>)"
         slots:
           domain: light
         requires_context:

--- a/sentences/ro/light_HassTurnOn.yaml
+++ b/sentences/ro/light_HassTurnOn.yaml
@@ -10,13 +10,13 @@ intents:
           domain: light
         response: light
       - sentences:
-          - "<porneste> [toate] <lumina> [<din>] <area>"
-          - "<porneste> [<din>] <area> [toate] <lumina>"
+          - "<porneste> (<lumina> | [toate] <luminile>) [<din>] <area>"
+          - "<porneste> [<din>] <area> (<lumina> | [toate] <luminile>)"
         slots:
           domain: light
         response: lights_area
       - sentences:
-          - "<porneste> [toate] <lumina>"
+          - "<porneste> (<lumina> | [toate] <luminile>)"
         slots:
           domain: light
         requires_context:

--- a/tests/ro/cover_HassGetState.yaml
+++ b/tests/ro/cover_HassGetState.yaml
@@ -10,10 +10,23 @@ tests:
         state: "closed"
       context:
         domain: cover
-    response: "Nu, fereastra din stanga este deschis"
+    response: "Nu, este deschis"
+  - sentences:
+      - "fereastra din stanga de la dormitor este inchisa?"
+      - "este inchisa fereastra din stanga din dormitor?"
+    intent:
+      name: HassGetState
+      slots:
+        name: "fereastra din stanga"
+        state: "closed"
+        area: "Dormitor"
+      context:
+        domain: cover
+    response: "Nu, este deschis"
 
   - sentences:
       - "este vreo fereastra deschisa in dormitor?"
+      - "sunt ferestre deschise in dormitor?"
     intent:
       name: HassGetState
       slots:
@@ -39,6 +52,7 @@ tests:
 
   - sentences:
       - "care ferestre sunt deschise?"
+      - "care fereastra este deschisa?"
     intent:
       name: HassGetState
       slots:

--- a/tests/ro/cover_HassTurnOff.yaml
+++ b/tests/ro/cover_HassTurnOff.yaml
@@ -1,6 +1,15 @@
 language: ro
 tests:
   - sentences:
+      - "inchide usa principala"
+    intent:
+      name: HassTurnOff
+      slots:
+        name: "usa principala"
+      context:
+        domain: cover
+    response: "Am închis"
+  - sentences:
       - "inchide usa principala de la intrare"
     intent:
       name: HassTurnOff
@@ -9,7 +18,8 @@ tests:
         area: "Intrare"
       context:
         domain: cover
-    response: "Am închis usa principala"
+    response: "Am închis"
+
   - sentences:
       - "inchide toate usile din hol"
     intent:
@@ -18,7 +28,7 @@ tests:
         area: "Hol"
         device_class: door
         domain: cover
-    response: "Am închis usile de la hol"
+    response: "Am închis usile"
   - sentences:
       - "inchide toate ferestrele din dormitor"
     intent:
@@ -27,7 +37,7 @@ tests:
         area: "Dormitor"
         device_class: window
         domain: cover
-    response: "Am închis ferestrele de la dormitor"
+    response: "Am închis ferestrele"
   - sentences:
       - "inchide toate jaluzelele de la dormitor"
     intent:
@@ -36,7 +46,7 @@ tests:
         area: "Dormitor"
         device_class: blind
         domain: cover
-    response: "Am închis jaluzelele de la dormitor"
+    response: "Am închis jaluzelele"
   - sentences:
       - "inchide portile din curte"
     intent:
@@ -45,4 +55,4 @@ tests:
         area: "Curte"
         device_class: gate
         domain: cover
-    response: "Am închis portile de la curte"
+    response: "Am închis portile"

--- a/tests/ro/cover_HassTurnOn.yaml
+++ b/tests/ro/cover_HassTurnOn.yaml
@@ -21,7 +21,7 @@ tests:
         domain: cover
         device_class: door
     response: "Am deschis"
-    
+
   - sentences:
       - "deschide toate usile din hol"
     intent:

--- a/tests/ro/cover_HassTurnOn.yaml
+++ b/tests/ro/cover_HassTurnOn.yaml
@@ -1,15 +1,25 @@
 language: ro
 tests:
   - sentences:
-      - "deschide usa principala din bucatarie"
+      - "deschide usa principala"
     intent:
       name: HassTurnOn
       slots:
         name: "usa principala"
-        area: "Bucatarie"
       context:
         domain: cover
-    response: "Am deschis usa principala"
+    response: "Am deschis"
+  - sentences:
+      - "deschide usa principala de la intrare"
+    intent:
+      name: HassTurnOn
+      slots:
+        name: "usa principala"
+        area: "Intrare"
+      context:
+        domain: cover
+    response: "Am deschis"
+
   - sentences:
       - "deschide toate usile din hol"
     intent:
@@ -18,7 +28,7 @@ tests:
         area: "Hol"
         device_class: door
         domain: cover
-    response: "Am deschis usile de la hol"
+    response: "Am deschis usile"
   - sentences:
       - "deschide toate ferestrele din dormitor"
     intent:
@@ -27,7 +37,7 @@ tests:
         area: "Dormitor"
         device_class: window
         domain: cover
-    response: "Am deschis ferestrele de la dormitor"
+    response: "Am deschis ferestrele"
   - sentences:
       - "deschide toate jaluzelele din dormitor"
     intent:
@@ -36,7 +46,7 @@ tests:
         area: "Dormitor"
         device_class: blind
         domain: cover
-    response: "Am deschis jaluzelele de la dormitor"
+    response: "Am deschis jaluzelele"
   - sentences:
       - "deschide portile din curte"
     intent:
@@ -45,4 +55,4 @@ tests:
         area: "Curte"
         device_class: gate
         domain: cover
-    response: "Am deschis portile de la curte"
+    response: "Am deschis portile"

--- a/tests/ro/fan_HassTurnOff.yaml
+++ b/tests/ro/fan_HassTurnOff.yaml
@@ -1,7 +1,16 @@
 language: ro
 tests:
   - sentences:
-      - "oprește ventilatorul din sufragerie"
+      - "oprește toate ventilatoarele din sufragerie"
+    intent:
+      name: HassTurnOff
+      slots:
+        area:
+          - "Sufragerie"
+          - "Camera de zi"
+        domain: fan
+    response: "Am oprit ventilatoarele"
+  - sentences:
       - "dezactiveaza aerisirea de la sufragerie"
     intent:
       name: HassTurnOff
@@ -10,7 +19,7 @@ tests:
           - "Sufragerie"
           - "Camera de zi"
         domain: fan
-    response: "Am oprit ventilatoarele de la sufragerie"
+    response: "Am oprit ventilatoarele"
   - sentences:
       - "oprește aerisirea"
       - "dezactiveaza ventilatorul"

--- a/tests/ro/fan_HassTurnOn.yaml
+++ b/tests/ro/fan_HassTurnOn.yaml
@@ -2,6 +2,15 @@ language: ro
 tests:
   - sentences:
       - "pornește ventilatorul din sufragerie"
+    intent:
+      name: HassTurnOn
+      slots:
+        area:
+          - "Sufragerie"
+          - "Camera de zi"
+        domain: fan
+    response: "Am pornit ventilatoarele"
+  - sentences:
       - "activeaza aerisirea de la sufragerie"
     intent:
       name: HassTurnOn
@@ -10,7 +19,7 @@ tests:
           - "Sufragerie"
           - "Camera de zi"
         domain: fan
-    response: "Am pornit ventilatoarele de la sufragerie"
+    response: "Am pornit ventilatoarele"
   - sentences:
       - "porneste aerisirea"
       - "activeaza ventilatorul"

--- a/tests/ro/homeassistant_HassGetState.yaml
+++ b/tests/ro/homeassistant_HassGetState.yaml
@@ -8,6 +8,15 @@ tests:
       slots:
         name: "temperatura exterioara"
     response: "Temperatura exterioara este 21 °C"
+  - sentences:
+      - "cat este temperatura exterioara din curte"
+      - "ce stare are temperatura exterioara din curte"
+    intent:
+      name: HassGetState
+      slots:
+        name: "temperatura exterioara"
+        area: "Curte"
+    response: "Temperatura exterioara este 21 °C"
 
   - sentences:
       - "lustra este pornita?"
@@ -17,7 +26,7 @@ tests:
       slots:
         name: "lustra"
         state: "on"
-    response: "Nu, lustra este oprit"
+    response: "Nu, este oprit"
   - sentences:
       - "lustra din dormitor este aprinsa?"
     intent:
@@ -26,9 +35,10 @@ tests:
         name: "lustra"
         state: "on"
         area: "Dormitor"
-    response: "Nu, lustra este oprit"
+    response: "Nu, este oprit"
 
   - sentences:
+      - "exista vreo lumina aprinsa in hol?"
       - "sunt lumini aprinse in hol?"
     intent:
       name: HassGetState
@@ -40,6 +50,7 @@ tests:
 
   - sentences:
       - "sunt toate luminile aprinse?"
+      - "sunt aprinse toate luminile?"
       - "toate luminile sunt aprinse?"
     intent:
       name: HassGetState
@@ -49,6 +60,7 @@ tests:
     response: "Nu, lustra și Spot 3 nu sunt aprinse"
 
   - sentences:
+      - "ce lumina este aprinsa?"
       - "care lumini sunt aprinse?"
     intent:
       name: HassGetState

--- a/tests/ro/light_HassGetState.yaml
+++ b/tests/ro/light_HassGetState.yaml
@@ -1,0 +1,70 @@
+language: ro
+tests:
+  - sentences:
+      - "plafoniera neagra este inchisa?"
+      - "este stinsa plafoniera neagra?"
+    intent:
+      name: HassGetState
+      slots:
+        name: "plafoniera neagra"
+        state: "off"
+      context:
+        domain: light
+    response: "Nu, plafoniera neagra este aprinsă"
+  - sentences:
+      - "plafoniera neagra de la hol este stinsa?"
+      - "este inchisa plafoniera neagra din hol?"
+    intent:
+      name: HassGetState
+      slots:
+        name: "plafoniera neagra"
+        state: "off"
+        area: "Hol"
+      context:
+        domain: light
+    response: "Nu, plafoniera neagra este aprinsă"
+
+  - sentences:
+      - "este vreo lumina aprinsa in dormitor?"
+      - "sunt becuri pornite in dormitor?"
+    intent:
+      name: HassGetState
+      slots:
+        area: "Dormitor"
+        state: "on"
+      context:
+        domain: light
+    response: "Nu"
+
+  - sentences:
+      - "sunt toate luminile stinse in hol?"
+      - "toate becurile sunt oprite in hol?"
+    intent:
+      name: HassGetState
+      slots:
+        area: "Hol"
+        state: "off"
+      context:
+        domain: light
+    response: "Nu, plafoniera neagra nu este"
+
+  - sentences:
+      - "care lumini sunt aprinse?"
+      - "care lumina este pornita?"
+    intent:
+      name: HassGetState
+      slots:
+        state: "on"
+      context:
+        domain: light
+    response: "plafoniera neagra, Spot 1, Spot 2 și încă 2"
+
+  - sentences:
+      - "cate lumini sunt aprinse?"
+    intent:
+      name: HassGetState
+      slots:
+        state: "on"
+      context:
+        domain: light
+    response: "5"

--- a/tests/ro/light_HassLightSet.yaml
+++ b/tests/ro/light_HassLightSet.yaml
@@ -3,31 +3,32 @@ tests:
   # brightness
   - sentences:
       - "schimba luminozitatea pentru plafoniera neagra la 50 la suta"
-      - "modifică plafoniera neagra la luminozitatea de 50 %"
-      - "seteaza la 50% luminozitatea de la plafoniera neagra"
+      - "modifică plafoniera neagra la luminozitatea de 50%"
+      - "seteaza la 50 luminozitatea de la plafoniera neagra"
+      - "luminozitate plafoniera neagra 50 de procente"
       - "seteaza plafoniera neagra la 50 la suta"
+      - "plafoniera neagra 50 procente"
     intent:
       name: HassLightSet
       slots:
         brightness: 50
         name: "plafoniera neagra"
-    response:
-      - "Luminozitatea pentru plafoniera neagra a fost modificată la 50 la sută"
-      - "Luminozitatea pentru plafoniera neagra a fost modificată la 50% la sută"
+    response: "Luminozitatea a fost modificată"
+
   - sentences:
       - "schimba luminozitatea pentru garaj la 50 la suta"
-      - "modifica luminozitate garaj la 50 %"
-      - "seteaza la 50% luminozitatea de la garaj"
+      - "luminozitate garaj 50 procente"
+      - "modifica luminozitate garaj la valoarea de 50 %"
+      - "seteaza la 50 luminozitatea de la garaj"
     intent:
       name: HassLightSet
       slots:
         brightness: 50
         area: "Garaj"
-    response:
-      - "Luminozitatea în garaj a fost modificată la 50 la sută"
-      - "Luminozitatea în garaj a fost modificată la 50% la sută"
+    response: "Luminozitatea a fost modificată"
   - sentences:
       - "schimba luminozitatea pentru plafoniera neagra la maximum"
+      - "plafoniera neagra luminozitate maxima"
       - "modifică plafoniera neagra la luminozitatea maxima"
       - "seteaza la maxim luminozitatea de la plafoniera neagra"
       - "seteaza plafoniera neagra la maximum"
@@ -36,10 +37,10 @@ tests:
       slots:
         brightness: 100
         name: "plafoniera neagra"
-    response:
-      - "Luminozitatea pentru plafoniera neagra a fost modificată la 100%"
+    response: "Luminozitatea a fost modificată la 100%"
   - sentences:
       - "schimba luminozitatea pentru garaj la valoarea maxima posibila"
+      - "luminozitate garaj maximum"
       - "seteaza garaj la luminozitatea maxima"
       - "seteaza la maximum luminozitatea de la garaj"
     intent:
@@ -47,8 +48,7 @@ tests:
       slots:
         brightness: 100
         area: "Garaj"
-    response:
-      - "Luminozitatea în garaj a fost modificată la 100%"
+    response: "Luminozitatea a fost modificată la 100%"
   - sentences:
       - "schimba luminozitatea pentru plafoniera neagra la minimum"
       - "modifică plafoniera neagra la luminozitatea minima"
@@ -59,7 +59,7 @@ tests:
         brightness: 1
         name: "plafoniera neagra"
     response:
-      - "Luminozitatea pentru plafoniera neagra a fost modificată la 1%"
+      - "Luminozitatea a fost modificată la 1%"
   - sentences:
       - "seteaza plafoniera neagra la jumatate"
     intent:
@@ -68,7 +68,7 @@ tests:
         brightness: 50
         name: "plafoniera neagra"
     response:
-      - "Luminozitatea pentru plafoniera neagra a fost modificată la 50%"
+      - "Luminozitatea a fost modificată la 50%"
   - sentences:
       - "schimba luminozitatea pentru garaj la valoarea minima posibila"
       - "seteaza garaj la luminozitatea minima"
@@ -79,7 +79,7 @@ tests:
         brightness: 1
         area: "Garaj"
     response:
-      - "Luminozitatea în garaj a fost modificată la 1%"
+      - "Luminozitatea a fost modificată la 1%"
 
   # color
   - sentences:
@@ -92,7 +92,7 @@ tests:
       slots:
         color: green
         name: "plafoniera neagra"
-    response: "Culoarea pentru plafoniera neagra a fost modificată în verde"
+    response: "Culoarea a fost modificată"
   - sentences:
       - "schimba culoarea din sufragerie in verde"
       - "schimba in sufragerie in verde"
@@ -105,4 +105,4 @@ tests:
         area:
           - "Sufragerie"
           - "Camera de zi"
-    response: "Culoarea luminilor din sufragerie a fost modificată în verde"
+    response: "Culoarea a fost modificată"

--- a/tests/ro/light_HassTurnOff.yaml
+++ b/tests/ro/light_HassTurnOff.yaml
@@ -7,23 +7,25 @@ tests:
       slots:
         name: plafoniera neagra
         domain: light
-    response: "Am stins plafoniera neagra"
+      context:
+        domain: light
+    response: "Am stins lumina"
   - sentences:
       - "stinge lumina din garaj"
       - "oprește lumina din garaj"
-      - "stop lumina din garaj"
-      - "închide lumina din garaj"
+      - "stop luminile din garaj"
+      - "închide toate luminile din garaj"
     intent:
       name: HassTurnOff
       slots:
         area: "Garaj"
         domain: light
-    response: "Am stins luminile de la garaj"
+    response: "Am stins luminile"
   - sentences:
       - "stinge lumina din sufragerie"
       - "oprește lumina din sufragerie"
-      - "stop lumina din sufragerie"
-      - "închide lumina din sufragerie"
+      - "stop luminile din sufragerie"
+      - "închide toate luminile din sufragerie"
     intent:
       name: HassTurnOff
       slots:
@@ -31,7 +33,7 @@ tests:
           - "Sufragerie"
           - "Camera de zi"
         domain: light
-    response: "Am stins luminile de la sufragerie"
+    response: "Am stins luminile"
   - sentences:
       - "opreste lumina"
     intent:

--- a/tests/ro/light_HassTurnOn.yaml
+++ b/tests/ro/light_HassTurnOn.yaml
@@ -7,23 +7,25 @@ tests:
       slots:
         name: plafoniera neagra
         domain: light
-    response: "Am aprins plafoniera neagra"
+      context:
+        domain: light
+    response: "Am aprins lumina"
   - sentences:
       - "start lumina din garaj"
       - "pornește lumina din garaj"
-      - "deschide lumina din garaj"
-      - "aprinde lumina din garaj"
+      - "deschide luminile din garaj"
+      - "aprinde toate luminile din garaj"
     intent:
       name: HassTurnOn
       slots:
         area: "Garaj"
         domain: light
-    response: "Am aprins luminile de la garaj"
+    response: "Am aprins luminile"
   - sentences:
       - "start lumina din sufragerie"
       - "pornește lumina din sufragerie"
-      - "deschide lumina din sufragerie"
-      - "aprinde lumina din sufragerie"
+      - "deschide luminile din sufragerie"
+      - "aprinde toate luminile din sufragerie"
     intent:
       name: HassTurnOn
       slots:
@@ -31,7 +33,7 @@ tests:
           - "Sufragerie"
           - "Camera de zi"
         domain: light
-    response: "Am aprins luminile de la sufragerie"
+    response: "Am aprins luminile"
   - sentences:
       - "porneste lumina"
     intent:


### PR DESCRIPTION
Drastically reduced the amount of grammatically incorrect sentences that are allowed by simply separating the singular/plural forms of domains, device classes, states etc. and only allowing correctly worded sentences.