### PR TITLE
Fix validation for permutations

### DIFF
--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -117,7 +117,7 @@ INTENT_ERRORS = {
 }
 
 SENTENCE_MATCHER = vol.All(
-    match_unicode_regex(r"^[\w\p{M} :\-'\|\(\)\[\]\{\}\<\>]+$"),
+    match_unicode_regex(r"^[\w\p{M} :\-'\|\(\)\[\]\{\}\<\>;]+$"),
     msg="Sentences should only contain words and matching syntax. They should not contain punctuation.",
 )
 


### PR DESCRIPTION
With the introduction of permutations in hassil 1.2.0 (#1465), the semicolon character is now a valid character in sentences.

This PR updates the validation script called when linting in order to allow semicolons