### PR TITLE
Fix recursive rule detection in tests

### DIFF
--- a/tests/test_language_intents.py
+++ b/tests/test_language_intents.py
@@ -99,7 +99,7 @@ def do_test_language_sentences(
                         language_sentences,
                         intent_name,
                         slot_schema,
-                        visited_rules=set(),
+                        initial_rule="",
                         found_slots=found_slots,
                     )
 
@@ -133,7 +133,7 @@ def _verify(
     intents: Intents,
     intent_name: str,
     slot_schema: dict[str, Any],
-    visited_rules: set[str],
+    initial_rule: str,
     found_slots: set[str],
 ) -> None:
     if isinstance(expression, ListReference):
@@ -158,11 +158,12 @@ def _verify(
         ), f"Missing expansion rule: <{rule_ref.rule_name}>. Are you missing an 'expansion_rules' entry in _common.yaml?"
 
         # Check for recursive rules (not supported)
-        assert (
-            rule_ref.rule_name not in visited_rules
-        ), f"Recursive rule detected: <{rule_ref.rule_name}>"
-
-        visited_rules.add(rule_ref.rule_name)
+        if not initial_rule:
+            initial_rule = rule_ref.rule_name
+        else:
+            assert (
+                rule_ref.rule_name != initial_rule
+            ), f"Recursive rule detected: <{rule_ref.rule_name}>"
 
         # Verify rule body
         for body_expression in _flatten(intents.expansion_rules[rule_ref.rule_name]):
@@ -171,7 +172,7 @@ def _verify(
                 intents,
                 intent_name,
                 slot_schema,
-                visited_rules,
+                initial_rule,
                 found_slots,
             )
 


### PR DESCRIPTION
the current recursive rule detection also recognize multiple usage of an expansion rule within another as recursion (_see https://github.com/home-assistant/intents/pull/1383#discussion_r1199583989_).

this PR will fix this

---
- defined expansion rules (_`sentences/de/_common.yaml`_)

```yaml
  ein: "ein[e|er|es|s]"
  irgend: "(irgend(<ein>|welche[s])|(einige|manche)[s]|<ein>) [der]"
```

- test result prior this change

```
$ pytest tests/test_language_intents.py --language de

[...]

E           AssertionError: Recursive rule detected: <ein>
E           assert 'ein' not in {'ein', 'irgend'}
E            +  where 'ein' = RuleReference(rule_name='ein').rule_name

tests/test_language_intents.py:161: AssertionError
======================================================================================================================================== short test summary info =========================================================================================================================================
FAILED tests/test_language_intents.py::test_binary_sensor_HassGetState[de] - AssertionError: Recursive rule detected: <ein>
====================================================================================================================================== 1 failed, 19 passed in 0.21s ======================================================================================================================================
```

- test result with this change

```
$ pytest tests/test_language_intents.py --language de

========================================================================================================================================== test session starts ===========================================================================================================================================
platform linux -- Python 3.10.10, pytest-7.2.2, pluggy-1.0.0
rootdir: /workspaces/homeassistant-intents, configfile: pyproject.toml
collected 20 items                                                                                                                                                                                                                                                                                       

tests/test_language_intents.py ....................                                                                                                                                                                                                                                                [100%]

=========================================================================================================================================== 20 passed in 0.20s ===========================================================================================================================================
```

---

regression/negativ test

- defined expansion rules (_`sentences/de/_common.yaml`_)

```yaml
  ein: "ein[e|er|es|s]"
  irgend: "(irgend(<irgend>|welche[s])|(einige|manche)[s]|<ein>) [der]"
```

- test result with this change

```
$ pytest tests/test_language_intents.py --language de

[...]

E               AssertionError: Recursive rule detected: <irgend>
E               assert 'irgend' != 'irgend'
E                +  where 'irgend' = RuleReference(rule_name='irgend').rule_name

tests/test_language_intents.py:164: AssertionError
======================================================================================================================================== short test summary info =========================================================================================================================================
FAILED tests/test_language_intents.py::test_binary_sensor_HassGetState[de] - AssertionError: Recursive rule detected: <irgend>
====================================================================================================================================== 1 failed, 19 passed in 0.20s ======================================================================================================================================
```