### PR TITLE
[DE] improve homeassistant_HassTurnOn and homeassistant_HassTurnOff

### DIFF
--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -128,6 +128,7 @@ expansion_rules:
   alle: "(alle|sämtliche)"
   schliessen: "(schlie(ß|ss)[e|en]|zumachen|zu machen)"
   öffnen: "(öffne[n]|aufmachen|auf machen)"
+  schalten: "(schalt[e|en])"
   machen: "(mach[e|en])"
   setzen: "(setz[e|en]|stell[e|en]|einstellen|änder[e|n]|veränder[e|n])"
   abdeckung: "(das Rollo|die Rollos|die (Abdeckung|Abdeckungen)|(den|die) Rolll(a|ä)den|die (Jalousie|Jalousien)|(den|die) Raffstore[s]|die (Markise|Markisen))"

--- a/sentences/de/homeassistant_HassTurnOff.yaml
+++ b/sentences/de/homeassistant_HassTurnOff.yaml
@@ -3,11 +3,11 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - (schalte|<machen>) <name> <aus>
+          - (<schalten>|<machen>) <name> <aus>
           - stoppe <name>
           - <deaktivieren> <name>
           - <name> <deaktivieren>
-          - <name> <aus>[schalten|<machen>]
+          - <name> <aus>[<schalten>|<machen>]
         excludes_context:
           domain:
             - binary_sensor

--- a/sentences/de/homeassistant_HassTurnOff.yaml
+++ b/sentences/de/homeassistant_HassTurnOff.yaml
@@ -3,11 +3,11 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - schalte <name> <aus>
+          - (schalte|<machen>) <name> <aus>
           - stoppe <name>
           - <deaktivieren> <name>
           - <name> <deaktivieren>
-          - <name> <aus>[schalten]
+          - <name> <aus>[schalten|<machen>]
         excludes_context:
           domain:
             - binary_sensor

--- a/sentences/de/homeassistant_HassTurnOn.yaml
+++ b/sentences/de/homeassistant_HassTurnOn.yaml
@@ -3,11 +3,11 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - (schalte|<machen>) <name> <an>
+          - (<schalten>|<machen>) <name> <an>
           - starte <name>
           - <aktivieren> <name>
           - <name> <aktivieren>
-          - <name> <an>[schalten|<machen>]
+          - <name> <an>[<schalten>|<machen>]
         excludes_context:
           domain:
             - binary_sensor

--- a/sentences/de/homeassistant_HassTurnOn.yaml
+++ b/sentences/de/homeassistant_HassTurnOn.yaml
@@ -3,11 +3,11 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - schalte <name> <an>
+          - (schalte|<machen>) <name> <an>
           - starte <name>
           - <aktivieren> <name>
           - <name> <aktivieren>
-          - <name> <an>[schalten]
+          - <name> <an>[schalten|<machen>]
         excludes_context:
           domain:
             - binary_sensor

--- a/tests/de/homeassistant_HassTurnOff.yaml
+++ b/tests/de/homeassistant_HassTurnOff.yaml
@@ -2,10 +2,12 @@ language: de
 tests:
   - sentences:
       - schalte die Schlafzimmerlampe aus
+      - mach die Schlafzimmerlampe aus
       - schalte bitte die Schlafzimmerlampe aus
       - bitte schalte die Schlafzimmerlampe aus
       - bitte die Schlafzimmerlampe ausschalten
       - Schlafzimmerlampe ausschalten
+      - Schlafzimmerlampe ausmachen
       - Schlafzimmerlampe abschalten
       - Schlafzimmerlampe aus
     intent:

--- a/tests/de/homeassistant_HassTurnOn.yaml
+++ b/tests/de/homeassistant_HassTurnOn.yaml
@@ -3,11 +3,13 @@ tests:
   - sentences:
       - schalte den Deckenventilator ein
       - schalte den Deckenventilator an
+      - mache den Deckenventilator an
       - starte den Deckenventilator
       - aktiviere den Deckenventilator
       - bitte den Deckenventilator anschalten
       - den Deckenventilator anschalten
       - Deckenventilator anschalten
+      - Deckenventilator anmachen
       - Deckenventilator an
       - Deckenventilator ein
     intent:


### PR DESCRIPTION
Add `<machen>` for more possible commands and `<schalten>` for the sake of reusability.