### PR TITLE
Add basic shopping list sentences for Russian

### DIFF
--- a/responses/ru/HassShoppingListAddItem.yaml
+++ b/responses/ru/HassShoppingListAddItem.yaml
@@ -1,0 +1,5 @@
+language: ru
+responses:
+  intents:
+    HassShoppingListAddItem:
+      item_added: "Добавляю {{ slots.item }}"

--- a/sentences/ru/_common.yaml
+++ b/sentences/ru/_common.yaml
@@ -88,6 +88,10 @@ lists:
         out: shutter
       - in: окн(о[м]|а[ми])
         out: window
+
+  shopping_list_item:
+    wildcard: true
+
 expansion_rules:
   name: "{name}"
   area: "[в|во|на] {area}"

--- a/sentences/ru/shopping_list_HassShoppingListAddItem.yaml
+++ b/sentences/ru/shopping_list_HassShoppingListAddItem.yaml
@@ -1,0 +1,11 @@
+language: ru
+intents:
+  HassShoppingListAddItem:
+    data:
+      - sentences:
+          - "добав(ить|ь) <item> в [мой] список покупок"
+          - "нужно купить <item> "
+        response: item_added
+        expansion_rules:
+          # Accusative case, e. g. "картошку"
+          item: "{shopping_list_item:item}"

--- a/tests/ru/shopping_list_HassShoppingListAddItem.yaml
+++ b/tests/ru/shopping_list_HassShoppingListAddItem.yaml
@@ -1,0 +1,18 @@
+language: ru
+tests:
+  - sentences:
+      - "добавить картошку в мой список покупок"
+      - "добавить картошку в список покупок"
+      - "добавь картошку в список покупок"
+    intent:
+      name: "HassShoppingListAddItem"
+      slots:
+        item: "картошку " # ?!
+    response: "Добавляю картошку"
+  - sentences:
+      - "нужно купить картошку"
+    intent:
+      name: "HassShoppingListAddItem"
+      slots:
+        item: "картошку" # <item> is at the end, so no leading space
+    response: "Добавляю картошку"


### PR DESCRIPTION
Leading spaces in slots complicate testing slightly, as sometimes they're present, sometimes not. Are they really necessary?

I've chosen within this particular intent for Russian to run with `<item>` in accusative case (винительный падеж) as that form in particular is useful both in a sentence and response — but isn't as great at getting displayed in the list (which normally uses nominative, именительный).

It would be the English equivalent of having a list that looks kinda like this:

- of potatoes
- of cheese
- of bread

…only in Russian that "of" being expressed as a particular form of the item. It's that same feeling of something missing at the front of it. Could feasibly be fixed with the right heading like "Top up supplies:" that flows nicely into "…of `<item>`" which I find a-ok. (I'll be using the equivalent of "Нужно купить" (≈"need to buy"), which is fine to be followed by a noun in accusative case)

I can also see how grammatical genders could bring some grief there later, e. g. `<item> added` would have to vary the `added` word depending on the gender of `<item>` between "добавлен", "добавлена" and "добавлено" (all of those are forms of "added").