### PR TITLE
[EN] HassGetState for sensors with different device_class

### DIFF
--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -302,6 +302,9 @@ expansion_rules:
   close: "(close|shut|lower)"
   set: "(set|make|change|turn)"
   numeric_value_set: "(set|change|turn|increase|decrease|make)"
+
+  # Questions
+  what_is_the_class_of_name: "(<what_is> the <class> (of|in|from|(indicated|measured) by) <name> [in <area>]|<what_is> <name>['s] <class> [in <area>]|<what_is> <area> <name>['s] <class>)"
 skip_words:
   - "please"
   - "can you"

--- a/sentences/en/sensor_HassGetState.yaml
+++ b/sentences/en/sensor_HassGetState.yaml
@@ -107,3 +107,515 @@ intents:
           device_class: data_rate
         expansion_rules:
           class: "[(download|upload|data)] (rate|speed)"
+
+      # Data size
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: data_size
+        slots:
+          domain: sensor
+          device_class: data_size
+        expansion_rules:
+          class: "([data] size|(amount|size) of [the] data)"
+
+      # Date
+      - sentences:
+          - "<what_is_the_class_of_name>"
+          - "when ((is|was) <name>|will <name> be|(will|did) <name> happen)"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: date
+        slots:
+          domain: sensor
+          device_class: date
+        expansion_rules:
+          class: "[calendar[istic]] date"
+
+      # Distance
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: distance
+        slots:
+          domain: sensor
+          device_class: distance
+        expansion_rules:
+          class: "distance"
+
+      # Duration
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: duration
+        slots:
+          domain: sensor
+          device_class: duration
+        expansion_rules:
+          class: "duration"
+
+      # Energy
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: energy
+        slots:
+          domain: sensor
+          device_class: energy
+        expansion_rules:
+          class: "[amount of] energy"
+
+      # Energy storage
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: energy_storage
+        slots:
+          domain: sensor
+          device_class: energy_storage
+        expansion_rules:
+          class: "[[total] amount of] [stored] energy"
+
+      # Skipping enum
+
+      # Frequency
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: frequency
+        slots:
+          domain: sensor
+          device_class: frequency
+        expansion_rules:
+          class: "frequency"
+
+      # Gas
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: gas
+        slots:
+          domain: sensor
+          device_class: gas
+        expansion_rules:
+          class: "[amount of] gas [volume]"
+
+      # Humidity
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: humidity
+        slots:
+          domain: sensor
+          device_class: humidity
+        expansion_rules:
+          class: "[(air|atmospheric)] [relative] humidity"
+
+      # Illuminance
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: illuminance
+        slots:
+          domain: sensor
+          device_class: illuminance
+        expansion_rules:
+          class: "([amount of] illuminance|(light|brightness) level)"
+
+      # Irradiance
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: irradiance
+        slots:
+          domain: sensor
+          device_class: irradiance
+        expansion_rules:
+          class: "([amount of] irradiance|[ir]radiation level)"
+
+      # Moisture
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: moisture
+        slots:
+          domain: sensor
+          device_class: moisture
+        expansion_rules:
+          class: "([relative] moisture|(percentage|ratio) of water)"
+
+      # Monetary
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: monetary
+        slots:
+          domain: sensor
+          device_class: monetary
+        expansion_rules:
+          class: "[amount of] (money|cash|cost)"
+
+      # Nitrogen dioxide
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: nitrogen_dioxide
+        slots:
+          domain: sensor
+          device_class: nitrogen_dioxide
+        expansion_rules:
+          class: "(nitrogen dioxide|NO2) (level|concentration)"
+
+      # Nitrogen monoxide
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: nitrogen_monoxide
+        slots:
+          domain: sensor
+          device_class: nitrogen_monoxide
+        expansion_rules:
+          class: "(nitrogen monoxide|NO) (level|concentration)"
+
+      # Nitrous oxide
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: nitrous_oxide
+        slots:
+          domain: sensor
+          device_class: nitrous_oxide
+        expansion_rules:
+          class: "(nitrous oxide|N2O) (level|concentration)"
+
+      # Ozone
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: ozone
+        slots:
+          domain: sensor
+          device_class: ozone
+        expansion_rules:
+          class: "(ozone|O3) level"
+
+      # PM1
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: pm1
+        slots:
+          domain: sensor
+          device_class: pm1
+        expansion_rules:
+          class: "((level|concentration) [of] PM1 [particles]|PM1 [particles] [level|concentration])"
+
+      # PM2.5
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: pm25
+        slots:
+          domain: sensor
+          device_class: pm25
+        expansion_rules:
+          class: "((level|concentration) [of] PM2.5 [particles]|PM2.5 [particles] [level|concentration])"
+
+      # PM10
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: pm10
+        slots:
+          domain: sensor
+          device_class: pm10
+        expansion_rules:
+          class: "((level|concentration) [of] PM10 [particles]|PM10 [particles] [level|concentration])"
+
+      # Power factor
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: power_factor
+        slots:
+          domain: sensor
+          device_class: power_factor
+        expansion_rules:
+          class: "power factor"
+
+      # Power
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: power
+        slots:
+          domain: sensor
+          device_class: power
+        expansion_rules:
+          class: "power"
+
+      # Precipitation
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: precipitation
+        slots:
+          domain: sensor
+          device_class: precipitation
+        expansion_rules:
+          class: "[accumulated] (precipitation|(rain|snow)[fall]) [level|quantity]"
+
+      # Precipitation intensity
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: precipitation_intensity
+        slots:
+          domain: sensor
+          device_class: precipitation_intensity
+        expansion_rules:
+          class: "(precipitation|(rain|snow)[fall]) (intensity|rate)"
+
+      # Pressure
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: pressure
+        slots:
+          domain: sensor
+          device_class: pressure
+        expansion_rules:
+          class: "pressure"
+
+      # Reactive power
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: reactive_power
+        slots:
+          domain: sensor
+          device_class: reactive_power
+        expansion_rules:
+          class: "reactive power"
+
+      # Signal strength
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: signal_strength
+        slots:
+          domain: sensor
+          device_class: signal_strength
+        expansion_rules:
+          class: "signal strength"
+
+      # Sound pressure
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: sound_pressure
+        slots:
+          domain: sensor
+          device_class: sound_pressure
+        expansion_rules:
+          class: "(sound|acoustic) pressure"
+
+      # Speed
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: speed
+        slots:
+          domain: sensor
+          device_class: speed
+        expansion_rules:
+          class: "(speed|velocity)"
+
+      # Sulphur dioxide
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: sulphur_dioxide
+        slots:
+          domain: sensor
+          device_class: sulphur_dioxide
+        expansion_rules:
+          class: "(sulphur dioxide|SO2) (level|concentration)"
+
+      # Temperature
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: temperature
+        slots:
+          domain: sensor
+          device_class: temperature
+        expansion_rules:
+          class: "temperature"
+
+      # Skipping Timestamp
+
+      # Volatile organic compounds
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: volatile_organic_compounds
+        slots:
+          domain: sensor
+          device_class: volatile_organic_compounds
+        expansion_rules:
+          class: "[concentration of] (VOC[s]|[volatile] organic compound[s])"
+
+      # Volatile organic compounds
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: volatile_organic_compounds_parts
+        slots:
+          domain: sensor
+          device_class: volatile_organic_compounds_parts
+        expansion_rules:
+          class: "[(concentration|ratio) of] (VOC[s]|[volatile] organic compound[s])"
+
+      # Voltage
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: voltage
+        slots:
+          domain: sensor
+          device_class: voltage
+        expansion_rules:
+          class: "voltage [drop]"
+
+      # Volume
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: volume
+        slots:
+          domain: sensor
+          device_class: volume
+        expansion_rules:
+          class: "volume"
+
+      # Volume storage
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: volume_storage
+        slots:
+          domain: sensor
+          device_class: volume_storage
+        expansion_rules:
+          class: "[total] [stored] volume"
+
+      # Water
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: water
+        slots:
+          domain: sensor
+          device_class: water
+        expansion_rules:
+          class: "[total] ([amount of] [consumed] water|water consumption)"
+
+      # Weight
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: weight
+        slots:
+          domain: sensor
+          device_class: weight
+        expansion_rules:
+          class: "(weight|mass)"
+
+      # Wind speed
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: wind_speed
+        slots:
+          domain: sensor
+          device_class: wind_speed
+        expansion_rules:
+          class: "[wind] (speed|velocity)"

--- a/sentences/en/sensor_HassGetState.yaml
+++ b/sentences/en/sensor_HassGetState.yaml
@@ -1,0 +1,109 @@
+language: en
+intents:
+  HassGetState:
+    data:
+      # https://www.home-assistant.io/integrations/sensor/
+      # Apparent power
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: apparent_power
+        slots:
+          domain: sensor
+          device_class: apparent_power
+        expansion_rules:
+          class: "apparent power"
+
+      # AQI
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: aqi
+        slots:
+          domain: sensor
+          device_class: aqi
+        expansion_rules:
+          class: "(AQI|air quality [index])"
+
+      # Atmospheric pressure
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: atmospheric_pressure
+        slots:
+          domain: sensor
+          device_class: atmospheric_pressure
+        expansion_rules:
+          class: "(atmospheric|air) pressure"
+
+      # Battery
+      - sentences:
+          - "<what_is_the_class_of_name>"
+          - "how much battery (does <name> have [left]|has <name> got [left]|is left in <name>)"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: battery
+        slots:
+          domain: sensor
+          device_class: battery
+        expansion_rules:
+          class: "[remaining] battery [level]"
+
+      # CO2
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: carbon_dioxide
+        slots:
+          domain: sensor
+          device_class: carbon_dioxide
+        expansion_rules:
+          class: "(carbon dioxide|CO2) (level|concentration)"
+
+      # CO
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: carbon_monoxide
+        slots:
+          domain: sensor
+          device_class: carbon_monoxide
+        expansion_rules:
+          class: "(carbon monoxide|CO) (level|concentration)"
+
+      # Current
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: current
+        slots:
+          domain: sensor
+          device_class: current
+        expansion_rules:
+          class: "[amount of] [electric[al]] current"
+
+      # Data rate
+      - sentences:
+          - "<what_is_the_class_of_name>"
+        response: one
+        requires_context:
+          domain: sensor
+          device_class: data_rate
+        slots:
+          domain: sensor
+          device_class: data_rate
+        expansion_rules:
+          class: "[(download|upload|data)] (rate|speed)"

--- a/tests/en/_fixtures.yaml
+++ b/tests/en/_fixtures.yaml
@@ -399,3 +399,274 @@ entities:
     attributes:
       device_class: data_rate
       unit_of_measurement: "MB/s"
+
+  - name: "Log file"
+    id: "sensor.log_file_size"
+    state: "106"
+    attributes:
+      device_class: data_size
+      unit_of_measurement: "kB"
+
+  - name: "Next birthday"
+    id: "sensor.next_birthday"
+    state: "2024-04-01"
+    attributes:
+      device_class: date
+
+  - name: "Car mileage"
+    id: "sensor.car_mileage"
+    state: "65536"
+    attributes:
+      device_class: distance
+      unit_of_measurement: "km"
+
+  - name: "Dishwasher current program"
+    id: "sensor.dishwasher_program_duration"
+    state: "64"
+    attributes:
+      device_class: duration
+      unit_of_measurement: "min"
+
+  - name: "Solar production"
+    id: "sensor.solar_production"
+    state: "3.2"
+    attributes:
+      device_class: energy
+      unit_of_measurement: "kWh"
+
+  - name: "Powerwall stored energy"
+    id: "sensor.powerwall_stored_energy"
+    state: "6"
+    attributes:
+      device_class: energy_storage
+      unit_of_measurement: "kWh"
+
+  - name: "Grid AC frequency"
+    id: "sensor.grid_frequency"
+    state: "51"
+    attributes:
+      device_class: frequency
+      unit_of_measurement: "Hz"
+
+  - name: "Monthly gas consumption"
+    id: "sensor.monthly_gas_consumption"
+    state: "12"
+    attributes:
+      device_class: gas
+      unit_of_measurement: "m³"
+
+  - name: "Living room humidity"
+    id: "sensor.living_room_humidity"
+    state: "48"
+    attributes:
+      device_class: humidity
+      unit_of_measurement: "%"
+
+  - name: "Living room illuminance"
+    id: "sensor.living_room_illuminance"
+    state: "438"
+    attributes:
+      device_class: illuminance
+      unit_of_measurement: "lux"
+
+  - name: "Living room heater irradiance"
+    id: "sensor.living_room_heater_irradiance"
+    state: "155"
+    attributes:
+      device_class: irradiance
+      unit_of_measurement: "W/m²"
+
+  - name: "Brewery mixer"
+    id: "sensor.bewery_mixer_moisture"
+    state: "83"
+    attributes:
+      device_class: moisture
+      unit_of_measurement: "%"
+
+  - name: "Price per kW"
+    id: "sensor.price_per_kW"
+    state: "1"
+    attributes:
+      device_class: monetary
+      unit_of_measurement: "EUR"
+
+  - name: "Heat pump NO2 sensor"
+    id: "sensor.heat_pump_no2"
+    state: "50"
+    attributes:
+      device_class: nitrogen_dioxide
+      unit_of_measurement: "µg/m³"
+
+  - name: "Heat pump NO sensor"
+    id: "sensor.heat_pump_no"
+    state: "50"
+    attributes:
+      device_class: nitrogen_monoxide
+      unit_of_measurement: "µg/m³"
+
+  - name: "Heat pump N2O sensor"
+    id: "sensor.heat_pump_n2o"
+    state: "50"
+    attributes:
+      device_class: nitrous_oxide
+      unit_of_measurement: "µg/m³"
+
+  - name: "Living room ozone sensor"
+    id: "sensor.living_room_ozone"
+    state: "50"
+    attributes:
+      device_class: ozone
+      unit_of_measurement: "µg/m³"
+
+  - name: "Living room PM1 sensor"
+    id: "sensor.living_room_pm1"
+    state: "50"
+    attributes:
+      device_class: pm1
+      unit_of_measurement: "µg/m³"
+
+  - name: "Living room PM2.5 sensor"
+    id: "sensor.living_room_pm25"
+    state: "50"
+    attributes:
+      device_class: pm25
+      unit_of_measurement: "µg/m³"
+
+  - name: "Living room PM10 sensor"
+    id: "sensor.living_room_pm10"
+    state: "50"
+    attributes:
+      device_class: pm10
+      unit_of_measurement: "µg/m³"
+
+  - name: "Wall plug power factor"
+    id: "sensor.wall_plug_power_factor"
+    state: "2"
+    attributes:
+      device_class: power_factor
+
+  - name: "Air conditioning power"
+    id: "sensor.aircon_power"
+    state: "380"
+    attributes:
+      device_class: power
+      unit_of_measurement: "W"
+
+  - name: "Outside rain sensor"
+    id: "sensor.rain_sensor_total"
+    state: "29"
+    attributes:
+      device_class: precipitation
+      unit_of_measurement: "mm"
+
+  - name: "Outside rain sensor"
+    id: "sensor.rain_sensor_intensity"
+    state: "144"
+    attributes:
+      device_class: precipitation_intensity
+      unit_of_measurement: "mm/h"
+
+  - name: "Car tyre pressure"
+    id: "sensor.tyre_pressure"
+    state: "2.1"
+    attributes:
+      device_class: pressure
+      unit_of_measurement: "bar"
+
+  - name: "Water pump reactive power"
+    id: "sensor.water_pump_reactive_power"
+    state: "22"
+    attributes:
+      device_class: reactive_power
+      unit_of_measurement: "VAR"
+
+  - name: "My phone GSM signal"
+    id: "sensor.my_phone_gsm_signal"
+    state: "-43"
+    attributes:
+      device_class: signal_strength
+      unit_of_measurement: "dBm"
+
+  - name: "Sound bar acoustic pressure"
+    id: "sensor.sound_bar_sound_pressure"
+    state: "62"
+    attributes:
+      device_class: sound_pressure
+      unit_of_measurement: "dB"
+
+  - name: "Travelling speed"
+    id: "sensor.traveling speed"
+    state: "67"
+    attributes:
+      device_class: speed
+      unit_of_measurement: "km/h"
+
+  - name: "Heat pump SO2 sensor"
+    id: "sensor.heat_pump_so2"
+    state: "50"
+    attributes:
+      device_class: sulphur_dioxide
+      unit_of_measurement: "µg/m³"
+
+  - name: "Furnace"
+    id: "sensor.furnace_temperature"
+    state: "380"
+    attributes:
+      device_class: temperature
+      unit_of_measurement: "°C"
+
+  - name: "Poo poo sensor"
+    id: "sensor.voc_sensor"
+    state: "35"
+    attributes:
+      device_class: volatile_organic_compounds
+      unit_of_measurement: "µg/m³"
+
+  - name: "Poo poo sensor 2"
+    id: "sensor.voc_sensor_parts"
+    state: "35"
+    attributes:
+      device_class: volatile_organic_compounds_parts
+      unit_of_measurement: "ppm"
+
+  - name: "Input voltage"
+    id: "sensor.input_voltage"
+    state: "12"
+    attributes:
+      device_class: voltage
+      unit_of_measurement: "V"
+
+  - name: "Water pump usage today"
+    id: "sensor.water_pump_usage_today"
+    state: "1356"
+    attributes:
+      device_class: volume
+      unit_of_measurement: "L"
+
+  - name: "Water pump buffer"
+    id: "sensor.water_pump_buffer"
+    state: "28"
+    attributes:
+      device_class: volume_storage
+      unit_of_measurement: "L"
+
+  - name: "Water pump usage"
+    id: "sensor.water_pump_usage"
+    state: "5987"
+    attributes:
+      device_class: water
+      unit_of_measurement: "L"
+
+  - name: "Bed sensor weight"
+    id: "sensor.bed_sensor_weight"
+    state: "87"
+    attributes:
+      device_class: weight
+      unit_of_measurement: "kg"
+
+  - name: "Mistral"
+    id: "sensor.mistral_speed"
+    state: "33"
+    attributes:
+      device_class: wind_speed
+      unit_of_measurement: "km/h"

--- a/tests/en/_fixtures.yaml
+++ b/tests/en/_fixtures.yaml
@@ -343,3 +343,59 @@ entities:
       out: "on"
     attributes:
       device_class: window
+
+  # https://www.home-assistant.io/integrations/sensor/
+  - name: "Appliance apparent power"
+    id: "sensor.appliance_apparent_power"
+    state: "2"
+    attributes:
+      device_class: apparent_power
+      unit_of_measurement: "VA"
+
+  - name: "Kitchen air quality sensor"
+    id: "sensor.kitchen_aqi_sensor"
+    state: "50"
+    attributes:
+      device_class: aqi
+
+  - name: "Outside air sensor"
+    id: "sensor.outside_pressure"
+    state: "1000"
+    attributes:
+      device_class: atmospheric_pressure
+      unit_of_measurement: "hPa"
+
+  - name: "My Phone"
+    id: "sensor.my_phone_battery"
+    state: "98"
+    attributes:
+      device_class: battery
+      unit_of_measurement: "%"
+
+  - name: "Heat pump CO2 sensor"
+    id: "sensor.heat_pump_co2"
+    state: "50"
+    attributes:
+      device_class: carbon_dioxide
+      unit_of_measurement: "ppm"
+
+  - name: "Heat pump CO sensor"
+    id: "sensor.heat_pump_co"
+    state: "48"
+    attributes:
+      device_class: carbon_monoxide
+      unit_of_measurement: "ppm"
+
+  - name: "House current draw"
+    id: "sensor.house_current"
+    state: "19"
+    attributes:
+      device_class: current
+      unit_of_measurement: "A"
+
+  - name: "Macrotorrent"
+    id: "sensor.macrotorrent_download_speed"
+    state: "22.9"
+    attributes:
+      device_class: data_rate
+      unit_of_measurement: "MB/s"

--- a/tests/en/sensor_HassGetState.yaml
+++ b/tests/en/sensor_HassGetState.yaml
@@ -1,0 +1,90 @@
+language: en
+tests:
+  # Apparent power
+  - sentences:
+      - "what is the apparent power indicated by appliance apparent power?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: apparent_power
+        name: "Appliance apparent power"
+    response: "Appliance apparent power is 2 VA"
+
+  # AQI
+  - sentences:
+      - "what is the air quality index of the kitchen air quality sensor?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: aqi
+        name: "Kitchen air quality sensor"
+    response: "Kitchen air quality sensor is 50"
+
+  # Atmospheric pressure
+  - sentences:
+      - "what is the air pressure of outside air sensor?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: atmospheric_pressure
+        name: "Outside air sensor"
+    response: "Outside air sensor is 1000 hPa"
+
+  # Battery
+  - sentences:
+      - "what is the battery level of my phone?"
+      - "how much battery does my phone have left?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: battery
+        name: "My Phone"
+    response: "My phone is 98 %"
+
+  # CO2
+  - sentences:
+      - "what is the heat pump co2 sensor's co2 level?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: carbon_dioxide
+        name: "Heat pump CO2 sensor"
+    response: "Heat pump co2 sensor is 50 ppm"
+
+  # CO
+  - sentences:
+      - "what's the carbon monoxide concentration measured by the heat pump co sensor?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: carbon_monoxide
+        name: "Heat pump CO sensor"
+    response: "Heat pump co sensor is 48 ppm"
+
+  # Current
+  - sentences:
+      - "what is the amount of current indicated by house current draw?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: current
+        name: "House current draw"
+    response: "House current draw is 19 A"
+
+  # Data rate
+  - sentences:
+      - "what is Macrotorrent's download speed?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: data_rate
+        name: "Macrotorrent"
+    response: "Macrotorrent is 22.9 MB/s"

--- a/tests/en/sensor_HassGetState.yaml
+++ b/tests/en/sensor_HassGetState.yaml
@@ -88,3 +88,433 @@ tests:
         device_class: data_rate
         name: "Macrotorrent"
     response: "Macrotorrent is 22.9 MB/s"
+
+  # Data size
+  - sentences:
+      - "what's the log file size?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: data_size
+        name: "Log file"
+    response: "Log file is 106 kB"
+
+  # Date
+  - sentences:
+      - "what is the date of next birthday?"
+      - "when will the next birthday be?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: date
+        name: "Next birthday"
+    response: "Next birthday is 2024-04-01"
+
+  # Distance
+  - sentences:
+      - "what is the car mileage distance?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: distance
+        name: "Car mileage"
+    response: "Car mileage is 65536 km"
+
+  # Duration
+  - sentences:
+      - "what is the dishwasher current program's duration?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: duration
+        name: "Dishwasher current program"
+    response: "Dishwasher current program is 64 min"
+
+  # Energy
+  - sentences:
+      - "what is the amount of energy from solar production?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: energy
+        name: "Solar production"
+    response: "Solar production is 3.2 kWh"
+
+  # Energy storage
+  - sentences:
+      - "what is the amount of energy in powerwall stored energy?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: energy_storage
+        name: "Powerwall stored energy"
+    response: "Powerwall stored energy is 6 kWh"
+
+  # Frequency
+  - sentences:
+      - "what's the frequency of the grid AC frequency?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: frequency
+        name: "Grid AC frequency"
+    response: "Grid ac frequency is 51 Hz"
+
+  # Gas
+  - sentences:
+      - "what is the amount of gas indicated by monthly gas consumption?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: gas
+        name: "Monthly gas consumption"
+    response: "Monthly gas consumption is 12 m³"
+
+  # Humidity
+  - sentences:
+      - "what is the relative humidity in living room humidity?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: humidity
+        name: "Living room humidity"
+    response: "Living room humidity is 48 %"
+
+  # Illuminance
+  - sentences:
+      - "what is living room illuminance's brightness level?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: illuminance
+        name: "Living room illuminance"
+    response: "Living room illuminance is 438 lux"
+
+  # Irradiance
+  - sentences:
+      - "what is the irradiance of Living room heater irradiance?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: irradiance
+        name: "Living room heater irradiance"
+    response: "Living room heater irradiance is 155 W/m²"
+
+  # Moisture
+  - sentences:
+      - "what is the brewery mixer moisture?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: moisture
+        name: "Brewery mixer"
+    response: "Brewery mixer is 83 %"
+
+  # Monetary
+  - sentences:
+      - "what is the cost of price per kw?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: monetary
+        name: "Price per kW"
+    response: "Price per kw is 1 EUR"
+
+  # Nitrogen dioxide
+  - sentences:
+      - "what is the nitrogen dioxide concentration of Heat pump NO2 sensor?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: nitrogen_dioxide
+        name: "Heat pump NO2 sensor"
+    response: "Heat pump no2 sensor is 50 µg/m³"
+
+  # Nitrogen monoxide
+  - sentences:
+      - "what is the nitrogen monoxide concentration of Heat pump NO sensor?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: nitrogen_monoxide
+        name: "Heat pump NO sensor"
+    response: "Heat pump no sensor is 50 µg/m³"
+
+  # Nitrogen oxide
+  - sentences:
+      - "what is the N2O concentration of Heat pump N2O sensor?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: nitrous_oxide
+        name: "Heat pump N2O sensor"
+    response: "Heat pump n2o sensor is 50 µg/m³"
+
+  # Ozone
+  - sentences:
+      - "what is the o3 level indicated by living room ozone sensor?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: ozone
+        name: "Living room ozone sensor"
+    response: "Living room ozone sensor is 50 µg/m³"
+
+  # PM1
+  - sentences:
+      - "what is the PM1 level indicated by living room PM1 sensor?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: pm1
+        name: "Living room PM1 sensor"
+    response: "Living room pm1 sensor is 50 µg/m³"
+
+  # PM2.5
+  - sentences:
+      - "what is the PM2.5 level indicated by living room PM2.5 sensor?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: pm25
+        name: "Living room PM2.5 sensor"
+    response: "Living room pm25 sensor is 50 µg/m³"
+
+  # PM10
+  - sentences:
+      - "what is the PM10 level indicated by living room PM10 sensor?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: pm10
+        name: "Living room PM10 sensor"
+    response: "Living room pm10 sensor is 50 µg/m³"
+
+  # Power factor
+  - sentences:
+      - "what is the power factor of the wall plug power factor?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: power_factor
+        name: "Wall plug power factor"
+    response: "Wall plug power factor is 2"
+
+  # Power
+  - sentences:
+      - "what is the power of air conditioning power?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: power
+        name: "Air conditioning power"
+    response: "Air conditioning power is 380 W"
+
+  # Precipitation
+  - sentences:
+      - "what is the accumulated rainfall indicated by Outside rain sensor?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: precipitation
+        name: "Outside rain sensor"
+    response: "Outside rain sensor is 29 mm"
+
+  # Precipitation intensity
+  - sentences:
+      - "what is the rainfall intensity indicated by Outside rain sensor?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: precipitation_intensity
+        name: "Outside rain sensor"
+    response: "Outside rain sensor is 144 mm/h"
+
+  # Pressure
+  - sentences:
+      - "what is the pressure of the car tyre pressure?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: pressure
+        name: "Car tyre pressure"
+    response: "Car tyre pressure is 2.1 bar"
+
+  # Reactiv epower
+  - sentences:
+      - "what is the reactive power of Water pump reactive power?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: reactive_power
+        name: "Water pump reactive power"
+    response: "Water pump reactive power is 22 VAR"
+
+  # Signal strength
+  - sentences:
+      - "what is the signal strength measured by my phone gsm signal?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: signal_strength
+        name: "My phone GSM signal"
+    response: "My phone gsm signal is -43 dBm"
+
+  # Sound pressure
+  - sentences:
+      - "what is the acoustic pressure measured by Sound bar acoustic pressure?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: sound_pressure
+        name: "Sound bar acoustic pressure"
+    response: "Sound bar acoustic pressure is 62 dB"
+
+  # Speed
+  - sentences:
+      - "what is the speed indicated by travelling speed?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: speed
+        name: "Travelling speed"
+    response: "Travelling speed is 67 km/h"
+
+  # Sulphur dioxide
+  - sentences:
+      - "what is the sulphur dioxide concentration of Heat pump SO2 sensor?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: sulphur_dioxide
+        name: "Heat pump SO2 sensor"
+    response: "Heat pump so2 sensor is 50 µg/m³"
+
+  # Temperature
+  - sentences:
+      - "what is the furnace temperature?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: temperature
+        name: "Furnace"
+    response: "Furnace is 380 °C"
+
+  # VOC
+  - sentences:
+      - "what is the concentration of organic compounds indicated by poo poo sensor?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: volatile_organic_compounds
+        name: "Poo poo sensor"
+    response: "Poo poo sensor is 35 µg/m³"
+
+  # VOC in parts
+  - sentences:
+      - "what is the concentration of organic compounds indicated by poo poo sensor 2?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: volatile_organic_compounds_parts
+        name: "Poo poo sensor 2"
+    response: "Poo poo sensor 2 is 35 ppm"
+
+  # Voltage
+  - sentences:
+      - "what is the input voltage voltage drop?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: voltage
+        name: "Input voltage"
+    response: "Input voltage is 12 V"
+
+  # Volume
+  - sentences:
+      - "what is the water pump usage today volume?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: volume
+        name: "Water pump usage today"
+    response: "Water pump usage today is 1356 L"
+
+  # Volume storage
+  - sentences:
+      - "what is the total stored volume in the water pump buffer?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: volume_storage
+        name: "Water pump buffer"
+    response: "Water pump buffer is 28 L"
+
+  # Water
+  - sentences:
+      - "what is the water pump usage total amount of consumed water?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: water
+        name: "Water pump usage"
+    response: "Water pump usage is 5987 L"
+
+  # Weight
+  - sentences:
+      - "what is the weight indicated by bed sensor weight?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: weight
+        name: "Bed sensor weight"
+    response: "Bed sensor weight is 87 kg"
+
+  # Wind speed
+  - sentences:
+      - "what is Mistral's speed?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: wind_speed
+        name: "Mistral"
+    response: "Mistral is 33 km/h"


### PR DESCRIPTION
Added sentences to get sensors by name for (almost) all `device_class`es from here https://www.home-assistant.io/integrations/sensor/