### PR TITLE
[DE] exclude sensor and binary sensor from homeassistant_HassTurnOff and homeassistant_HassTurnOn

### DIFF
--- a/sentences/de/homeassistant_HassTurnOff.yaml
+++ b/sentences/de/homeassistant_HassTurnOff.yaml
@@ -10,7 +10,9 @@ intents:
           - <name> <aus>[schalten]
         excludes_context:
           domain:
+            - binary_sensor
             - cover
             - lock
             - scene
             - script
+            - sensor

--- a/sentences/de/homeassistant_HassTurnOn.yaml
+++ b/sentences/de/homeassistant_HassTurnOn.yaml
@@ -10,7 +10,9 @@ intents:
           - <name> <an>[schalten]
         excludes_context:
           domain:
+            - binary_sensor
             - cover
             - lock
             - scene
             - script
+            - sensor


### PR DESCRIPTION
Exclude `sensor` and `binary_sensor` from `homeassistant_HassTurnOff` and `homeassistant_HassTurnOn` as they are in English.