### PR TITLE
[el] Add sentences/test for homeassistant_HassGetState

### DIFF
--- a/sentences/el/_common.yaml
+++ b/sentences/el/_common.yaml
@@ -52,9 +52,9 @@ lists:
         out: 1
   on_off_states:
     values:
-      - in: "on"
+      - in: "(ανοι(κ|χ)τ(ός|ή|ό|οί|ές|ά)|αναμμέν(ος|η|ο|οι|ες|α))"
         out: "on"
-      - in: "off"
+      - in: "(κλειστ|σβηστ)(ός|ή|ό|οί|ές|ά)"
         out: "off"
   on_off_domains:
     values:
@@ -62,7 +62,7 @@ lists:
         out: light
       - in: (ανεμιστήρα[ς])
         out: fan
-      - in: (διακόπτη[ς|ες])
+      - in: διακόπτ(ης|η|ες)
         out: switch
   cover_states:
     values:

--- a/sentences/el/homeassistant_HassGetState.yaml
+++ b/sentences/el/homeassistant_HassGetState.yaml
@@ -1,4 +1,39 @@
 language: el
 intents:
   HassGetState:
-    data: []
+    data:
+      - sentences:
+          # - (do you know|tell me|<what_is>) [the state of] <name> [in <area>]
+          - (ποι(ός|α|ο|οί|ές|α) είναι) [κατάσταση] <name> [<area>]
+          - τι κατάσταση έχει <name> [<area>]
+          - σε (τι|ποια) κατάσταση (είναι|βρίσκεται) <name> [<area>]
+        response: one
+        excludes_context:
+          domain:
+            - scene
+            - script
+
+      - sentences:
+          - είναι <name> {on_off_states:state} [<area>]
+        response: one_yesno
+        excludes_context:
+          domain:
+            - cover
+
+      - sentences:
+          - <exist> {on_off_domains:domain} {on_off_states:state} [<area>]
+          - <exist> {on_off_states:state} {on_off_domains:domain} [<area>]
+        response: any
+
+      - sentences:
+          - είναι [όλ(οι|ες|α)] (οι|τα) {on_off_domains:domain} {on_off_states:state} [<area>]
+          - είναι [όλ(οι|ες|α)] (οι|τα) {on_off_domains:domain} <area> {on_off_states:state}
+        response: all
+
+      - sentences:
+          - ποι(ος|α|ο|οι|ες) {on_off_domains:domain} [είναι] {on_off_states:state} [<area>]
+        response: which
+
+      - sentences:
+          - πόσ(οι|ες|α) {on_off_domains:domain} [είναι] {on_off_states:state} [<area>]
+        response: how_many

--- a/tests/el/_fixtures.yaml
+++ b/tests/el/_fixtures.yaml
@@ -12,14 +12,72 @@ areas:
     id: garden
 entities:
   - name: Φωτιστικό [του] υπνοδωματίου
+    state:
+      in: "κλειστό"
+      out: "off"
     id: light.bedroom_lamp
     area: bedroom
+
+  - name: Διακόπτη[ς] [του] υπνοδωματίου
+    state:
+      in: "κλειστός"
+      out: "off"
+    id: switch.bedroom
+    area: bedroom
+
   - name: Διακόπτη[ς] [της] κουζίνας
+    state:
+      in: "ανοικτός"
+      out: "on"
     id: switch.kitchen
     area: kitchen
+
+  - name: "Κουζίνα πάγκος"
+    id: "light.kitchen_countertop"
+    area: "kitchen"
+    state:
+      in: "ανοικτό"
+      out: "on"
+
+  - name: "Κουζίνα οροφή"
+    id: "light.kitchen_ceiling"
+    area: "kitchen"
+    state:
+      in: "ανοικτό"
+      out: "on"
+
+  - name: "Κουζίνα ντουλάπια"
+    id: "light.kitchen_cabinets"
+    area: "kitchen"
+    state:
+      in: "ανοικτό"
+      out: "on"
+
   - name: Ανεμιστήρα[ς] [της] οροφής
     id: fan.ceiling
     area: living_room
+
+  - name: "Εξωτερική θερμοκρασία"
+    id: "sensor.outside_temperature"
+    area: "garage"
+    state: "22"
+    attributes:
+      unit_of_measurement: "°C"
+
+  - name: "Φωτιστικό Σαλονιο'υ"
+    id: "light.living_room_lamp"
+    area: "living_room"
+    state:
+      in: "ανοικτό"
+      out: "on"
+
+  - name: "Φως [στο] Γκαράζ"
+    id: "light.garage"
+    area: "garage"
+    state:
+      in: "ανοικτό"
+      out: "on"
+
   - name: Θερμοστάτη[ς] [του] σαλονιού
     id: climate.living_room
     area: living_room

--- a/tests/el/homeassistant_HassGetState.yaml
+++ b/tests/el/homeassistant_HassGetState.yaml
@@ -1,2 +1,88 @@
 language: el
-tests: []
+tests:
+  - sentences:
+      - "ποια είναι η εξωτερική θερμοκρασία;"
+      - "τι κατάσταση έχει η εξωτερική θερμοκρασία;"
+      - "σε ποια κατάσταση βρίσκεται η εξωτερική θερμοκρασία;"
+    intent:
+      name: HassGetState
+      slots:
+        name: "Εξωτερική θερμοκρασία"
+    response: "Εξωτερική θερμοκρασία έχει κατάσταση 22 °C"
+
+  - sentences:
+      - "είναι το φωτιστικό υπνοδωματίου ανοικτό;"
+    intent:
+      name: HassGetState
+      slots:
+        name: "Φωτιστικό υπνοδωματίου"
+        state: "on"
+    response: "Όχι, κλειστό"
+
+  - sentences:
+      - "υπάρχουν ανοικτοί διακόπτες στην κουζίνα;"
+      - "υπάρχει διακόπτης αναμμένος στην κουζίνα;"
+    intent:
+      name: HassGetState
+      slots:
+        area: "Κουζίνα"
+        domain: "switch"
+        state: "on"
+    response: "Ναι, Διακόπτης της κουζίνας"
+
+  - sentences:
+      - "είναι όλοι οι διακόπτες ανοικτοί;"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "switch"
+        state: "on"
+    response: "Όχι, δεν ισχύει για Διακόπτης του υπνοδωματίου"
+
+  - sentences:
+      - "είναι οι διακόπτες στην κουζίνα αναμμένοι;"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "switch"
+        state: "on"
+        area: "Κουζίνα"
+    response: "Ναι"
+
+  - sentences:
+      - "είναι όλα τα φώτα σβηστά;"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "light"
+        state: "off"
+    response: "Όχι, δεν ισχύει για Κουζίνα ντουλάπια, Κουζίνα οροφή, Κουζίνα πάγκος και 2 ακόμα"
+
+  - sentences:
+      - "ποια φώτα είναι ανοικτά;"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "light"
+        state: "on"
+    response: "Κουζίνα ντουλάπια, Κουζίνα οροφή, Κουζίνα πάγκος και 2 ακόμα"
+
+  - sentences:
+      - "πόσα φώτα είναι ανοικτά;"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "light"
+        state: "on"
+    response: "5"
+
+  - sentences:
+      - "είναι όλα τα φώτα ανοικτά στην κουζίνα;"
+      - "είναι τα φώτα στην κουζίνα ανοικτά;"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "light"
+        state: "on"
+        area: "Κουζίνα"
+    response: "Ναι"


### PR DESCRIPTION
This PR adds the missing el sentences and tests for homeassistant_HassGetState.

Btw I'm generally trying to be consistent with the current translations of state values. But I noticed that the on/off states for light entities are currently translated as:
- on: Ενεργό
- off: Ανενεργό

I don't think that anyone really says "το φως είναι ενεργό", the usual phrases are:
- το φως είναι ανοικτό / κλειστό
- το φως είναι αναμμένο / σβηστό

Maybe we can try to fix this? Should this change be done in lokalise?