### PR TITLE
Local expansion rules

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hassil==1.0.6
+hassil==1.1.0
 PyYAML==6.0
 voluptuous==0.13.1
 regex==2023.3.23

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -128,6 +128,7 @@ SENTENCE_SCHEMA = vol.Schema(
             str: {
                 vol.Required("data"): [
                     {
+                        vol.Optional("expansion_rules"): {str: str},
                         vol.Required("sentences"): [SENTENCE_MATCHER],
                         vol.Optional("slots"): {
                             str: match_anything,

--- a/tests/test_language_intents.py
+++ b/tests/test_language_intents.py
@@ -7,8 +7,14 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from hassil import Intents
-from hassil.expression import Expression, ListReference, RuleReference, Sequence
-from hassil.intents import SlotList, TextSlotList
+from hassil.expression import (
+    Expression,
+    ListReference,
+    RuleReference,
+    Sentence,
+    Sequence,
+)
+from hassil.intents import TextSlotList
 
 from . import SENTENCES_DIR
 
@@ -138,7 +144,7 @@ def _verify(
     slot_schema: dict[str, Any],
     visited_rules: set[str],
     found_slots: set[str],
-    expansion_rules: dict[str, SlotList],
+    expansion_rules: dict[str, Sentence],
 ) -> None:
     if isinstance(expression, ListReference):
         list_ref: ListReference = expression
@@ -177,7 +183,7 @@ def _verify(
                 slot_schema,
                 visited_rules,
                 found_slots,
-                expansion_rules
+                expansion_rules,
             )
 
 

--- a/tests/test_language_intents.py
+++ b/tests/test_language_intents.py
@@ -8,7 +8,7 @@ from typing import Any, Iterable
 
 from hassil import Intents
 from hassil.expression import Expression, ListReference, RuleReference, Sequence
-from hassil.intents import TextSlotList
+from hassil.intents import SlotList, TextSlotList
 
 from . import SENTENCES_DIR
 
@@ -79,6 +79,8 @@ def do_test_language_sentences(
             if not data.sentences:
                 continue
 
+            expansion_rules = language_sentences.expansion_rules | data.expansion_rules
+
             if file_domain != "homeassistant":
                 # Domain specific files (ie light_HassTurnOn.yaml) should only match
                 # sentences for the light domain.
@@ -101,6 +103,7 @@ def do_test_language_sentences(
                         slot_schema,
                         visited_rules=set(),
                         found_slots=found_slots,
+                        expansion_rules=expansion_rules,
                     )
 
                 # Add inferred slots
@@ -135,6 +138,7 @@ def _verify(
     slot_schema: dict[str, Any],
     visited_rules: set[str],
     found_slots: set[str],
+    expansion_rules: dict[str, SlotList],
 ) -> None:
     if isinstance(expression, ListReference):
         list_ref: ListReference = expression
@@ -154,8 +158,8 @@ def _verify(
     elif isinstance(expression, RuleReference):
         rule_ref: RuleReference = expression
         assert (
-            rule_ref.rule_name in intents.expansion_rules
-        ), f"Missing expansion rule: <{rule_ref.rule_name}>. Are you missing an 'expansion_rules' entry in _common.yaml?"
+            rule_ref.rule_name in expansion_rules
+        ), f"Missing expansion rule: <{rule_ref.rule_name}>. Are you missing an 'expansion_rules' entry in _common.yaml or in the intent data?"
 
         # Check for recursive rules (not supported)
         assert (
@@ -165,7 +169,7 @@ def _verify(
         visited_rules.add(rule_ref.rule_name)
 
         # Verify rule body
-        for body_expression in _flatten(intents.expansion_rules[rule_ref.rule_name]):
+        for body_expression in _flatten(expansion_rules[rule_ref.rule_name]):
             _verify(
                 body_expression,
                 intents,
@@ -173,6 +177,7 @@ def _verify(
                 slot_schema,
                 visited_rules,
                 found_slots,
+                expansion_rules
             )
 
 


### PR DESCRIPTION
Bump hassil to 1.1.0 (Local expansion rules)
Implement logic that allows access to expansion rules in the context of an intent

We could easily have reusable sentences if we were able to define or overwrite some expansion rules locally. Imagine the following scenario:

Most nominal binary sensor sentences sound something like

```
- is [<some_particular_device_class>] <name> {bs_device_class_state:state} [in <area>]
- is <name> [<some_particular_device_class>] {bs_device_clas0s_state:state} [in <area>]
- is [<some_particular_device_class>] <name> in <area> {bs_device_class_state:state}
- is <name> [<some_particular_device_class>] in <area> {bs_device_class_state:state}
```

but it's hard to write those variations for each device_class.

Imagine the following expansion rule:

```
is_name_state_in_area: "is (<name> [<class>] | <class> <name>) (<state> [in <area>]|in <area> <state>)"
```

The `<name>` and `<area>` expansion rules are defined globally. But if, for each device class, you could do something like

```
intents:
  HassGetState:
    data:
      - expansion_rules:
          state: "{bs_battery_states:state}"
          class: "battery"
        sentences:
          - "<is_name_state_in_area>"
        response: one_yesno
        requires_context:
          domain: binary_sensor
          device_class: battery
        slots:
          domain: binary_sensor
          device_class: battery
      - expansion_rules:
          state: "{bs_gas_states:state}"
          class: "gas sensor"
        sentences:
          - "<is_name_state_in_area>"
        response: one_yesno
        requires_context:
          domain: binary_sensor
          device_class: gas
        slots:
          domain: binary_sensor
          device_class: gas
```

that would make the sentences far easier to write and maintain.