### PR TITLE
[NL] Support for opening and closing locks

### DIFF
--- a/responses/nl/HassTurnOff.yaml
+++ b/responses/nl/HassTurnOff.yaml
@@ -9,3 +9,5 @@ responses:
       light_all: "Alle lampen uitgezet"
       fan_all: "Alle ventilatoren uitgezet"
       cover_device_class: "{{ slots.device_class | capitalize }} gesloten"
+      lock: "Ontgrendeld"
+      lock_area: "Sloten ontgrendeld"

--- a/responses/nl/HassTurnOn.yaml
+++ b/responses/nl/HassTurnOn.yaml
@@ -11,3 +11,5 @@ responses:
       cover_device_class: "{{ slots.device_class | capitalize }} geopend"
       scene: "Geactiveerd"
       script: "Gestart"
+      lock: "Vergrendeld"
+      lock_area: "Sloten vergrendeld"

--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -311,13 +311,20 @@ expansion_rules:
   # generic expansion rules for sentences
   name: "[de|het] {name}"
   area: "[de|het] {area}"
+  in: "[in|op|van|bij]"
+  met: "(door|met|bij)"
+  name_area: >
+    (
+      [[door|met|bij] [de|het] {area}][ ]{name}
+      |[<in> [de|het] {area}] [door|met|bij] <name>
+      |[<met>] [de|het] {name} [[in|op|van|bij] <area>]
+    )
   doe: "(zet[ten]|mag|mogen|doe[n]|verander[en]|maak|maken|schakel[en])"
-  zou: "(kan|kun[t]|zal|zou) [je|jij|u]"
+  zou: "(kan|kun[t]|zal|zou|wil[t]) [je|jij|u]"
   naar: "(naar|op)"
   detecteer: "(detecteert|registreert|detecteren|registereren|gedetecteerd|geregistreerd|waar[ ]genomen)"
   sensor: "[een|de] (apparaat|apparaten|sensor[s|en])"
   is: "(zijn|is|staa(n|t)|zit[ten]|word[t|en]|lig(t|gen))"
-  in: "[in|op|van|bij]"
   alle: "(alle|elk[e]|ieder[e]|overal)"
   staat: "(status|staat|stand)"
   # cover deivce classes
@@ -335,7 +342,10 @@ expansion_rules:
   ventilator: "[de|een] (ventilator[s|en]|fan[s])"
   schakelaar: "[de|een] (schakelaar[s]|switch[es]|plug[gen])"
   afdekking: "[de|het] (<awning>|<blind>|<curtain>|<door>|<garage>|<gate>|<shade>|<shutter>|<window>)"
-  slot: "[de|het|een] ([deur]slot[en])"
+  slot: "[de|het|een] ([deur]slot[en]|vergrendeling[en])"
+  op_slot: "<naar> (slot|vergrendeld)"
+  van_slot: "[<naar>] (van [het] slot|ontgrendeld)"
+  slot_name_area: "[<in> <area>] (<slot> [van] [{area}[ ]]<name>|[de|het] {name}[ ]([deur]slot[en]|vergrendeling[en])) [[in|op|van|bij] [de|het] {area}]"
   # combination of device/entity types
   type: (<lamp>|<ventilator>|<afdekking>|<schakelaar>)
   # light brightness

--- a/sentences/nl/climate_HassClimateGetTemperature.yaml
+++ b/sentences/nl/climate_HassClimateGetTemperature.yaml
@@ -7,7 +7,7 @@ intents:
           - "Wat is de temperatuur"
           - "Hoe <warm> is [het in] <area>"
           - "Hoeveel graden [celcius] is [het in] <area>"
-          - "Wat is de temperatuur in <area>"
+          - "Wat is de temperatuur <in> <area>"
           - "Wat is <area> temperatuur"
           - "Hoe <warm> staat <name> [ingesteld]"
           - "Op hoeveel graden [celcius] staat <name> [ingesteld]"

--- a/sentences/nl/climate_HassClimateSetTemperature.yaml
+++ b/sentences/nl/climate_HassClimateSetTemperature.yaml
@@ -3,9 +3,9 @@ intents:
   HassClimateSetTemperature:
     data:
       - sentences:
-          - "[<doe>|<zou>] [de] temperatuur <naar> <temperature> [graden] [willen|kunnen] [<doe>]"
-          - "[<doe>|<zou>] [de] temperatuur <naar> <temperature> [graden] in <area> [willen|kunnen] [<doe>]"
-          - "[<doe>|<zou>] <area> temperatuur <naar> <temperature> [graden] [willen|kunnen] [<doe>]"
-          - "[<doe>|<zou>] <name> [temperatuur] <naar> <temperature> graden [willen|kunnen] [<doe>]"
-          - "[<doe>|<zou>] <name> temperatuur <naar> <temperature> [graden] [willen|kunnen] [<doe>]"
-          - "[<doe>|<zou>] de temperatuur van <name> <naar> <temperature> [graden] [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] [de] temperatuur <naar> <temperature> [graden] [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>] [de] temperatuur <naar> <temperature> [graden] <in> <area> [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>] <area> temperatuur <naar> <temperature> [graden] [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>] <name> [temperatuur] <naar> <temperature> graden [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>] <name> temperatuur <naar> <temperature> [graden] [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>] de temperatuur van <name> <naar> <temperature> [graden] [[willen|kunnen] <doe>]"

--- a/sentences/nl/cover_HassGetState.yaml
+++ b/sentences/nl/cover_HassGetState.yaml
@@ -11,7 +11,7 @@ intents:
           domain: cover
 
       - sentences:
-          - <is> [er] [in <area>|ergens|nog] [een] {cover_classes:device_class} [<in> <area>] {cover_states:state} [<in> <area>]
+          - <is> [er] [<in> <area>|ergens|nog] [een] {cover_classes:device_class} [<in> <area>] {cover_states:state} [<in> <area>]
         response: any
         slots:
           domain: cover

--- a/sentences/nl/cover_HassTurnOff.yaml
+++ b/sentences/nl/cover_HassTurnOff.yaml
@@ -4,14 +4,14 @@ intents:
     data:
       - sentences:
           - "sluit <name>"
-          - "[<doe>|<zou>] <name> <dicht> [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] <name> <dicht> [[willen|kunnen] <doe>]"
         response: "cover"
         slots:
           domain: cover
 
       - sentences:
           - "sluit [de] garage[ ][deur]"
-          - "[<doe>|<zou>] [de] garage[ ][deur] dicht [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] [de] garage[ ][deur] dicht [[willen|kunnen] <doe>]"
         response: "cover_device_class"
         slots:
           device_class: "garage"
@@ -19,7 +19,7 @@ intents:
 
       - sentences:
           - sluit <name> <in> <area>
-          - "[<doe>|<zou>] <name> (<dicht> <in> <area>|<in> <area> <dicht>) [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] <name> (<dicht> <in> <area>|<in> <area> <dicht>) [[willen|kunnen] <doe>]"
           - "<zou> <name> <in> <area> (willen|kunnen) [<dicht>]"
         response: "cover"
         slots:
@@ -32,7 +32,7 @@ intents:
 
       - sentences:
           - "sluit [de|het] <curtain> <in> <area>"
-          - "[<doe>|<zou>] [de|het] <curtain> (<dicht> <in> <area>|<in> <area> <dicht>) [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] [de|het] <curtain> (<dicht> <in> <area>|<in> <area> <dicht>) [[willen|kunnen] <doe>]"
           - "<zou> [de|het] <curtain> <in> <area> [willen|kunnen] <dicht>"
         response: "cover"
         slots:
@@ -41,7 +41,7 @@ intents:
 
       - sentences:
           - "sluit [de|het] (<blind>|<shutter>|<shade>) <in> <area>"
-          - "[<doe>|<zou>] [de|het] (<blind>|<shutter>|<shade>) (<dicht> <in> <area>|<in> <area> <dicht>) [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] [de|het] (<blind>|<shutter>|<shade>) (<dicht> <in> <area>|<in> <area> <dicht>) [[willen|kunnen] <doe>]"
           - "<zou> [de|het] (<blind>|<shutter>|<shade>) <in> <area> [willen|kunnen] <dicht>"
         response: "cover"
         slots:

--- a/sentences/nl/cover_HassTurnOn.yaml
+++ b/sentences/nl/cover_HassTurnOn.yaml
@@ -4,14 +4,14 @@ intents:
     data:
       - sentences:
           - "open <name>"
-          - "[<doe>|<zou>] <name> <open> [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] <name> <open> [[willen|kunnen] <doe>]"
         response: "cover"
         slots:
           domain: cover
 
       - sentences:
           - "open [de] garage[ ][deur]"
-          - "[<doe>|<zou>] [de] garage[ ][deur] [<open>] [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] [de] garage[ ][deur] [<open>] [[willen|kunnen] <doe>]"
         response: "cover_device_class"
         slots:
           device_class: garage
@@ -19,7 +19,7 @@ intents:
 
       - sentences:
           - "open <name> <in> <area>"
-          - "[<doe> |<zou> ]<name> (<open> <in> <area>|<in> <area> <open>) [willen|kunnen] [<doe>]"
+          - "[<doe> |<zou> ]<name> (<open> <in> <area>|<in> <area> <open>) [[willen|kunnen] <doe>]"
           - "<zou> <name> <in> <area> (willen|kunnen) <open>"
         response: "cover"
         slots:
@@ -32,7 +32,7 @@ intents:
 
       - sentences:
           - "open [de|het] <curtain> <in> <area>"
-          - "[<doe>|<zou>] [de|het] <curtain> (<open> <in> <area>|<in> <area> <open>) [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] [de|het] <curtain> (<open> <in> <area>|<in> <area> <open>) [[willen|kunnen] <doe>]"
           - "<zou> [de|het] <curtain> <in> <area> [willen|kunnen] <open>"
         response: cover
         slots:
@@ -41,7 +41,7 @@ intents:
 
       - sentences:
           - "open [de|het] (<blind>|<shutter>|<shade>) <in> <area>"
-          - "[<doe>|<zou>] [de|het] (<blind>|<shutter>|<shade>) (<open> <in> <area>|<in> <area> <open>) [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] [de|het] (<blind>|<shutter>|<shade>) (<open> <in> <area>|<in> <area> <open>) [[willen|kunnen] <doe>]"
           - "<zou> [de|het] (<blind>|<shutter>|<shade>) <in> <area> [willen|kunnen] <open>"
         response: cover
         slots:

--- a/sentences/nl/fan_HassTurnOff.yaml
+++ b/sentences/nl/fan_HassTurnOff.yaml
@@ -3,9 +3,9 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "[<doe>|<zou>] [<alle>] <ventilator> [<naar>] uit [willen|kunnen] [<doe>] in <area>"
-          - "[<doe>|<zou>] [<alle>] <ventilator> <in> <area> [<naar>] uit [willen|kunnen] [<doe>]"
-          - "[<doe>|<zou>] [(<alle>|<in>)] <area> <ventilator> [<naar>] uit [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] [<alle>] <ventilator> [<naar>] uit [[willen|kunnen] <doe>] <in> <area>"
+          - "[<doe>|<zou>] [<alle>] <ventilator> <in> <area> [<naar>] uit [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>] [(<alle>|<in>)] <area> <ventilator> [<naar>] uit [[willen|kunnen] <doe>]"
           - "[<zou>] [(<alle>|<in>)] [<area>[ ]]<ventilator> [<in> <area>] [willen|kunnen] (uit[ ]zetten|uitschakelen)"
         response: fans_area
         slots:
@@ -13,7 +13,7 @@ intents:
           name: "all"
 
       - sentences:
-          - "[<doe>|<zou>] ((overal|<alle>) <ventilator>|<ventilator> overal) uit [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] ((overal|<alle>) <ventilator>|<ventilator> overal) uit [[willen|kunnen] <doe>]"
         response: "fan_all"
         slots:
           domain: "fan"

--- a/sentences/nl/fan_HassTurnOn.yaml
+++ b/sentences/nl/fan_HassTurnOn.yaml
@@ -3,11 +3,11 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "[<doe>|<zou>] [<alle>] <ventilator> [<naar>] aan [willen|kunnen] [<doe>] in <area>"
-          - "Schakel [<alle>] <ventilator> [<naar>] in in <area>"
-          - "[<doe>|<zou>] [<alle>] <ventilator> <in> <area> [<naar>] aan [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] [<alle>] <ventilator> [<naar>] aan [[willen|kunnen] <doe>] <in> <area>"
+          - "Schakel [<alle>] <ventilator> [<naar>] in <in> <area>"
+          - "[<doe>|<zou>] [<alle>] <ventilator> <in> <area> [<naar>] aan [[willen|kunnen] <doe>]"
           - "Schakel [<alle>] <ventilator> <in> <area> [<naar>] in"
-          - "[<doe>|<zou>] [(<alle>|<in>)] <area> <ventilator> [<naar>] aan [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] [(<alle>|<in>)] <area> <ventilator> [<naar>] aan [[willen|kunnen] <doe>]"
           - "Schakel [(<alle>|<in>)] <area>[ ]<ventilator> [<naar>] in"
           - "[<zou>] [(<alle>|<in>)] [<area>[ ]]<ventilator> [<in> <area>] [willen|kunnen] (aan[ ]zetten|inschakelen)"
         response: fans_area

--- a/sentences/nl/homeassistant_HassTurnOff.yaml
+++ b/sentences/nl/homeassistant_HassTurnOff.yaml
@@ -3,7 +3,7 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "[<doe>|<zou>] <name>[ ][<type>] [<naar>] uit [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] <name>[ ][<type>] [<naar>] uit [[willen|kunnen] <doe>]"
           - "[<zou>] <name>[ ][<type>] [willen|kunnen] (uit[ ]zetten|uitschakelen)"
         excludes_context:
           domain:

--- a/sentences/nl/homeassistant_HassTurnOn.yaml
+++ b/sentences/nl/homeassistant_HassTurnOn.yaml
@@ -3,7 +3,7 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "[<doe>|<zou>] <name>[ ][<type>] [<naar>] (aan|in) [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] <name>[ ][<type>] [<naar>] (aan|in) [[willen|kunnen] <doe>]"
           - "schakel <name>[ ][<type>] [<naar>] in"
           - "[<zou>] <name>[ ][<type>] [willen|kunnen] (aan[ ]zetten|inschakelen)"
         excludes_context:

--- a/sentences/nl/light_HassLightSet.yaml
+++ b/sentences/nl/light_HassLightSet.yaml
@@ -4,42 +4,42 @@ intents:
     data:
       # Brightness value
       - sentences:
-          - "[<doe>|<zou>] <name>[ ][<lamp>][ ][<helderheid>] [<naar>] <brightness> [willen|kunnen] [<doe>]"
-          - "[<doe>|<zou>] <helderheid> [van] <name>[ ][<lamp>] [<naar>] <brightness> [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] <name>[ ][<lamp>][ ][<helderheid>] [<naar>] <brightness> [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>] <helderheid> [van] <name>[ ][<lamp>] [<naar>] <brightness> [[willen|kunnen] <doe>]"
         response: "brightness"
 
       - sentences:
-          - "[<doe>|<zou>] [<helderheid>] <in> <area>[[ ]<lamp>] [<naar>] <brightness> [willen|kunnen] [<doe>]"
-          - "[<doe>|<zou>] <area>[ ][<helderheid>|lamp] [<naar>] <brightness> [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] [<helderheid>] <in> <area>[[ ]<lamp>] [<naar>] <brightness> [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>] <area>[ ][<helderheid>|lamp] [<naar>] <brightness> [[willen|kunnen] <doe>]"
         slots:
           name: "all"
         response: "brightness"
 
       # Max/Min brightness
       - sentences:
-          - "[<doe>|<zou>] <name>[ ][lamp][ ][<helderheid>] [<naar>] [het] {brightness_level:brightness} [willen|kunnen] [<doe>]"
-          - "[<doe>|<zou>] <helderheid> [van] <name>[ ][<lamp>] [<naar>] [het] {brightness_level:brightness} [willen|kunnen] [<doe>]"
-          - "[<doe>|<zou>] <name>[ ][lamp] [<naar>] [de|het] {brightness_level:brightness} <helderheid> [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] <name>[ ][lamp][ ][<helderheid>] [<naar>] [het] {brightness_level:brightness} [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>] <helderheid> [van] <name>[ ][<lamp>] [<naar>] [het] {brightness_level:brightness} [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>] <name>[ ][lamp] [<naar>] [de|het] {brightness_level:brightness} <helderheid> [[willen|kunnen] <doe>]"
         requires_context:
           domain: light
         response: "brightness"
 
       - sentences:
-          - "[<doe>|<zou>] [<helderheid>] <in> <area> [<naar>] [het] {brightness_level:brightness} [willen|kunnen] [<doe>]"
-          - "[<doe>|<zou>] <area>[ ][<helderheid>] [<naar>] [het] {brightness_level:brightness} [willen|kunnen] [<doe>]"
-          - "[<doe>|<zou>] <area> [<naar>] [de|het] {brightness_level:brightness} [<helderheid>] [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] [<helderheid>] <in> <area> [<naar>] [het] {brightness_level:brightness} [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>] <area>[ ][<helderheid>] [<naar>] [het] {brightness_level:brightness} [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>] <area> [<naar>] [de|het] {brightness_level:brightness} [<helderheid>] [[willen|kunnen] <doe>]"
         slots:
           name: "all"
         response: "brightness"
 
       # Color
       - sentences:
-          - "[<doe>|<zou>] <name>[ ][<lamp>][ ][kleur] [<naar>] {color} [willen|kunnen] [<doe>]"
-          - "[<doe>|<zou>] [[de] kleur van] <name>[ ][<lamp>] [<naar>] {color} [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] <name>[ ][<lamp>][ ][kleur] [<naar>] {color} [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>] [[de] kleur van] <name>[ ][<lamp>] [<naar>] {color} [[willen|kunnen] <doe>]"
         response: "color"
 
       - sentences:
-          - "[<doe>|<zou>] [[de] kleur van] [[<alle>] <lamp>] [in|van] <area>[[ ]<lamp>] [<naar>] {color} [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] [[de] kleur van] [[<alle>] <lamp>] [in|van] <area>[[ ]<lamp>] [<naar>] {color} [[willen|kunnen] <doe>]"
         response: "color"
         slots:
           name: "all"

--- a/sentences/nl/light_HassTurnOff.yaml
+++ b/sentences/nl/light_HassTurnOff.yaml
@@ -3,9 +3,9 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "[<doe>|<zou>] [<alle>] <lamp> [<naar>] uit [willen|kunnen] [<doe>] in <area>"
-          - "[<doe>|<zou>] [<alle>] <lamp> <in> <area> [<naar>] uit [willen|kunnen] [<doe>]"
-          - "[<doe>|<zou>] [(<alle>|<in>)] <area>[ ]<lamp> [<naar>] uit [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] [<alle>] <lamp> [<naar>] uit [[willen|kunnen] <doe>] <in> <area>"
+          - "[<doe>|<zou>] [<alle>] <lamp> <in> <area> [<naar>] uit [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>] [(<alle>|<in>)] <area>[ ]<lamp> [<naar>] uit [[willen|kunnen] <doe>]"
           - "[<zou>] [(<alle>|<in>)] [<area>[ ]]<lamp> [<in> <area>] [willen|kunnen] (uit[ ]zetten|uitschakelen)"
         response: "lights_area"
         slots:
@@ -13,7 +13,7 @@ intents:
           name: "all"
 
       - sentences:
-          - "[<doe>|<zou>] ((overal|<alle>) <lamp>|<lamp> overal) uit [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] ((overal|<alle>) <lamp>|<lamp> overal) uit [[willen|kunnen] <doe>]"
         response: "light_all"
         slots:
           domain: "light"

--- a/sentences/nl/light_HassTurnOn.yaml
+++ b/sentences/nl/light_HassTurnOn.yaml
@@ -3,11 +3,11 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "[<doe>|<zou>] [<alle>] <lamp> [<naar>] aan [willen|kunnen] [<doe>] (in|op) <area>"
+          - "[<doe>|<zou>] [<alle>] <lamp> [<naar>] aan [[willen|kunnen] <doe>] (in|op) <area>"
           - "Schakel [<alle>] <lamp> [<naar>] in (in|op) <area>"
-          - "[<doe>|<zou>] [<alle>] <lamp> <in> <area> [<naar>] aan [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] [<alle>] <lamp> <in> <area> [<naar>] aan [[willen|kunnen] <doe>]"
           - "Schakel [<alle>] <lamp> <in> <area> in"
-          - "[<doe>|<zou>] [(<alle>|<in>)] <area>[ ]<lamp> aan [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] [(<alle>|<in>)] <area>[ ]<lamp> aan [[willen|kunnen] <doe>]"
           - "Schakel [(<alle>|<in>)] <area>[ ]<lamp> in"
           - "[<zou>] [(<alle>|<in>)] [<area>[ ]]<lamp> [<in> <area>] [willen|kunnen] (aan[ ]zetten|inschakelen)"
         response: "lights_area"

--- a/sentences/nl/lock_HassTurnOff.yaml
+++ b/sentences/nl/lock_HassTurnOff.yaml
@@ -7,6 +7,7 @@ intents:
           - ontgrendel <name_area>
           - <zou> <name_area> [willen|kunnen] ontgrendelen [<in> <area>]
           - "[<doe>|<zou>] <slot_name_area> open [[willen|kunnen] <doe>] [<in> <area>]"
+          - open <slot_name_area>
           - <zou> <slot_name_area> [willen|kunnen] openen [<in> <area>]
         requires_context:
           domain: lock

--- a/sentences/nl/lock_HassTurnOff.yaml
+++ b/sentences/nl/lock_HassTurnOff.yaml
@@ -1,0 +1,31 @@
+language: nl
+intents:
+  HassTurnOff:
+    data:
+      - sentences:
+          - "[<doe>|<zou>|haal] <name_area> <van_slot> [[willen|kunnen] (<doe>|halen)] [<in> <area>]"
+          - ontgrendel <name_area>
+          - <zou> <name_area> [willen|kunnen] ontgrendelen [<in> <area>]
+          - "[<doe>|<zou>] <slot_name_area> open [[willen|kunnen] <doe>] [<in> <area>]"
+          - <zou> <slot_name_area> [willen|kunnen] openen [<in> <area>]
+        requires_context:
+          domain: lock
+        response: lock
+
+      - sentences:
+          - "[<doe>|<zou>] [<alle>] (<slot>|deur[en]) <van_slot> [[willen|kunnen] <doe>] <in> <area>"
+          - "[<doe>|<zou>] [<alle>] <area>[ |<alle>](<slot>|deur[en]) <van_slot> [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>] [<alle>] (<slot>|deur[en]) <in> <area> <van_slot> [[willen|kunnen] <doe>]"
+          - "ontgrendel [<alle>] (<in> <area>[ |<alle>](<slot>|deur[en])|(<slot>|deur[en]) <in> <area>)"
+          - <zou> [<alle>] (<in> <area>[ |<alle>](<slot>|deur[en])|(<slot>|deur[en]) <in> <area>) [willen|kunnen] ontgrendelen
+          - <zou> [<alle>] (<slot>|deur[en]) [willen|kunnen] ontgrendelen <in> <area>
+          - "[<doe>|<zou>] [<alle>] <in> <area>[ |<alle>]<slot> open [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>] [<alle>] <slot> <in> <area> open [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>] [<alle>] <slot> open [[willen|kunnen] <doe>] <in> <area>"
+          - "open [<alle>] (<in> <area>[ |<alle>]<slot>|<slot> <in> <area>)"
+          - <zou> [<alle>] (<in> <area>[ |<alle>]<slot>|<slot> <in> <area>) [willen|kunnen] openen
+          - <zou> [<alle>] <slot> [willen|kunnen] openen <in> <area>
+        response: lock_area
+        slots:
+          domain: "lock"
+          name: "all"

--- a/sentences/nl/lock_HassTurnOn.yaml
+++ b/sentences/nl/lock_HassTurnOn.yaml
@@ -1,0 +1,32 @@
+language: nl
+intents:
+  HassTurnOn:
+    data:
+      - sentences:
+          - "[<doe>|<zou>] <name_area> <op_slot> [[willen|kunnen] <doe>] [<in> <area>]"
+          - vergrendel <name_area>
+          - <zou> <name_area> [willen|kunnen] vergrendelen [<in> <area>]
+          - "[<doe>|<zou>] <slot_name_area> dicht [[willen|kunnen] <doe>] [<in> <area>]"
+          - sluit <slot_name_area>
+          - <zou> <slot_name_area> [willen|kunnen] sluiten [<in> <area>]
+        requires_context:
+          domain: lock
+        response: lock
+
+      - sentences:
+          - "[<doe>|<zou>] [<alle>] (<slot>|deur[en]) <op_slot> [[willen|kunnen] <doe>] <in> <area>"
+          - "[<doe>|<zou>] [<alle>] <area>[ |<alle>](<slot>|deur[en]) <op_slot> [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>] [<alle>] (<slot>|deur[en]) <in> <area> <op_slot> [[willen|kunnen] <doe>]"
+          - "vergrendel [<alle>] (<in> <area>[ |<alle>](<slot>|deur[en])|(<slot>|deur[en]) <in> <area>)"
+          - <zou> [<alle>] (<in> <area>[ |<alle>](<slot>|deur[en])|(<slot>|deur[en]) <in> <area>) [willen|kunnen] vergrendelen
+          - <zou> [<alle>] (<slot>|deur[en]) [willen|kunnen] vergrendelen <in> <area>
+          - "[<doe>|<zou>] [<alle>] <in> <area>[ |<alle>]<slot> dicht [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>] [<alle>] <slot> <in> <area> dicht [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>] [<alle>] <slot> dicht [[willen|kunnen] <doe>] <in> <area>"
+          - "sluit [<alle>] (<in> <area>[ |<alle>]<slot>|<slot> <in> <area>)"
+          - <zou> [<alle>] (<in> <area>[ |<alle>]<slot>|<slot> <in> <area>) [willen|kunnen] sluiten
+          - <zou> [<alle>] <slot> [willen|kunnen] sluiten <in> <area>
+        response: lock_area
+        slots:
+          domain: "lock"
+          name: "all"

--- a/sentences/nl/scene_HassTurnOn.yaml
+++ b/sentences/nl/scene_HassTurnOn.yaml
@@ -4,7 +4,7 @@ intents:
     data:
       - sentences:
           - "(activeer|start|schakel) [scene|scène] <name>[ ][scene|scène] [<naar>] [in]"
-          - "[<doe>|<zou>] [scene|scène] <name>[ ][scene|scène] [<naar>] (aan|in) [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] [scene|scène] <name>[ ][scene|scène] [<naar>] (aan|in) [[willen|kunnen] <doe>]"
           - "[<zou>] <name>[ ][scene|scène] [willen|kunnen] (aan[ ]zetten|inschakelen|starten|activeren)"
         requires_context:
           domain: scene

--- a/sentences/nl/script_HassTurnOn.yaml
+++ b/sentences/nl/script_HassTurnOn.yaml
@@ -4,7 +4,7 @@ intents:
     data:
       - sentences:
           - "(activeer|start|schakel) [script] <name>[ ][script] [<naar>] [in]"
-          - "[<doe>|<zou>] [script] <name>[ ][script] [<naar>] (aan|in) [willen|kunnen] [<doe>]"
+          - "[<doe>|<zou>] [script] <name>[ ][script] [<naar>] (aan|in) [[willen|kunnen] <doe>]"
           - "[<zou>] <name>[ ][script] [willen|kunnen] (aan[ ]zetten|inschakelen|starten|activeren)"
         requires_context:
           domain: script

--- a/tests/nl/lock_HassTurnOff.yaml
+++ b/tests/nl/lock_HassTurnOff.yaml
@@ -1,0 +1,35 @@
+language: nl
+tests:
+  - sentences:
+      - "haal de voordeur van het slot"
+      - "zou je de voordeur van het slot willen halen"
+      - "ontgrendel de voordeur"
+      - "maak het voordeurslot open"
+      - "open het slot van de voordeur"
+    intent:
+      name: HassTurnOff
+      context:
+        domain: lock
+      slots:
+        name: Voordeur
+    response: "Ontgrendeld"
+
+  - sentences:
+      - Doe alle deuren van slot in de keuken
+      - Doe alle keukenvergrendelingen naar ontgrendeld
+      - Doe overal het slot in de keuken van het slot
+      - Ontgrendel alle keukensloten
+      - Wil je de keukendeuren ontgrendelen
+      - Zou je alle deuren willen ontgrendelen in de keuken
+      - Doe alle keukensloten open
+      - Zou je alle sloten in de keuken open willen doen
+      - Kun je overal het slot open doen in keuken
+      - open de keukensloten
+      - wil je de keukensloten openen
+      - zou je alle sloten willen openen in de keuken
+    intent:
+      name: HassTurnOff
+      slots:
+        area: Keuken
+        domain: lock
+        name: all

--- a/tests/nl/lock_HassTurnOff.yaml
+++ b/tests/nl/lock_HassTurnOff.yaml
@@ -6,6 +6,7 @@ tests:
       - "ontgrendel de voordeur"
       - "maak het voordeurslot open"
       - "open het slot van de voordeur"
+      - "kunt u het voordeurslot openen"
     intent:
       name: HassTurnOff
       context:

--- a/tests/nl/lock_HassTurnOn.yaml
+++ b/tests/nl/lock_HassTurnOn.yaml
@@ -1,0 +1,37 @@
+language: nl
+tests:
+  - sentences:
+      - "zet de voordeur op slot"
+      - "zou je de voordeur naar vergrendeld willen doen"
+      - "vergrendel de voordeur"
+      - "kun je de voordeur vergrendelen"
+      - "maak het voordeurslot dicht"
+      - "sluit slot voordeur"
+      - "zou je het voordeurslot willen sluiten"
+    intent:
+      name: HassTurnOn
+      context:
+        domain: lock
+      slots:
+        name: Voordeur
+    response: "Vergrendeld"
+
+  - sentences:
+      - Doe alle deuren op slot in de keuken
+      - Doe alle keukenvergrendelingen op slot
+      - Doe overal het slot in de keuken naar vergrendeld
+      - Vergrendel alle keukensloten
+      - Wil je de keukensloten vergrendelen
+      - Zou je alle deuren willen vergrendelen in de keuken
+      - Doe alle keukensloten dicht
+      - Zou je alle sloten in de keuken dicht willen doen
+      - Kun je overal het slot dicht doen in keuken
+      - sluit de keukensloten
+      - wil je de keukensloten sluiten
+      - zou je alle sloten willen sluiten in de keuken
+    intent:
+      name: HassTurnOn
+      slots:
+        area: Keuken
+        domain: lock
+        name: all


### PR DESCRIPTION
* Added intents for opening/closing locks by name
* Added intents for opening/closing all locks in an area
* Made a minor change the polite ending of sentences `[zouden|willen] [<doe>]` is changed to `[[zouden|willen] <doe>]` to treat it as one optional part (this causes the changes in the other files)
* replaced `in <area>` for all sentences to `<in> <area>` to allow `op zolder`, `bij de schoorsteen`

I already used the new expansion rules from #1174 

For the named intents a reference to `<slot>` is required in case `[doe] open/sluit/doe dicht` is used to avoid confusion with doors
For the area intents you can refer to `deur[en]` instead of `<slot>` in case `vergrendelen|ontgrendelen|op slot|van slot` is used. You can only refer to `<slot>` for `open|sluiten|dicht doen|open doen`.