### PR TITLE
Bump to hassil 1.0.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hassil==1.0.5
+hassil==1.0.6
 PyYAML==6.0
 voluptuous==0.13.1
 regex==2022.10.31

--- a/sentences/ro/homeassistant_HassGetState.yaml
+++ b/sentences/ro/homeassistant_HassGetState.yaml
@@ -18,6 +18,7 @@ intents:
         excludes_context:
           domain:
             - cover
+            - binary_sensor
 
       - sentences:
           - "(e[ste] | exist(ă|a)) [<vreun>] {on_off_domains_singular:domain} {on_off_states_singular:state} [<in> <area>]"


### PR DESCRIPTION
This adds a requires/excludes context check *before* matching, so sentence templates with mismatched constraints can be skipped over during tests.

In the future, this should be extended to slot lists so that entities which can't possibly match the current intent are not checked during matching.