### PR TITLE
[FR] more sentence for Get State. And simplification of some answers

### DIFF
--- a/responses/fr/HassGetState.yaml
+++ b/responses/fr/HassGetState.yaml
@@ -5,7 +5,7 @@ responses:
       # the number of names returned is limited to 4, in case there are more, the first 3 names and the remaining count is returned
       # with 4 names or less, the names are joined with a comma ", " and the last name is joined with " and "
       one: |
-        L'etat de l'appareil {{ slots.name | capitalize }} est {{ state.state_with_unit }}
+        {{ slots.name | capitalize }} est {{ state.state_with_unit }}
 
       one_yesno: |
         {% if query.matched %}
@@ -21,14 +21,14 @@ responses:
           {% if match | length > 4 %}
             Oui, {{ match[:3] | join(", ") }} et {{ (match | length - 3) }} autres
           {% elif match | length == 1 %}
-            Oui, l'appareil
+            Oui,
             {% for name in match -%}
               {% if not loop.first and not loop.last %}, {% elif loop.last and not loop.first %} et {% endif -%}
               {{ name }}
             {% endfor %}
             est {{ state.state_with_unit }}
           {%- else -%}
-            Oui, les appareils
+            Oui,
             {% for name in match -%}
               {% if not loop.first and not loop.last %}, {% elif loop.last and not loop.first %} et {% endif -%}
               {{ name }}
@@ -48,13 +48,13 @@ responses:
           {% if no_match | length > 4 %}
             Non,pas  {{ no_match[:3] | join(", ") }} et {{ (no_match | length - 3) }} autres
           {% elif no_match | length == 1 %}
-            Non, pas l'appareil
+            Non, pas
             {% for name in no_match -%}
               {% if not loop.first and not loop.last %}, {% elif loop.last and not loop.first %} et {% endif -%}
               {{ name }}
             {%- endfor %}
           {%- else -%}
-            Non, pas les appareils 
+            Non, pas
             {% for name in no_match -%}
               {% if not loop.first and not loop.last %}, {% elif loop.last and not loop.first %} et {% endif -%}
               {{ name }}
@@ -69,17 +69,14 @@ responses:
           {% set match = query.matched | map(attribute="name") | sort | list %}
           {% set count_match = match | length | int %}
           {% if match | count > 4 %}
-            Les appareils 
             {{ match[:3] | join(", ") }} et {{ (match | length - 3) }} autres
           {% elif match | count == 1 %}
-            L'appareil 
             {% for name in match %}
               {% if not loop.first and not loop.last %}, {% elif loop.last and not loop.first %} et {% endif -%}
               {{ name }}
             {% endfor %}
             est {{ state.state_with_unit }}
           {% else %}
-            Les appareils 
             {% for name in match %}
               {% if not loop.first and not loop.last %}, {% elif loop.last and not loop.first %} et {% endif -%}
               {{ name }}

--- a/sentences/fr/homeassistant_HassGetState.yaml
+++ b/sentences/fr/homeassistant_HassGetState.yaml
@@ -3,7 +3,11 @@ intents:
   HassGetState:
     data:
       - sentences:
-          - quel est [l'etat de|le statut de ] <name> [<dans> <area>]
+          - quel est [l'etat de|l'état de|le statut de] <name> [<dans> <area>]
+          - quelle est [la valeur de] <name> [<dans> <area>]
+          - comment est <name> [<dans> <area>]
+          - donne moi [l'etat de|l'état de|le statut de] <name> [<dans> <area>]
+          - donne moi [la valeur de] <name> [<dans> <area>]
         response: one
         excludes_context:
           domain:

--- a/sentences/fr/homeassistant_HassGetState.yaml
+++ b/sentences/fr/homeassistant_HassGetState.yaml
@@ -6,6 +6,7 @@ intents:
           - quel est [l'etat de|l'état de|le statut de] <name> [<dans> <area>]
           - quelle est [la valeur de] <name> [<dans> <area>]
           - comment est <name> [<dans> <area>]
+          - comment va <name> [<dans> <area>]
           - donne moi [l'etat de|l'état de|le statut de|la valeur de] <name> [<dans> <area>]
         response: one
         excludes_context:

--- a/sentences/fr/homeassistant_HassGetState.yaml
+++ b/sentences/fr/homeassistant_HassGetState.yaml
@@ -6,8 +6,7 @@ intents:
           - quel est [l'etat de|l'état de|le statut de] <name> [<dans> <area>]
           - quelle est [la valeur de] <name> [<dans> <area>]
           - comment est <name> [<dans> <area>]
-          - donne moi [l'etat de|l'état de|le statut de] <name> [<dans> <area>]
-          - donne moi [la valeur de] <name> [<dans> <area>]
+          - donne moi [l'etat de|l'état de|le statut de|la valeur de] <name> [<dans> <area>]
         response: one
         excludes_context:
           domain:

--- a/tests/fr/binary_sensor_HassGetState.yaml
+++ b/tests/fr/binary_sensor_HassGetState.yaml
@@ -21,7 +21,7 @@ tests:
         device_class: battery
         area: "cuisine"
         state: "off"
-    response: "Non, pas l'appareil téléphone"
+    response: "Non, pas téléphone"
 
   - sentences:
       - "Toutes les batteries sont elles pleines ?"
@@ -31,7 +31,7 @@ tests:
         domain: binary_sensor
         device_class: battery
         state: "off"
-    response: "Non, pas l'appareil téléphone"
+    response: "Non, pas téléphone"
 
   - sentences:
       - "Quelles batteries sont faibles ?"
@@ -41,7 +41,7 @@ tests:
         domain: binary_sensor
         device_class: battery
         state: "on"
-    response: "L'appareil téléphone est faible"
+    response: "téléphone est faible"
 
   - sentences:
       - "Combien de batteries sont elles faibles ?"
@@ -86,7 +86,7 @@ tests:
         domain: binary_sensor
         device_class: battery_charging
         state: "on"
-    response: "Oui, les appareils portable et téléphone sont en charge"
+    response: "Oui, portable et téléphone sont en charge"
 
   - sentences:
       - "Y a-t-il des batteries en charge dans la cuisine?"
@@ -97,7 +97,7 @@ tests:
         device_class: battery_charging
         state: "on"
         area: "cuisine"
-    response: "Oui, l'appareil téléphone est en charge"
+    response: "Oui, téléphone est en charge"
 
   - sentences:
       - "Toutes les batteries sont elles en chargement ?"
@@ -119,7 +119,7 @@ tests:
         domain: binary_sensor
         device_class: battery_charging
         state: "on"
-    response: "Les appareils portable et téléphone sont en charges"
+    response: "portable et téléphone sont en charges"
 
   - sentences:
       - "Combien de batteries sont en charge ?"
@@ -177,7 +177,7 @@ tests:
         device_class: "carbon_monoxide"
         area: chambre
         state: "on"
-    response: "Oui, l'appareil capteur CO2 chambre est déclenché"
+    response: "Oui, capteur CO2 chambre est déclenché"
 
   - sentences:
       - "Il y a un capteur de CO2 déclenché ?"
@@ -187,7 +187,7 @@ tests:
         domain: binary_sensor
         device_class: carbon_monoxide
         state: "on"
-    response: "Oui, l'appareil capteur CO2 chambre est déclenché"
+    response: "Oui, capteur CO2 chambre est déclenché"
 
   - sentences:
       - "Y a-t-il un capteur de CO2 déclenché dans la cuisine ?"
@@ -209,7 +209,7 @@ tests:
         domain: binary_sensor
         device_class: carbon_monoxide
         state: "on"
-    response: "Non, pas l'appareil capteur monoxyde"
+    response: "Non, pas capteur monoxyde"
 
   - sentences:
       - "Tous les capteurs de CO2 sont ils sécurisés ?"
@@ -219,7 +219,7 @@ tests:
         domain: binary_sensor
         device_class: carbon_monoxide
         state: "off"
-    response: "Non, pas l'appareil capteur CO2 chambre"
+    response: "Non, pas capteur CO2 chambre"
 
   - sentences:
       - "Quel capteur de CO2 est détecté ?"
@@ -230,7 +230,7 @@ tests:
         domain: binary_sensor
         device_class: carbon_monoxide
         state: "on"
-    response: "L'appareil capteur CO2 chambre est déclenché"
+    response: "capteur CO2 chambre est déclenché"
 
   - sentences:
       - "Quel capteur de CO2 est détecté dans la chambre?"
@@ -241,7 +241,7 @@ tests:
         domain: binary_sensor
         device_class: carbon_monoxide
         state: "on"
-    response: "L'appareil capteur CO2 chambre est déclenché"
+    response: "capteur CO2 chambre est déclenché"
 
   - sentences:
       - "Combien de capteurs de monoxyde sont en alarme ?"
@@ -287,7 +287,7 @@ tests:
         domain: binary_sensor
         device_class: cold
         state: "on"
-    response: "L'appareil tuyau est froid"
+    response: "tuyau est froid"
 
   - sentences:
       - "Combien de choses sont froides?"
@@ -319,7 +319,7 @@ tests:
         domain: binary_sensor
         device_class: connectivity
         state: "on"
-    response: "Oui, l'appareil Téléphone est connecté"
+    response: "Oui, Téléphone est connecté"
 
   - sentences:
       - "toutes les appareils sont ils connectés ?"
@@ -339,7 +339,7 @@ tests:
         domain: binary_sensor
         device_class: connectivity
         state: "on"
-    response: "L'appareil Téléphone est connecté"
+    response: "Téléphone est connecté"
 
   - sentences:
       - "Combien d'appareils sont connectés ?"

--- a/tests/fr/cover_HassGetState.yaml
+++ b/tests/fr/cover_HassGetState.yaml
@@ -30,7 +30,7 @@ tests:
         area: "salon"
         device_class: curtain
         state: "open"
-    response: "Oui, l'appareil rideau droit est ouvert"
+    response: "Oui, rideau droit est ouvert"
 
   - sentences:
       - "tous les rideaux sont ouverts dans le salon ?"
@@ -42,7 +42,7 @@ tests:
         area: "salon"
         device_class: curtain
         state: "open"
-    response: "Non, pas l'appareil rideau gauche"
+    response: "Non, pas rideau gauche"
 
   - sentences:
       - "quels rideaux sont fermés ?"
@@ -52,7 +52,7 @@ tests:
         domain: cover
         device_class: curtain
         state: "closed"
-    response: "Les appareils rideau de la chambre et rideau gauche sont fermés"
+    response: "rideau de la chambre et rideau gauche sont fermés"
 
   - sentences:
       - "combien de rideaux sont fermés ?"

--- a/tests/fr/homeassistant_HassGetState.yaml
+++ b/tests/fr/homeassistant_HassGetState.yaml
@@ -12,6 +12,7 @@ tests:
 
   - sentences:
       - "Comment est la lampe de chevet?"
+      - "Comment va la lampe de chevet  s'il te plaît ?"
       - "donne moi l'état de la lampe de chevet"
     intent:
       name: HassGetState

--- a/tests/fr/homeassistant_HassGetState.yaml
+++ b/tests/fr/homeassistant_HassGetState.yaml
@@ -2,11 +2,22 @@ language: fr
 tests:
   - sentences:
       - "quel est la température extérieure ?"
+      - "quelle est la température extérieure s'il te plaît?"
+      - "donne moi la température extérieure"
     intent:
       name: HassGetState
       slots:
         name: "température extérieure"
-    response: "L'etat de l'appareil Température extérieure est 21 °C"
+    response: "Température extérieure est 21 °C"
+
+  - sentences:
+      - "Comment est la lampe de chevet?"
+      - "donne moi l'état de la lampe de chevet"
+    intent:
+      name: HassGetState
+      slots:
+        name: "lampe de chevet"
+    response: "Lampe de chevet est éteinte"
 
   - sentences:
       - "La lampe de chevet de la chambre est allumée ?"
@@ -20,12 +31,13 @@ tests:
 
   - sentences:
       - "Quel est le statut de l'interrupteur de l'entrée ?"
+      - "Donne moi l'état de l'interrupteur de l'entrée ?"
     intent:
       name: HassGetState
       slots:
         name: "interrupteur"
         area: "entrée"
-    response: "L'etat de l'appareil Interrupteur est allumé"
+    response: "Interrupteur est allumé"
 
   - sentences:
       - "tous les interrupteurs sont allumés ?"
@@ -43,7 +55,7 @@ tests:
       slots:
         domain: "light"
         state: "off"
-    response: "Oui, l'appareil lampe de chevet est éteinte"
+    response: "Oui, lampe de chevet est éteinte"
 
   - sentences:
       - "quelles sont les lumières allumées ?"
@@ -52,7 +64,7 @@ tests:
       slots:
         domain: "light"
         state: "on"
-    response: "Les appareils lampe de l'entrée et lumière du plafond sont allumés"
+    response: "lampe de l'entrée et lumière du plafond sont allumés"
 
   - sentences:
       - "combien de lumières sont allumées ?"

--- a/tests/fr/lock_HassGetState.yaml
+++ b/tests/fr/lock_HassGetState.yaml
@@ -20,7 +20,7 @@ tests:
       slots:
         domain: lock
         state: "unlocked"
-    response: "Oui, l'appareil porte d'entrée est déverrouillé"
+    response: "Oui, porte d'entrée est déverrouillé"
 
   - sentences:
       - "Toutes les portes sont-elles fermées ?"
@@ -29,7 +29,7 @@ tests:
       slots:
         domain: lock
         state: "locked"
-    response: "Non, pas l'appareil porte d'entrée"
+    response: "Non, pas porte d'entrée"
 
   - sentences:
       - "Quelles portes sont verrouillées ?"
@@ -38,7 +38,7 @@ tests:
       slots:
         domain: lock
         state: "locked"
-    response: "L'appareil porte de garage est verrouillé"
+    response: "porte de garage est verrouillé"
 
   - sentences:
       - "combien de portes sont verrouillées ?"


### PR DESCRIPTION
Added a few sentences that feel more natural when trying to get the state of a sensor.
A few examples:

- Donne moi la température extérieure
- Donne moi la valeur de ...
- etc...

I also added the feminine of "Quel est" ...
Today if you ask assist "Quelle est la temperature extérieure?", no intent will match because the STT understands feminine but the only intent available is masculine "Quel est ..."

I also removed the word "Appareil" from every response to simplify the answers 