### PR TITLE
[cs] Make error responses gender neutral

### DIFF
--- a/sentences/cs/_common.yaml
+++ b/sentences/cs/_common.yaml
@@ -1,8 +1,8 @@
 language: cs
 responses:
   errors:
-    no_intent: "Omlouvám se, ale nerozuměl jsem tomu"
-    no_area: "Oblast {{ area }} jsem nenašel"
+    no_intent: "Omlouvám se, ale nerozumím"
+    no_area: "Oblast {{ area }} nenalezena"
     no_domain: "{{ area }} neobsahuje {{ domain }}"
     no_device_class: "{{ area }} neobsahuje {{ device_class }}"
     no_entity: "Žádné zařízení ani entita se nejmenuje {{ entity }}"


### PR DESCRIPTION
Some error responses in Czech are not written in neutral grammatical gender, sounding weird when female voice is used for TTS.