### PR TITLE
[EN] Add default response for HassGetState

### DIFF
--- a/responses/en/HassGetState.yaml
+++ b/responses/en/HassGetState.yaml
@@ -2,6 +2,8 @@ language: en
 responses:
   intents:
     HassGetState:
+      default: "{{ state.state_with_unit }}" # used mostly for custom sentences
+
       # the number of names returned is limited to 4, in case there are more, the first 3 names and the remaining count is returned
       # with 4 names or less, the names are joined with a comma ", " and the last name is joined with " and "
       one: |


### PR DESCRIPTION
Let's say somebody has the following 2 entities:

- `Alice time to home` (`sensor.alice_time_to_home`, provided by Waze, UOM `minutes`)
- `Bob time to home` (`sensor.alice_time_to_home`, provided by Waze, UOM `minutes`)
and defines a custom sentence under `conversation:`, along the lines of:

`config/custom_sentences/en/time_to_home.yaml`
```
language: ro
intents:
  HassGetState:
    data:
      - sentences:
          - "how much longer [un]till {person_to_sensor:name} gets home"
          - "when will {person_to_sensor:name} be home"

lists:
  person_to_sensor:
    values:
      - in: "Alice"
        out: "Alice time to home"
      - in: "Bob"
        out: "Bob time to home"
```

This will fail because there is no `default` response. If we were to add a `response: one`, the response would be `Alice is 10 minutes` instead of `Alice time to home is 10 minutes`.

As such, this PR introduces a very simple `10 minutes` response for the above scenario, where people to add query sentences to default intents can use for `HassGetState`.