### PR TITLE
[NB] Fix light response bug

### DIFF
--- a/sentences/nb/light_HassTurnOff.yaml
+++ b/sentences/nb/light_HassTurnOff.yaml
@@ -11,6 +11,6 @@ intents:
           name: all
         response: lights_area
       - sentences:
-          - "<skru_på> <lys> <navn>"
+          - "<skru_av> <lys> <navn>"
         slots:
           domain: light

--- a/sentences/nb/light_HassTurnOff.yaml
+++ b/sentences/nb/light_HassTurnOff.yaml
@@ -9,3 +9,8 @@ intents:
         slots:
           domain: light
           name: all
+        response: lights_area
+      - sentences:
+          - "<skru_på> <lys> <navn>"
+        slots:
+          domain: light

--- a/sentences/nb/light_HassTurnOn.yaml
+++ b/sentences/nb/light_HassTurnOn.yaml
@@ -9,6 +9,7 @@ intents:
         slots:
           domain: light
           name: all
+        response: lights_area
       - sentences:
           - "<skru_på> <lys> <navn>"
         slots:

--- a/tests/nb/light_HassTurnOff.yaml
+++ b/tests/nb/light_HassTurnOff.yaml
@@ -40,6 +40,7 @@ tests:
         area: Kjøkken
         domain: light
         name: all
+    response: "Slo av lys"
   - sentences:
       - slukk lys på soverom
       - slukk lys på soverommet
@@ -59,6 +60,7 @@ tests:
         area: Soverom
         domain: light
         name: all
+    response: "Slo av lys"
   - sentences:
       - Skru av lyset i stue
     intent:
@@ -67,3 +69,4 @@ tests:
         area: Stue
         domain: light
         name: all
+    response: "Slo av lys"

--- a/tests/nb/light_HassTurnOn.yaml
+++ b/tests/nb/light_HassTurnOn.yaml
@@ -42,6 +42,7 @@ tests:
         area: Kjøkken
         domain: light
         name: all
+    response: "Slo på lys"
   - sentences:
       - tenn lys på soverom
       - tenn lys på soverommet
@@ -61,6 +62,7 @@ tests:
         area: Soverom
         domain: light
         name: all
+    response: "Slo på lys"
   - sentences:
       - Skru på lyset i stue
     intent:
@@ -69,3 +71,4 @@ tests:
         area: Stue
         domain: light
         name: all
+    response: "Slo på lys"


### PR DESCRIPTION
This PR will fix an issue with turning on/off lights.

When I ran this command:
```bash
python3 -m script.intentfest parse --language nb --sentence "skru på lys i garasje"
```

I got this error:
```bash
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/Users/stale/private_projects/home-assistant/intents/script/intentfest/__main__.py", line 29, in <module>
    sys.exit(main())
  File "/Users/stale/private_projects/home-assistant/intents/script/intentfest/__main__.py", line 24, in main
    return module.run()
  File "/Users/stale/private_projects/home-assistant/intents/script/intentfest/parse.py", line 89, in run
    render_response(response_template, result, matched, unmatched)
  File "/Users/stale/private_projects/home-assistant/intents/shared/__init__.py", line 177, in render_response
    return env.from_string(response_template).render(
  File "/Users/stale/private_projects/home-assistant/intents/venv/lib/python3.10/site-packages/jinja2/environment.py", line 1301, in render
    self.environment.handle_exception()
  File "/Users/stale/private_projects/home-assistant/intents/venv/lib/python3.10/site-packages/jinja2/environment.py", line 936, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "<template>", line 1, in top-level template code
jinja2.exceptions.UndefinedError: 'None' has no attribute 'domain'
```

This PR will also remove these warnings:

```bash
[WARN] tests/nb/light_HassTurnOff.yaml: 3 test(s) missing response check
[WARN] tests/nb/light_HassTurnOn.yaml: 3 test(s) missing response check
```

Had to add a response for `light_HassTurnOn.yaml` and `light_HassTurnOff.yaml`.