### PR TITLE
Bump hassil to 1.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hassil==1.1.0
+hassil==1.2.0
 PyYAML==6.0.1
 voluptuous==0.13.1
 regex==2023.3.23


### PR DESCRIPTION
Bump hassil library to version 1.2.0: https://github.com/home-assistant/hassil/compare/v1.1.0...v1.2.0