### PR TITLE
[EN] Add short form of what's in HassGetState

### DIFF
--- a/sentences/en/homeassistant_HassGetState.yaml
+++ b/sentences/en/homeassistant_HassGetState.yaml
@@ -3,7 +3,7 @@ intents:
   HassGetState:
     data:
       - sentences:
-          - (do you know|tell me|what is) [the state of] <name> [in <area>]
+          - (do you know|tell me|<what_is>) [the state of] <name> [in <area>]
         response: one
         excludes_context:
           domain:

--- a/tests/en/homeassistant_HassGetState.yaml
+++ b/tests/en/homeassistant_HassGetState.yaml
@@ -2,6 +2,7 @@ language: en
 tests:
   - sentences:
       - "what is the outside temperature?"
+      - "what's the outside temperature?"
     intent:
       name: HassGetState
       slots:


### PR DESCRIPTION
An attempt to fix #1343 

The short form of "what is" ("what's") was missing from the sentences for the `homeassistant_HassGetState` intent.