### PR TITLE
[NL] Expansion rules <name_area> and <met>

### DIFF
--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -311,13 +311,19 @@ expansion_rules:
   # generic expansion rules for sentences
   name: "[de|het] {name}"
   area: "[de|het] {area}"
+  in: "[in|op|van|bij]"
+  name_area: >
+    (
+      [[door|met|bij] [de|het] {area}][ ]{name}
+      |[<in> [de|het] {area}] [door|met|bij] <name>
+      |[door|met|bij] [de|het] {name} [[in|op|van|bij] <area>]
+    )
   doe: "(zet[ten]|mag|mogen|doe[n]|verander[en]|maak|maken|schakel[en])"
   zou: "(kan|kun[t]|zal|zou) [je|jij|u]"
   naar: "(naar|op)"
   detecteer: "(detecteert|registreert|detecteren|registereren|gedetecteerd|geregistreerd|waar[ ]genomen)"
   sensor: "[een|de] (apparaat|apparaten|sensor[s|en])"
   is: "(zijn|is|staa(n|t)|zit[ten]|word[t|en]|lig(t|gen))"
-  in: "[in|op|van|bij]"
   alle: "(alle|elk[e]|ieder[e]|overal)"
   staat: "(status|staat|stand)"
   # cover deivce classes

--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -312,11 +312,12 @@ expansion_rules:
   name: "[de|het] {name}"
   area: "[de|het] {area}"
   in: "[in|op|van|bij]"
+  met: "(door|met|bij)"
   name_area: >
     (
       [[door|met|bij] [de|het] {area}][ ]{name}
       |[<in> [de|het] {area}] [door|met|bij] <name>
-      |[door|met|bij] [de|het] {name} [[in|op|van|bij] <area>]
+      |[<met>] [de|het] {name} [[in|op|van|bij] <area>]
     )
   doe: "(zet[ten]|mag|mogen|doe[n]|verander[en]|maak|maken|schakel[en])"
   zou: "(kan|kun[t]|zal|zou) [je|jij|u]"

--- a/sentences/nl/binary_sensor_HassGetState.yaml
+++ b/sentences/nl/binary_sensor_HassGetState.yaml
@@ -24,10 +24,10 @@ intents:
           device_class: battery_charging
 
       - sentences:
-          - "<detecteer> [door|met] <name_area> {bs_carbon_monoxide_states:state} [<in> <area>]"
+          - "<detecteer> [<met>] <name_area> {bs_carbon_monoxide_states:state} [<in> <area>]"
           - "neemt <name_area> {bs_carbon_monoxide_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
-          - "<is> [er] [<in> <area>] {bs_carbon_monoxide_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
-          - "<is> [er] [<in> <area>] {bs_carbon_monoxide_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
+          - "<is> [er] [<in> <area>] {bs_carbon_monoxide_states:state} <detecteer> <name_area>"
+          - "<is> [er] [<in> <area>] {bs_carbon_monoxide_states:state} <met> [<area>][ ]<name> <detecteer> [<in> <area>]"
           - "<is> [er] <name_area> {bs_carbon_monoxide_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:
@@ -38,10 +38,10 @@ intents:
           device_class: carbon_monoxide
 
       - sentences:
-          - "(is|<detecteer>) [er] <in>[door|met] [<area>][ ]<name> [<in> <area>] {bs_cold_states:state} [<in> <area>]"
+          - "(is|<detecteer>) [er] [<in>|<met>] [<area>][ ]<name> [<in> <area>] {bs_cold_states:state} [<in> <area>]"
           - "neemt <name_area> {bs_cold_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
-          - "<is> [er] [<in> <area>] {bs_cold_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
-          - "<is> [er] [<in> <area>] {bs_cold_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
+          - "<is> [er] [<in> <area>] {bs_cold_states:state} <detecteer> <name_area>"
+          - "<is> [er] [<in> <area>] {bs_cold_states:state} <met> [<area>][ ]<name> <detecteer> [<in> <area>]"
           - "<is> [er] <name_area>  {bs_cold_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:
@@ -82,10 +82,10 @@ intents:
           device_class: garage_door
 
       - sentences:
-          - "<detecteer> [in|op|van|bij|door|met] [<area>][ ]<name> [<in> <area>] {bs_gas_states:state} [<in> <area>]"
+          - "<detecteer> [<in>|<met>] [<area>][ ]<name> [<in> <area>] {bs_gas_states:state} [<in> <area>]"
           - "neemt <name_area> {bs_gas_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
-          - "<is> [er] [<in> <area>] {bs_gas_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
-          - "<is> [er] [<in> <area>] {bs_gas_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
+          - "<is> [er] [<in> <area>] {bs_gas_states:state} <detecteer> <name_area>"
+          - "<is> [er] [<in> <area>] {bs_gas_states:state} <met> [<area>][ ]<name> <detecteer> [<in> <area>]"
           - "<is> [er] <name_area> {bs_gas_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:
@@ -96,10 +96,10 @@ intents:
           device_class: gas
 
       - sentences:
-          - "(<is>|<detecteer>) [er] [in|op|van|bij|door|met] [<area>][ ]<name> [<in> <area>] {bs_heat_states:state} [<in> <area>]"
+          - "(<is>|<detecteer>) [er] [<in>|<met>] [<area>][ ]<name> [<in> <area>] {bs_heat_states:state} [<in> <area>]"
           - "neemt <name_area> {bs_heat_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
-          - "<is> [er] [<in> <area>] {bs_heat_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
-          - "<is> [er] [<in> <area>] {bs_heat_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
+          - "<is> [er] [<in> <area>] {bs_heat_states:state} <detecteer> <name_area>"
+          - "<is> [er] [<in> <area>] {bs_heat_states:state} <met> [<area>][ ]<name> <detecteer> [<in> <area>]"
           - "<is> [er] <name_area> {bs_heat_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:
@@ -110,10 +110,10 @@ intents:
           device_class: heat
 
       - sentences:
-          - "(<is>|<detecteer>) [er] [in|op|van|bij|door|met] [<area>][ ]<name> [<in> <area>] {bs_light_states:state} [<in> <area>]"
+          - "(<is>|<detecteer>) [er] [<in>|<met>] [<area>][ ]<name> [<in> <area>] {bs_light_states:state} [<in> <area>]"
           - "neemt <name_area> {bs_light_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
-          - "<is> [er] [<in> <area>] {bs_light_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
-          - "<is> [er] [<in> <area>] {bs_light_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
+          - "<is> [er] [<in> <area>] {bs_light_states:state} <detecteer> <name_area>"
+          - "<is> [er] [<in> <area>] {bs_light_states:state} <met> [<area>][ ]<name> <detecteer> [<in> <area>]"
           - "<is> [er] <name_area> {bs_light_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:
@@ -134,10 +134,10 @@ intents:
           device_class: lock
 
       - sentences:
-          - "(<is>|<detecteer>) [in|op|van|bij|door|met] [<area>][ ]<name> [<in> <area>] {bs_moisture_states:state} [<in> <area>]"
+          - "(<is>|<detecteer>) [<in>|<met>] [<area>][ ]<name> [<in> <area>] {bs_moisture_states:state} [<in> <area>]"
           - "neemt <name_area> {bs_moisture_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
-          - "<is> [er] [<in> <area>] {bs_moisture_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
-          - "<is> [er] [<in> <area>] {bs_moisture_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
+          - "<is> [er] [<in> <area>] {bs_moisture_states:state} <detecteer> <name_area>"
+          - "<is> [er] [<in> <area>] {bs_moisture_states:state} <met> [<area>][ ]<name> <detecteer> [<in> <area>]"
           - "<is> [er] <name_area> {bs_moisture_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:
@@ -148,10 +148,10 @@ intents:
           device_class: moisture
 
       - sentences:
-          - "<detecteer> [er] [in|op|van|bij|door|met] [<area>][ ]<name> [<in> <area>] {bs_motion_states:state} [<in> <area>]"
+          - "<detecteer> [er] [<in>|<met>] [<area>][ ]<name> [<in> <area>] {bs_motion_states:state} [<in> <area>]"
           - "neemt <name_area> {bs_motion_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
-          - "<is> [er] [<in> <area>] {bs_motion_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
-          - "<is> [er] [<in> <area>] {bs_motion_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
+          - "<is> [er] [<in> <area>] {bs_motion_states:state} <detecteer> <name_area>"
+          - "<is> [er] [<in> <area>] {bs_motion_states:state} <met> [<area>][ ]<name> <detecteer> [<in> <area>]"
           - "<is> [er] <name_area> {bs_motion_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:
@@ -162,10 +162,10 @@ intents:
           device_class: motion
 
       - sentences:
-          - "<detecteer> [er] [in|op|van|bij|door|met] [<area>][ ]<name> [<in> <area>] {bs_occupancy_states:state} [<in> <area>]"
+          - "<detecteer> [er] [<in>|<met>] [<area>][ ]<name> [<in> <area>] {bs_occupancy_states:state} [<in> <area>]"
           - "neemt <name_area> {bs_occupancy_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
-          - "(is|zijn|word[t|en]) [er] [<in> <area>] {bs_occupancy_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
-          - "(is|zijn|wordt[t|en]) [er] [<in> <area>] {bs_occupancy_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
+          - "(is|zijn|word[t|en]) [er] [<in> <area>] {bs_occupancy_states:state} <detecteer> <name_area>"
+          - "(is|zijn|wordt[t|en]) [er] [<in> <area>] {bs_occupancy_states:state} <met> [<area>][ ]<name> <detecteer> [<in> <area>]"
           - "<is> [er] <name_area> {bs_occupancy_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:
@@ -197,10 +197,10 @@ intents:
           device_class: plug
 
       - sentences:
-          - "(<is>|<detecteer>) [er] [in|op|van|bij|door|met] [<area>][ ]<name> [<in> <area>] {bs_power_states:state} [<in> <area>]"
+          - "(<is>|<detecteer>) [er] [<in>|<met>] [<area>][ ]<name> [<in> <area>] {bs_power_states:state} [<in> <area>]"
           - "neemt <name_area> {bs_power_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
-          - "<is> [er] [<in> <area>] {bs_power_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
-          - "<is> [er] [<in> <area>] {bs_power_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
+          - "<is> [er] [<in> <area>] {bs_power_states:state} <detecteer> <name_area>"
+          - "<is> [er] [<in> <area>] {bs_power_states:state} <met> [<area>][ ]<name> <detecteer> [<in> <area>]"
           - "<is> [er] <name_area> {bs_power_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:
@@ -254,10 +254,10 @@ intents:
           device_class: safety
 
       - sentences:
-          - "(<is>|<detecteer>) [er] [in|op|van|bij|door|met] [<area>][ ]<name> [<in> <area>] {bs_smoke_states:state} [<in> <area>]"
+          - "(<is>|<detecteer>) [er] [<in>|<met>] [<area>][ ]<name> [<in> <area>] {bs_smoke_states:state} [<in> <area>]"
           - "neemt <name_area> {bs_smoke_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
-          - "<is> [er] [<in> <area>] {bs_smoke_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
-          - "<is> [er] [<in> <area>] {bs_smoke_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
+          - "<is> [er] [<in> <area>] {bs_smoke_states:state} <detecteer> <name_area>"
+          - "<is> [er] [<in> <area>] {bs_smoke_states:state} <met> [<area>][ ]<name> <detecteer> [<in> <area>]"
           - "<is> [er] <name_area> {bs_smoke_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:
@@ -268,10 +268,10 @@ intents:
           device_class: smoke
 
       - sentences:
-          - "(<is>|<detecteer>) [er] [in|op|van|bij|door|met] [<area>][ ]<name> [<in> <area>] {bs_sound_states:state} [<in> <area>]"
+          - "(<is>|<detecteer>) [er] [<in>|<met>] [<area>][ ]<name> [<in> <area>] {bs_sound_states:state} [<in> <area>]"
           - "neemt <name_area> {bs_sound_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
-          - "<is> [er] [<in> <area>] {bs_sound_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
-          - "<is> [er] [<in> <area>] {bs_sound_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
+          - "<is> [er] [<in> <area>] {bs_sound_states:state} <detecteer> <name_area>"
+          - "<is> [er] [<in> <area>] {bs_sound_states:state} <met> [<area>][ ]<name> <detecteer> [<in> <area>]"
           - "<is> [er] <name_area> {bs_sound_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:
@@ -284,8 +284,8 @@ intents:
       - sentences:
           - "(<is>|<detecteer>) [er] [in|op|van|bij] [<area>][ |door |met |bij ]<name> [<in> <area>] {bs_tamper_states:state} [<in> <area>]"
           - "neemt <name_area> {bs_tamper_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
-          - "<is> [er] [<in> <area>] {bs_tamper_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
-          - "<is> [er] [<in> <area>] {bs_tamper_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
+          - "<is> [er] [<in> <area>] {bs_tamper_states:state} <detecteer> <name_area>"
+          - "<is> [er] [<in> <area>] {bs_tamper_states:state} <met> [<area>][ ]<name> <detecteer> [<in> <area>]"
           - "<is> [er] <name_area> {bs_tamper_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:
@@ -309,10 +309,10 @@ intents:
 
       - sentences:
           - "{bs_vibration_states:state} <name_area>"
-          - "(is|<detecteer>) [er] <in> [door|met] [<area>][ ]<name> [<in> <area>] {bs_vibration_states:state} [<in> <area>]"
+          - "(is|<detecteer>) [er] <name_area> {bs_vibration_states:state} [<in> <area>]"
           - "neemt [<area>][ ]<name> [<in> <area>] {bs_vibration_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
-          - "<is> [er] [<in> <area>] {bs_vibration_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
-          - "<is> [er] [<in> <area>] {bs_vibration_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
+          - "<is> [er] [<in> <area>] {bs_vibration_states:state} <detecteer> <name_area>"
+          - "<is> [er] [<in> <area>] {bs_vibration_states:state} <met> [<area>][ ]<name> <detecteer> [<in> <area>]"
           - "<is> [er] <name_area> {bs_vibration_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:

--- a/sentences/nl/binary_sensor_HassGetState.yaml
+++ b/sentences/nl/binary_sensor_HassGetState.yaml
@@ -24,11 +24,11 @@ intents:
           device_class: battery_charging
 
       - sentences:
-          - "<detecteer> [in|op|van|bij|door|met] [<area>][ ]<name> [<in> <area>] {bs_carbon_monoxide_states:state} [<in> <area>]"
-          - "neemt [<in> <area>][ ]<name> [<in> <area>] {bs_carbon_monoxide_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
+          - "<detecteer> [door|met] <name_area> {bs_carbon_monoxide_states:state} [<in> <area>]"
+          - "neemt <name_area> {bs_carbon_monoxide_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
           - "<is> [er] [<in> <area>] {bs_carbon_monoxide_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
           - "<is> [er] [<in> <area>] {bs_carbon_monoxide_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
-          - "<is> [er] [in|op|van|bij] [<area>][ |door |met |bij ]<name> [<in> <area>] {bs_carbon_monoxide_states:state} <detecteer> [<in> <area>]"
+          - "<is> [er] <name_area> {bs_carbon_monoxide_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -39,10 +39,10 @@ intents:
 
       - sentences:
           - "(is|<detecteer>) [er] <in>[door|met] [<area>][ ]<name> [<in> <area>] {bs_cold_states:state} [<in> <area>]"
-          - "neemt [<in> <area>][ ]<name> [<in> <area>] {bs_cold_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
+          - "neemt <name_area> {bs_cold_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
           - "<is> [er] [<in> <area>] {bs_cold_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
           - "<is> [er] [<in> <area>] {bs_cold_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
-          - "<is> [er] [in|op|van|bij] [<area>][ |door |met |bij ]<name> [<in> <area>] {bs_cold_states:state} <detecteer> [<in> <area>]"
+          - "<is> [er] <name_area>  {bs_cold_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -52,7 +52,7 @@ intents:
           device_class: cold
 
       - sentences:
-          - "<is> [<in> <area>][ ]<name> [<in> <area>] {bs_connectivity_states:state} [<in> <area>]"
+          - "<is> <name_area> {bs_connectivity_states:state} [<in> <area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -62,7 +62,7 @@ intents:
           device_class: connectivity
 
       - sentences:
-          - "<is> [<in> <area>][ ]<name> [<in> <area>] {bs_door_states:state} [<in> <area>]"
+          - "<is> <name_area> {bs_door_states:state} [<in> <area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -72,7 +72,7 @@ intents:
           device_class: door
 
       - sentences:
-          - "<is> [<in> <area>][ ]<name> [<in> <area>] {bs_garage_door_states:state} [<in> <area>]"
+          - "<is> <name_area> {bs_garage_door_states:state} [<in> <area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -83,10 +83,10 @@ intents:
 
       - sentences:
           - "<detecteer> [in|op|van|bij|door|met] [<area>][ ]<name> [<in> <area>] {bs_gas_states:state} [<in> <area>]"
-          - "neemt [<in> <area>][ ]<name> [<in> <area>] {bs_gas_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
+          - "neemt <name_area> {bs_gas_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
           - "<is> [er] [<in> <area>] {bs_gas_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
           - "<is> [er] [<in> <area>] {bs_gas_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
-          - "<is> [er] [in|op|van|bij] [<area>][ |door |met |bij ]<name> [<in> <area>] {bs_gas_states:state} <detecteer> [<in> <area>]"
+          - "<is> [er] <name_area> {bs_gas_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -97,10 +97,10 @@ intents:
 
       - sentences:
           - "(<is>|<detecteer>) [er] [in|op|van|bij|door|met] [<area>][ ]<name> [<in> <area>] {bs_heat_states:state} [<in> <area>]"
-          - "neemt [<in> <area>][ ]<name> [<in> <area>] {bs_heat_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
+          - "neemt <name_area> {bs_heat_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
           - "<is> [er] [<in> <area>] {bs_heat_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
           - "<is> [er] [<in> <area>] {bs_heat_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
-          - "<is> [er] [in|op|van|bij] [<area>][ |door |met |bij ]<name> [<in> <area>] {bs_heat_states:state} <detecteer> [<in> <area>]"
+          - "<is> [er] <name_area> {bs_heat_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -111,10 +111,10 @@ intents:
 
       - sentences:
           - "(<is>|<detecteer>) [er] [in|op|van|bij|door|met] [<area>][ ]<name> [<in> <area>] {bs_light_states:state} [<in> <area>]"
-          - "neemt [<in> <area>][ ]<name> [<in> <area>] {bs_light_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
+          - "neemt <name_area> {bs_light_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
           - "<is> [er] [<in> <area>] {bs_light_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
           - "<is> [er] [<in> <area>] {bs_light_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
-          - "<is> [er] [in|op|van|bij|door|met] [<area>][ |door |met |bij ]<name> [<in> <area>] {bs_light_states:state} <detecteer> [<in> <area>]"
+          - "<is> [er] <name_area> {bs_light_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -124,7 +124,7 @@ intents:
           device_class: light
 
       - sentences:
-          - "<is> [<in> <area>][ ]<name> [<in> <area>] {bs_lock_states:state} [<in> <area>]"
+          - "<is> <name_area> {bs_lock_states:state} [<in> <area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -135,10 +135,10 @@ intents:
 
       - sentences:
           - "(<is>|<detecteer>) [in|op|van|bij|door|met] [<area>][ ]<name> [<in> <area>] {bs_moisture_states:state} [<in> <area>]"
-          - "neemt [<in> <area>][ ]<name> [<in> <area>] {bs_moisture_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
+          - "neemt <name_area> {bs_moisture_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
           - "<is> [er] [<in> <area>] {bs_moisture_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
           - "<is> [er] [<in> <area>] {bs_moisture_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
-          - "<is> [er] [in|op|van|bij] [<area>][ |door |met |bij ]<name> [<in> <area>] {bs_moisture_states:state} <detecteer> [<in> <area>]"
+          - "<is> [er] <name_area> {bs_moisture_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -149,10 +149,10 @@ intents:
 
       - sentences:
           - "<detecteer> [er] [in|op|van|bij|door|met] [<area>][ ]<name> [<in> <area>] {bs_motion_states:state} [<in> <area>]"
-          - "neemt [<in> <area>][ ]<name> [<in> <area>] {bs_motion_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
+          - "neemt <name_area> {bs_motion_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
           - "<is> [er] [<in> <area>] {bs_motion_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
           - "<is> [er] [<in> <area>] {bs_motion_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
-          - "<is> [er] [in|op|van|bij] [<area>][ |door |met |bij ]<name> [<in> <area>] {bs_motion_states:state} <detecteer> [<in> <area>]"
+          - "<is> [er] <name_area> {bs_motion_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -163,10 +163,10 @@ intents:
 
       - sentences:
           - "<detecteer> [er] [in|op|van|bij|door|met] [<area>][ ]<name> [<in> <area>] {bs_occupancy_states:state} [<in> <area>]"
-          - "neemt [<in> <area>][ ]<name> [<in> <area>] {bs_occupancy_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
+          - "neemt <name_area> {bs_occupancy_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
           - "(is|zijn|word[t|en]) [er] [<in> <area>] {bs_occupancy_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
           - "(is|zijn|wordt[t|en]) [er] [<in> <area>] {bs_occupancy_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
-          - "(is|zijn|wordt[t|en]) [er] [in|op|van|bij] [<area>][ |door |met |bij ]<name> [<in> <area>] {bs_occupancy_states:state} <detecteer> [<in> <area>]"
+          - "<is> [er] <name_area> {bs_occupancy_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -176,7 +176,7 @@ intents:
           device_class: occupancy
 
       - sentences:
-          - "<is> [<in> <area>][ ]<name> [<in> <area>] {bs_opening_states:state} [<in> <area>]"
+          - "<is> <name_area> {bs_opening_states:state} [<in> <area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -198,10 +198,10 @@ intents:
 
       - sentences:
           - "(<is>|<detecteer>) [er] [in|op|van|bij|door|met] [<area>][ ]<name> [<in> <area>] {bs_power_states:state} [<in> <area>]"
-          - "neemt [<in> <area>][ ]<name> [<in> <area>] {bs_power_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
+          - "neemt <name_area> {bs_power_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
           - "<is> [er] [<in> <area>] {bs_power_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
           - "<is> [er] [<in> <area>] {bs_power_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
-          - "<is> [er] [in|op|van|bij] [<area>][ |door |met |bij ]<name> [<in> <area>] {bs_power_states:state} <detecteer> [<in> <area>]"
+          - "<is> [er] <name_area> {bs_power_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -211,7 +211,7 @@ intents:
           device_class: power
 
       - sentences:
-          - "<is> [<in> <area>][ ]<name> [<in> <area>] {bs_presence_states:state} [<in> <area>]"
+          - "<is> <name_area> {bs_presence_states:state} [<in> <area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -221,8 +221,8 @@ intents:
           device_class: presence
 
       - sentences:
-          - "<is> er [<in> <area>] [een] proble[e]m[en] met [<in> <area>][ ]<name> [<in> <area>]"
-          - "heeft [<in> <area>][ ]<name> [<in> <area>] [een] proble[e]m[en] [<in> <area>]"
+          - "<is> er [<in> <area>] [een] proble[e]m[en] met <name_area>"
+          - "heeft <name_area> [een] proble[e]m[en] [<in> <area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -233,8 +233,8 @@ intents:
           state: "on"
 
       - sentences:
-          - "<is> [<in> <area>][ ]<name> [<in> <area>] {bs_running_states:state} [<in> <area>]"
-          - "{bs_running_states:state} [<in> <area>][ ]<name> [<in> <area>] [<in> <area>]"
+          - "<is> <name_area> {bs_running_states:state} [<in> <area>]"
+          - "{bs_running_states:state} <name_area> [<in> <area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -255,10 +255,10 @@ intents:
 
       - sentences:
           - "(<is>|<detecteer>) [er] [in|op|van|bij|door|met] [<area>][ ]<name> [<in> <area>] {bs_smoke_states:state} [<in> <area>]"
-          - "neemt [<in> <area>][ ]<name> [<in> <area>] {bs_smoke_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
+          - "neemt <name_area> {bs_smoke_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
           - "<is> [er] [<in> <area>] {bs_smoke_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
           - "<is> [er] [<in> <area>] {bs_smoke_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
-          - "<is> [er] [in|op|van|bij] [<area>][ |door |met |bij ]<name> [<in> <area>] {bs_smoke_states:state} <detecteer> [<in> <area>]"
+          - "<is> [er] <name_area> {bs_smoke_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -269,10 +269,10 @@ intents:
 
       - sentences:
           - "(<is>|<detecteer>) [er] [in|op|van|bij|door|met] [<area>][ ]<name> [<in> <area>] {bs_sound_states:state} [<in> <area>]"
-          - "neemt [<in> <area>][ ]<name> [<in> <area>] {bs_sound_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
+          - "neemt <name_area> {bs_sound_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
           - "<is> [er] [<in> <area>] {bs_sound_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
           - "<is> [er] [<in> <area>] {bs_sound_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
-          - "<is> [er] [in|op|van|bij] [<area>][ |door |met |bij ]<name> [<in> <area>] {bs_sound_states:state} <detecteer> [<in> <area>]"
+          - "<is> [er] <name_area> {bs_sound_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -283,10 +283,10 @@ intents:
 
       - sentences:
           - "(<is>|<detecteer>) [er] [in|op|van|bij] [<area>][ |door |met |bij ]<name> [<in> <area>] {bs_tamper_states:state} [<in> <area>]"
-          - "neemt [<in> <area>][ ]<name> [<in> <area>] {bs_tamper_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
+          - "neemt <name_area> {bs_tamper_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
           - "<is> [er] [<in> <area>] {bs_tamper_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
           - "<is> [er] [<in> <area>] {bs_tamper_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
-          - "<is> [er] [in|op|van|bij] [<area>][ |door |met |bij ]<name> [<in> <area>] {bs_tamper_states:state} <detecteer> [<in> <area>]"
+          - "<is> [er] <name_area> {bs_tamper_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -297,8 +297,8 @@ intents:
 
       - sentences:
           - "<is> [<in> <area>][ ]<name> [[in|op|van] [<area>]] {bs_update_states:state} [<in> <area>]"
-          - "<is> [er] [<in> <area>] [een] {bs_update_states:state} [klaar] voor [<in> <area>][ ]<name> [<in> <area>]"
-          - "<is> [er] voor [<in> <area>][ ]<name> [<in> <area>] [een] {bs_update_states:state} [klaar] [<in> <area>]"
+          - "<is> [er] [<in> <area>] [een] {bs_update_states:state} [klaar] voor <name_area>"
+          - "<is> [er] voor <name_area> [een] {bs_update_states:state} [klaar] [<in> <area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -308,12 +308,12 @@ intents:
           device_class: update
 
       - sentences:
-          - "{bs_vibration_states:state} [<in> <area>][ ]<name> [<in> <area>]"
+          - "{bs_vibration_states:state} <name_area>"
           - "(is|<detecteer>) [er] <in> [door|met] [<area>][ ]<name> [<in> <area>] {bs_vibration_states:state} [<in> <area>]"
           - "neemt [<area>][ ]<name> [<in> <area>] {bs_vibration_states:state} (waar [<in> <area>]|[<in> <area>] waar)"
           - "<is> [er] [<in> <area>] {bs_vibration_states:state} <detecteer> (bij|door) [<area>][ ]<name> [<in> <area>]"
           - "<is> [er] [<in> <area>] {bs_vibration_states:state} (bij|door) [<area>][ ]<name> <detecteer> [<in> <area>]"
-          - "<is> [er] [<in> <area>][ ][door|met|bij][ ]<name> [<in> <area>] {bs_vibration_states:state} <detecteer> [<in> <area>]"
+          - "<is> [er] <name_area> {bs_vibration_states:state} <detecteer> [<in> <area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -350,7 +350,7 @@ intents:
           device_class: vibration
 
       - sentences:
-          - "<is> [<in> <area>][ ]<name> [<in> <area>] {bs_window_states:state} [<in> <area>]"
+          - "<is> <name_area> {bs_window_states:state} [<in> <area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor

--- a/sentences/nl/cover_HassGetState.yaml
+++ b/sentences/nl/cover_HassGetState.yaml
@@ -3,7 +3,7 @@ intents:
   HassGetState:
     data:
       - sentences:
-          - <is> [<in> <area>] <name> [<in> <area>] {cover_states:state} [<in> <area>]
+          - "<is> [er] <name_area> {cover_states:state} [<in> <area>]"
         response: one_yesno
         requires_context:
           domain: cover


### PR DESCRIPTION
Introduced a new expansion_rule `<name_are>`

It has 3 frequently used options for the combination of the name and the area.
It has 2 advantages
* it simplifies the sentences (as all expansion rules do)
* it avoids grammatically incorrect versions or double usage of area around the name, as the 3 options are now separated, and not in one line which would allow all to be used.