### PR TITLE
Bugfixes from hassil 1.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hassil==1.2.0
+hassil==1.2.2
 PyYAML==6.0.1
 voluptuous==0.13.1
 regex==2023.3.23

--- a/sentences/bg/cover_HassTurnOff.yaml
+++ b/sentences/bg/cover_HassTurnOff.yaml
@@ -19,7 +19,6 @@ intents:
           - "<close>  <area> [<all>] <covers>"
         response: "cover_area"
         slots:
-          area: "bedroom"
           device_class:
             - "blind"
             - "curtain"

--- a/sentences/bg/cover_HassTurnOn.yaml
+++ b/sentences/bg/cover_HassTurnOn.yaml
@@ -19,7 +19,6 @@ intents:
           - "<open> <area> [<all>] <covers>"
         response: "cover_area"
         slots:
-          area: "bedroom"
           device_class:
             - "blind"
             - "curtain"

--- a/sentences/he/light_HassLightSet.yaml
+++ b/sentences/he/light_HassLightSet.yaml
@@ -11,6 +11,4 @@ intents:
           - "קבע [את] [ה]בהירות ה<name> ל<brightness> ב<area>"
           - "שנה [את] [ה]בהירות ה<name> ל<brightness> ב<area>"
           - "הגדר [את] [ה]בהירות ה<name> ל<brightness> ב<area>"
-        slots:
-          name: all
         response: brightness_area

--- a/sentences/vi/fan_HassTurnOff.yaml
+++ b/sentences/vi/fan_HassTurnOff.yaml
@@ -8,4 +8,3 @@ intents:
           - "tắt [tất cả | toàn bộ] <name> [trong] <area>"
         slots:
           domain: "fan"
-          name: "all"

--- a/sentences/vi/fan_HassTurnOn.yaml
+++ b/sentences/vi/fan_HassTurnOn.yaml
@@ -7,4 +7,3 @@ intents:
           - "bật [hết | tất cả | toàn bộ] <name> <area>"
         slots:
           domain: "fan"
-          name: "all"

--- a/tests/bg/cover_HassTurnOff.yaml
+++ b/tests/bg/cover_HassTurnOff.yaml
@@ -31,22 +31,22 @@ tests:
     intent:
       name: HassTurnOff
       slots:
-        area: bedroom
+        area: кухнята
         device_class:
           - blind
           - curtain
           - shutter
         domain: cover
-    response: Затворих bedroom
+    response: Затворих кухнята
   - sentences:
       - затвори в кухнята всичките щора
     intent:
       name: HassTurnOff
       slots:
-        area: bedroom
+        area: кухнята
         device_class:
           - blind
           - curtain
           - shutter
         domain: cover
-    response: Затворих bedroom
+    response: Затворих кухнята

--- a/tests/bg/cover_HassTurnOn.yaml
+++ b/tests/bg/cover_HassTurnOn.yaml
@@ -31,22 +31,22 @@ tests:
     intent:
       name: HassTurnOn
       slots:
-        area: bedroom
+        area: кухнята
         device_class:
           - blind
           - curtain
           - shutter
         domain: cover
-    response: Отворих bedroom
+    response: Отворих кухнята
   - sentences:
       - отвори в кухнята всичките щора
     intent:
       name: HassTurnOn
       slots:
-        area: bedroom
+        area: кухнята
         device_class:
           - blind
           - curtain
           - shutter
         domain: cover
-    response: Отворих bedroom
+    response: Отворих кухнята

--- a/tests/bg/homeassistant_HassTurnOff.yaml
+++ b/tests/bg/homeassistant_HassTurnOff.yaml
@@ -61,7 +61,7 @@ tests:
     intent:
       name: HassTurnOff
       slots:
-        area: bedroom
+        area: спалнята
         device_class:
           - blind
           - curtain

--- a/tests/bg/homeassistant_HassTurnOn.yaml
+++ b/tests/bg/homeassistant_HassTurnOn.yaml
@@ -51,7 +51,7 @@ tests:
     intent:
       name: HassTurnOn
       slots:
-        area: bedroom
+        area: спалнята
         device_class:
           - blind
           - curtain

--- a/tests/he/homeassistant_HassTurnOff.yaml
+++ b/tests/he/homeassistant_HassTurnOff.yaml
@@ -41,4 +41,4 @@ tests:
         area: סלון
         domain: cover
         device_class:
-          - garage
+          - door

--- a/tests/he/homeassistant_HassTurnOn.yaml
+++ b/tests/he/homeassistant_HassTurnOn.yaml
@@ -41,4 +41,4 @@ tests:
         area: סלון
         domain: cover
         device_class:
-          - garage
+          - door

--- a/tests/he/light_HassLightSet.yaml
+++ b/tests/he/light_HassLightSet.yaml
@@ -18,5 +18,5 @@ tests:
       name: HassLightSet
       slots:
         brightness: 50
-        name: all
+        name: אור
         area: סלון

--- a/tests/hr/light_HassLightSet.yaml
+++ b/tests/hr/light_HassLightSet.yaml
@@ -118,7 +118,7 @@ tests:
     intent:
       name: HassLightSet
       slots:
-        brightness: 100
+        brightness: 1
         name:
           - noćno svjetlo
     response: "Jačina svjetla je postavljena"

--- a/tests/ka/light_HassTurnOff.yaml
+++ b/tests/ka/light_HassTurnOff.yaml
@@ -12,4 +12,4 @@ tests:
       name: HassTurnOff
       slots:
         domain: light
-        area: kitchen
+        area: სამზარეულო

--- a/tests/ka/light_HassTurnOn.yaml
+++ b/tests/ka/light_HassTurnOn.yaml
@@ -12,4 +12,4 @@ tests:
       name: HassTurnOn
       slots:
         domain: light
-        area: kitchen
+        area: სამზარეულო

--- a/tests/ms/cover_HassTurnOff.yaml
+++ b/tests/ms/cover_HassTurnOff.yaml
@@ -5,16 +5,16 @@ tests:
     intent:
       name: HassTurnOff
       slots:
-        area: garaj
+        area: Ruang Tamu
         device_class: garage
         domain: cover
-    response: Kawasan garaj telah ditutupkan
+    response: Kawasan ruang tamu telah ditutupkan
   - sentences:
       - tutup pagar ruang tamu
     intent:
       name: HassTurnOff
       slots:
-        area: garaj
+        area: Ruang Tamu
         device_class: garage
         domain: cover
-    response: Kawasan garaj telah ditutupkan
+    response: Kawasan ruang tamu telah ditutupkan

--- a/tests/ms/cover_HassTurnOn.yaml
+++ b/tests/ms/cover_HassTurnOn.yaml
@@ -5,22 +5,22 @@ tests:
     intent:
       name: HassTurnOn
       slots:
-        area: living_room
+        area: Ruang Tamu
         device_class:
           - blind
           - curtain
           - shutter
         domain: cover
-    response: Kawasan living_room telah dibuka
+    response: Kawasan ruang tamu telah dibuka
   - sentences:
       - buka semua langsir ruang tamu
     intent:
       name: HassTurnOn
       slots:
-        area: living_room
+        area: Ruang Tamu
         device_class:
           - blind
           - curtain
           - shutter
         domain: cover
-    response: Kawasan living_room telah dibuka
+    response: Kawasan ruang tamu telah dibuka

--- a/tests/ms/fan_HassTurnOff.yaml
+++ b/tests/ms/fan_HassTurnOff.yaml
@@ -9,4 +9,4 @@ tests:
       name: HassTurnOff
       slots:
         domain: fan
-        area: living_room
+        area: Ruang Tamu

--- a/tests/ms/fan_HassTurnOn.yaml
+++ b/tests/ms/fan_HassTurnOn.yaml
@@ -9,4 +9,4 @@ tests:
       name: HassTurnOn
       slots:
         domain: fan
-        area: living_room
+        area: Ruang Tamu

--- a/tests/ms/homeassistant_HassTurnOff.yaml
+++ b/tests/ms/homeassistant_HassTurnOff.yaml
@@ -13,6 +13,6 @@ tests:
     intent:
       name: HassTurnOff
       slots:
-        area: garaj
+        area: Garaj
         device_class: garage
         domain: cover

--- a/tests/ms/homeassistant_HassTurnOn.yaml
+++ b/tests/ms/homeassistant_HassTurnOn.yaml
@@ -13,7 +13,7 @@ tests:
     intent:
       name: HassTurnOn
       slots:
-        area: living_room
+        area: Ruang Tamu
         device_class:
           - blind
           - curtain

--- a/tests/vi/fan_HassTurnOff.yaml
+++ b/tests/vi/fan_HassTurnOff.yaml
@@ -10,4 +10,4 @@ tests:
       slots:
         area: phòng khách
         domain: fan
-        name: all
+        name: quạt trần

--- a/tests/vi/fan_HassTurnOn.yaml
+++ b/tests/vi/fan_HassTurnOn.yaml
@@ -9,4 +9,4 @@ tests:
       slots:
         area: phòng bếp
         domain: fan
-        name: all
+        name: quạt trần


### PR DESCRIPTION
1. Upgrade to hassil 1.2.2 which contains bugfixes: https://github.com/home-assistant/hassil/compare/v1.2.1...v1.2.2
2. Fix incorrect slot values exposed by the bug fixes

In previous hassil versions, hard-coded slot values always overrode the slot values discovered during recognition. This was fixed in 1.2.2.