### PR TITLE
Add HassShoppingListAddItem intent + wildcards

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -141,3 +141,16 @@ HassClimateGetTemperature:
   response_variables:
     state:
       description: "State of the entity that contains the temperature"
+
+# -----------------------------------------------------------------------------
+# shopping_list
+# -----------------------------------------------------------------------------
+
+HassShoppingListAddItem:
+  supported: true
+  domain: shopping_list
+  description: "Adds an item to the shopping list"
+  slots:
+    item:
+      description: "Item to add"
+      required: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hassil==1.2.0
+hassil==1.2.2
 PyYAML==6.0.1
 voluptuous==0.13.1
 regex==2023.3.23

--- a/responses/README.md
+++ b/responses/README.md
@@ -2,7 +2,7 @@
 
 YAML files for each intent with the [response template](https://www.home-assistant.io/docs/configuration/templating/) that Home Assistant will give when the intent is executed.
 
-The success sentences are rendered as a Home Assistant template. Intents can make extra variables available that can be referenced in the success message. An example extra variable would be the [state object](https://www.home-assistant.io/docs/configuration/state_object) of the matched entity for the sentence "what is the temperature?".
+The sentences are rendered as a Home Assistant template with access to variables such as `state` and `slots`. The [state object](https://www.home-assistant.io/docs/configuration/state_object) contains the state of the matched object. A `slots` object contains the text of each matched intent slot.
 
 ## File Format
 
@@ -11,11 +11,9 @@ language: "<language code>"
 responses:
   intents:
     <intent name>:
-      # List of responses. A random one will be executed. Responses are rendered
-      # as a Home Assistant template. Intents can make extra variables
-      # available that can be referenced in the success message.
-      success:
-        - "{{ state.state }} degrees"
+      # List of responses. If "response" is not set in the intent, then "default" will be used.
+      default:
+        - "{{ slots.name }} is {{ state.state_with_unit }}"
 ```
 
 **NOTE:** These are not the same format as the sentence templates in this repository.

--- a/responses/en/HassShoppingListAddItem.yaml
+++ b/responses/en/HassShoppingListAddItem.yaml
@@ -1,0 +1,5 @@
+language: "en"
+responses:
+  intents:
+    HassShoppingListAddItem:
+      item_added: "Added {{ slots.item }}"

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -172,6 +172,7 @@ SENTENCE_COMMON_SCHEMA = vol.Schema(
                         vol.Required("to"): int,
                         vol.Optional("step", default=1): int,
                     },
+                    "wildcard": bool,
                 }
             )
         },

--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -286,6 +286,9 @@ lists:
       - in: "clear"
         out: "closed"
 
+  item:
+    wildcard: true
+
 expansion_rules:
   name: "[the] {name}"
   area: "[the] {area}"

--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -286,7 +286,7 @@ lists:
       - in: "clear"
         out: "closed"
 
-  item:
+  shopping_list_item:
     wildcard: true
 
 expansion_rules:

--- a/sentences/en/shopping_list_HassShoppingListAddItem.yaml
+++ b/sentences/en/shopping_list_HassShoppingListAddItem.yaml
@@ -3,8 +3,9 @@ intents:
   HassShoppingListAddItem:
     data:
       - sentences:
-          - add {item} to<my_list>
-          - put {item} (on|in)<my_list>
+          - add <item> to<my_list>
+          - put <item> (on|in)<my_list>
         response: item_added
         expansion_rules:
           my_list: "[ my|the][ shopping] list"
+          item: "{shopping_list_item:item}"

--- a/sentences/en/shopping_list_HassShoppingListAddItem.yaml
+++ b/sentences/en/shopping_list_HassShoppingListAddItem.yaml
@@ -1,0 +1,10 @@
+language: "en"
+intents:
+  HassShoppingListAddItem:
+    data:
+      - sentences:
+          - add {item} to<my_list>
+          - put {item} (on|in)<my_list>
+        response: item_added
+        expansion_rules:
+          my_list: "[ my|the][ shopping] list"

--- a/tests/en/shopping_list_HassShoppingListAddItem.yaml
+++ b/tests/en/shopping_list_HassShoppingListAddItem.yaml
@@ -1,0 +1,10 @@
+language: en
+tests:
+  - sentences:
+      - add apples to my shopping list
+      - put apples on the list
+    intent:
+      name: HassShoppingListAddItem
+      slots:
+        item: "apples "
+    response: Added apples


### PR DESCRIPTION
Using the new [wildcards](https://github.com/home-assistant/hassil/pull/56) feature of hassil, this PR adds support for the `HassShoppingListAddItem` intent (English) and adds wildcards to the validation logic.

Phrases like "add apples to the shopping list" will work as expected. However, "add apples and bananas to the shopping list" will add a single item named "apples and bananas". Splitting conjunctions may be done in the future, but this behavior is acceptable for now. 