### PR TITLE
[FR] Match french answers to the official Response Style Guide (part 1)

### DIFF
--- a/responses/fr/HassLightSet.yaml
+++ b/responses/fr/HassLightSet.yaml
@@ -3,5 +3,4 @@ responses:
   intents:
     HassLightSet:
       brightness: "Luminosité réglée"
-      color: "Couleur de {{ slots.name }} réglée en {{ slots.color }}"
-      color_area: "Couleur de {{ slots.area }} réglée en {{ slots.color }}"
+      color: "Couleur réglée"

--- a/responses/fr/HassTurnOff.yaml
+++ b/responses/fr/HassTurnOff.yaml
@@ -2,10 +2,8 @@ language: fr
 responses:
   intents:
     HassTurnOff:
-      default: "{{ slots.name }} éteint"
+      default: "éteint"
       lights: "Lumières éteintes"
-      fans_area: "Ventilateurs de {{ slots.area }} éteints"
-      fan_all: "Tous les ventilateurs sont éteints"
-      cover: "{{ slots.name }} fermé"
-      cover_area: "Ouvrants de {{ slots.area }} fermés"
+      fans: "Ventilateurs éteints"
+      covers: "Ouvrants fermés"
       cover_device_class: "{{ slots.device_class }} fermé"

--- a/responses/fr/HassTurnOn.yaml
+++ b/responses/fr/HassTurnOn.yaml
@@ -2,11 +2,8 @@ language: fr
 responses:
   intents:
     HassTurnOn:
-      default: "{{ slots.name }} allumé"
+      default: "Allumé"
       lights: "Lumières allumées"
-      fans_area: "Ventilateurs de {{ slots.area }} allumés"
-      fan_all: "Allume tous les ventilateurs"
-      cover: "{{ slots.name }} ouvert"
-      cover_area: "Ouvrants de {{ slots.area }} ouverts"
+      fans: "Ventilateurs allumés"
+      covers: "Ouvrants ouverts"
       cover_device_class: "{{ slots.device_class }} ouvert"
-      cover_all: "Ouvre tous les ouvrants de {{ slots.area }}"

--- a/sentences/fr/cover_HassTurnOff.yaml
+++ b/sentences/fr/cover_HassTurnOff.yaml
@@ -10,7 +10,7 @@ intents:
           domain: cover
       - sentences:
           - <ferme> [tous] (<volets>|<volet>) <dans> <area>
-        response: cover_area
+        response: covers
         slots:
           device_class:
             - blind

--- a/sentences/fr/cover_HassTurnOn.yaml
+++ b/sentences/fr/cover_HassTurnOn.yaml
@@ -10,7 +10,7 @@ intents:
           domain: cover
       - sentences:
           - <ouvre> [tous] (<volets>|<volet>) <dans> <area>
-        response: cover_area
+        response: covers
         slots:
           device_class:
             - blind

--- a/sentences/fr/fan_HassTurnOff.yaml
+++ b/sentences/fr/fan_HassTurnOff.yaml
@@ -7,9 +7,9 @@ intents:
         slots:
           domain: fan
           name: all
-        response: fan_all
+        response: fans
       - sentences:
           - "<eteins> <ventilateur> [<dans>] [<area>]"
         slots:
           domain: fan
-        response: fans_area
+        response: fans

--- a/sentences/fr/fan_HassTurnOn.yaml
+++ b/sentences/fr/fan_HassTurnOn.yaml
@@ -7,9 +7,9 @@ intents:
         slots:
           domain: fan
           name: all
-        response: fan_all
+        response: fans
       - sentences:
           - "<allume> (<ventilateur> | <ventilateurs>) [<dans>] [<area>]"
         slots:
           domain: fan
-        response: fans_area
+        response: fans

--- a/sentences/fr/homeassistant_HassTurnOff.yaml
+++ b/sentences/fr/homeassistant_HassTurnOff.yaml
@@ -7,7 +7,7 @@ intents:
           - <eteins> <name> <dans> <area>
       - sentences:
           - <ferme> <name>
-        response: cover
+        response: covers
       - sentences:
           - <ferme> <name> <dans> <area>
-        response: cover_area
+        response: covers

--- a/sentences/fr/homeassistant_HassTurnOn.yaml
+++ b/sentences/fr/homeassistant_HassTurnOn.yaml
@@ -7,7 +7,7 @@ intents:
           - <allume> <name> <dans> <area>
       - sentences:
           - <ouvre> <name>
-        response: cover
+        response: covers
       - sentences:
           - <ouvre> <name> <dans> <area>
-        response: cover_area
+        response: covers

--- a/sentences/fr/light_HassLightSet.yaml
+++ b/sentences/fr/light_HassLightSet.yaml
@@ -38,14 +38,25 @@ intents:
           - "(augmente|baisse) [la] (luminosité|lumière) [<de>] <name> [dans] <area> [à] <brightness>"
         response: brightness
 
-      # color
+      # color (name)
       - sentences:
-          - <regle> [la couleur] [de | des] [toutes] <lumieres> <dans> <area> [avec la
-            couleur | de couleur | en] {color}
+          - "<regle> [la couleur] [<de>] <name> [en] {color}"
+          - "<regle> <name> [avec la couleur | de couleur | en] {color}"
+          - "<allume> <name> [avec la couleur | de couleur | en] {color}"
+        response: color
+
+      # color (area)
+      - sentences:
+          - "<regle> [la couleur] [<de>] [toutes] [<lumieres>] [<de>] <area> [en] {color}"
+          - "<regle> [la couleur] [des] [<lumieres>] [<dans>] <area> [en] {color}"
+          - "<regle> [toutes] [<lumieres>] [<de>] <area> [avec la couleur | de couleur | en] {color}"
+          - "<allume> [toutes] [<lumieres>] [<de>] <area> [avec la couleur | de couleur | en] {color}"
         slots:
           name: all
-        response: color_area
+        response: color
+
+      # color (name + area)
       - sentences:
-          - <regle> [la couleur de] <name> <dans> <area> [avec la couleur |
+          - <regle> [la couleur de] <name> [<dans>] <area> [avec la couleur |
             de couleur | en] {color}
-        response: color_area
+        response: color

--- a/tests/fr/cover_HassTurnOff.yaml
+++ b/tests/fr/cover_HassTurnOff.yaml
@@ -30,7 +30,7 @@ tests:
           - curtain
           - shutter
         domain: cover
-    response: Ouvrants de cuisine fermés
+    response: Ouvrants fermés
   - sentences:
       - ferme tous les stores
       - baisser tous les stores

--- a/tests/fr/cover_HassTurnOn.yaml
+++ b/tests/fr/cover_HassTurnOn.yaml
@@ -30,7 +30,7 @@ tests:
           - curtain
           - shutter
         domain: cover
-    response: Ouvrants de cuisine ouverts
+    response: Ouvrants ouverts
   - sentences:
       - ouvre tous les stores
       - monter tous les stores

--- a/tests/fr/fan_HassTurnOff.yaml
+++ b/tests/fr/fan_HassTurnOff.yaml
@@ -13,4 +13,4 @@ tests:
         area: salon
         domain: fan
         name: all
-    response: "Tous les ventilateurs sont éteints"
+    response: "Ventilateurs éteints"

--- a/tests/fr/fan_HassTurnOn.yaml
+++ b/tests/fr/fan_HassTurnOn.yaml
@@ -11,4 +11,4 @@ tests:
         area: salon
         domain: fan
         name: all
-    response: "Allume tous les ventilateurs"
+    response: "Ventilateurs allumés"

--- a/tests/fr/homeassistant_HassTurnOff.yaml
+++ b/tests/fr/homeassistant_HassTurnOff.yaml
@@ -9,7 +9,7 @@ tests:
       slots:
         name: lumière du plafond
         area: chambre
-    response: "lumière du plafond éteint"
+    response: "éteint"
   - sentences:
       - éteins le ventilateur de plafond
       - arrêter le ventilateur de plafond
@@ -17,7 +17,7 @@ tests:
       name: HassTurnOff
       slots:
         name: ventilateur de plafond
-    response: "ventilateur de plafond éteint"
+    response: "éteint"
   - sentences:
       - stoppe le ventilateur de plafond de la chambre
     intent:
@@ -25,7 +25,7 @@ tests:
       slots:
         name: ventilateur de plafond
         area: chambre
-    response: "ventilateur de plafond éteint"
+    response: "éteint"
   - sentences:
       - ferme le rideau gauche
       - baisser le rideau gauche
@@ -33,7 +33,7 @@ tests:
       name: HassTurnOff
       slots:
         name: rideau gauche
-    response: "rideau gauche fermé"
+    response: "Ouvrants fermés"
   - sentences:
       - ferme le rideau gauche du salon
       - baisser le rideau gauche du salon
@@ -42,7 +42,7 @@ tests:
       slots:
         name: rideau gauche
         area: salon
-    response: "Ouvrants de salon fermés"
+    response: "Ouvrants fermés"
   - sentences:
       - ferme la porte du garage
       - baisser la porte du garage
@@ -69,7 +69,7 @@ tests:
           - curtain
           - shutter
         domain: cover
-    response: "Ouvrants de cuisine fermés"
+    response: "Ouvrants fermés"
   - sentences:
       - baisse tous les stores
       - fermer tous les volets

--- a/tests/fr/homeassistant_HassTurnOn.yaml
+++ b/tests/fr/homeassistant_HassTurnOn.yaml
@@ -7,7 +7,7 @@ tests:
       name: HassTurnOn
       slots:
         name: ventilateur de plafond
-    response: "ventilateur de plafond allumé"
+    response: "Allumé"
   - sentences:
       - allume l'interrupteur de la cuisine
       - activer l'interrupteur de la cuisine
@@ -15,7 +15,7 @@ tests:
       name: HassTurnOn
       slots:
         name: interrupteur de la cuisine
-    response: "interrupteur de la cuisine allumé"
+    response: "Allumé"
   - sentences:
       - allume le ventilateur de plafond du salon
       - activer le ventilateur de plafond du salon
@@ -24,7 +24,7 @@ tests:
       slots:
         name: ventilateur de plafond
         area: salon
-    response: "ventilateur de plafond allumé"
+    response: "Allumé"
   - sentences:
       - ouvre le rideau gauche
       - monter le rideau gauche
@@ -32,7 +32,7 @@ tests:
       name: HassTurnOn
       slots:
         name: rideau gauche
-    response: "rideau gauche ouvert"
+    response: "Ouvrants ouverts"
   - sentences:
       - ouvre le rideau gauche du salon
       - monter le rideau gauche du salon
@@ -41,7 +41,7 @@ tests:
       slots:
         name: rideau gauche
         area: salon
-    response: "Ouvrants de salon ouverts"
+    response: "Ouvrants ouverts"
   - sentences:
       - ouvre la porte du garage
       - monter la porte du garage
@@ -71,7 +71,7 @@ tests:
           - curtain
           - shutter
         domain: cover
-    response: "Ouvrants de cuisine ouverts"
+    response: "Ouvrants ouverts"
   - sentences:
       - ouvre tous les stores
       - monter tous les volets

--- a/tests/fr/light_HassLightSet.yaml
+++ b/tests/fr/light_HassLightSet.yaml
@@ -61,7 +61,35 @@ tests:
         area: chambre
     response: Luminosité réglée
 
-  # color
+  # color (name)
+  - sentences:
+      - "règle la lampe de chevet en rouge"
+      - "règle la couleur de la lampe de chevet en rouge"
+      - "allume la lampe de chevet en rouge"
+      - "régler la lampe de chevet en rouge"
+    intent:
+      name: HassLightSet
+      slots:
+        color: red
+        name: lampe de chevet
+    response: Couleur réglée
+
+  # color (area)
+  - sentences:
+      - "règle la cuisine en rouge"
+      - "allume la cuisine en rouge"
+      - "régler la cuisine en rouge"
+      - "règle les lumières de la cuisine en rouge"
+      - "allume les lumières de la cuisine en rouge"
+    intent:
+      name: HassLightSet
+      slots:
+        color: red
+        area: cuisine
+        name: all
+    response: Couleur réglée
+
+  # color (name + area)
   - sentences:
       - met la lumière du plafond de la chambre en rouge
       - mettre la lumière du plafond de la chambre de couleur rouge
@@ -72,6 +100,7 @@ tests:
         area: chambre
         color: red
         name: lumière du plafond
+    response: Couleur réglée
   - sentences:
       - met la lumière du plafond de la chambre en blanc
       - mettre la lumière du plafond de la chambre de couleur blanche
@@ -81,6 +110,7 @@ tests:
         area: chambre
         color: white
         name: lumière du plafond
+    response: Couleur réglée
   - sentences:
       - met la couleur de la lampe de chevet de la chambre en rouge
       - régler la couleur de la lampe de chevet de la chambre en rouge
@@ -90,6 +120,7 @@ tests:
         area: chambre
         color: red
         name: lampe de chevet
+    response: Couleur réglée
 
   - sentences:
       - met la couleur des lampes de la chambre en rouge
@@ -100,3 +131,4 @@ tests:
         area: chambre
         color: red
         name: all
+    response: Couleur réglée


### PR DESCRIPTION
👋 

As per [this discussion](https://github.com/home-assistant/intents/discussions/1354), and as per [this guide](https://developers.home-assistant.io/docs/voice/intent-recognition/style-guide/), I removed all mentions of {name} and {area} in the 3 most used intents

- HassLightSet
- HassTurnOff
- HassTurnOn

The answers are now simpler and more generic, so they are cached better (among other benefits)

I'll try to do the other intent whenever I have time 🙏
