### PR TITLE
Fix "all" response grammar and include the state

### DIFF
--- a/responses/en/HassGetState.yaml
+++ b/responses/en/HassGetState.yaml
@@ -38,13 +38,13 @@ responses:
         {% else %}
           {% set no_match = query.unmatched | map(attribute="name") | sort | list %}
           {% if no_match | length > 4 %}
-            No, {{ no_match[:3] | join(", ") }} and {{ (no_match | length - 3) }} more not
+            No, {{ no_match[:3] | join(", ") }} and {{ (no_match | length - 3) }} more are not {{ slots.state }}
           {%- else -%}
             No,
             {% for name in no_match -%}
               {% if not loop.first and not loop.last %}, {% elif loop.last and not loop.first %} and {% endif -%}
               {{ name }}
-            {%- endfor %} not
+            {%- endfor %} {% if no_match | length > 1 %}are{% else %}is{% endif %} not {{ slots.state }}
           {% endif %}
         {% endif %}
 

--- a/tests/en/binary_sensor_HassGetState.yaml
+++ b/tests/en/binary_sensor_HassGetState.yaml
@@ -30,7 +30,7 @@ tests:
         domain: binary_sensor
         device_class: battery
         state: "on"
-    response: "No, Phone not"
+    response: "No, Phone is not low"
 
   - sentences:
       - "which batteries are low?"
@@ -146,7 +146,7 @@ tests:
         domain: binary_sensor
         device_class: carbon_monoxide
         state: "on"
-    response: "No, CO2 not"
+    response: "No, CO2 is not on"
 
   - sentences:
       - "which carbon monoxide sensors are on?"
@@ -328,7 +328,7 @@ tests:
         domain: binary_sensor
         device_class: gas
         state: "on"
-    response: "No, Gas not"
+    response: "No, Gas is not on"
 
   - sentences:
       - "which gas sensors are on?"
@@ -422,7 +422,7 @@ tests:
         domain: binary_sensor
         device_class: light
         state: "on"
-    response: "No, Light not"
+    response: "No, Light is not detected"
 
   - sentences:
       - "which lights are detected?"
@@ -500,7 +500,7 @@ tests:
         domain: binary_sensor
         device_class: moisture
         state: "on"
-    response: "No, Kitchen leak sensor not"
+    response: "No, Kitchen leak sensor is not wet"
 
   - sentences:
       - "which water sensors are wet?"
@@ -672,7 +672,7 @@ tests:
         domain: binary_sensor
         device_class: opening
         state: "on"
-    response: "No, Shed Door not"
+    response: "No, Shed Door is not open"
 
   - sentences:
       - "which openings are open?"
@@ -828,7 +828,7 @@ tests:
         domain: binary_sensor
         device_class: presence
         state: "on"
-    response: "No, Phone not"
+    response: "No, Phone is not home"
 
   - sentences:
       - "which devices are home?"
@@ -967,7 +967,7 @@ tests:
         domain: binary_sensor
         device_class: smoke
         state: "on"
-    response: "No, Kitchen Smoke not"
+    response: "No, Kitchen Smoke is not triggered"
 
   - sentences:
       - "which smoke sensors are triggered?"

--- a/tests/en/cover_HassGetState.yaml
+++ b/tests/en/cover_HassGetState.yaml
@@ -30,7 +30,7 @@ tests:
         area: "Living Room"
         device_class: curtain
         state: "open"
-    response: "No, Curtain Right not"
+    response: "No, Curtain Right is not open"
 
   - sentences:
       - "which curtains are closed?"

--- a/tests/en/homeassistant_HassGetState.yaml
+++ b/tests/en/homeassistant_HassGetState.yaml
@@ -35,7 +35,7 @@ tests:
       slots:
         domain: "switch"
         state: "on"
-    response: "No, Bedroom Switch not"
+    response: "No, Bedroom Switch is not on"
 
   - sentences:
       - "are all lights off?"
@@ -44,7 +44,7 @@ tests:
       slots:
         domain: "light"
         state: "off"
-    response: "No, Garage Light, Kitchen cabinets, Kitchen ceiling and 3 more not"
+    response: "No, Garage Light, Kitchen cabinets, Kitchen ceiling and 3 more are not off"
 
   - sentences:
       - "which lights are on?"

--- a/tests/en/lock_HassGetState.yaml
+++ b/tests/en/lock_HassGetState.yaml
@@ -26,7 +26,7 @@ tests:
       slots:
         domain: lock
         state: "locked"
-    response: "No, Back Door not"
+    response: "No, Back Door is not locked"
 
   - sentences:
       - "which doors are locked?"


### PR DESCRIPTION
### Before:
**Query**: "are all windows closed?"
**Answer**: "No, Living Room Window Left and Shed Window not"

**Query**: "are all water sensors wet?"
**Answer**: "No, Kitchen leak sensor not"

### After:
**Query**: "are all windows closed?"
**Answer**: "No, Living Room Window Left and Shed Window are not closed"

**Query**: "are all water sensors wet?"
**Answer**: "No, Kitchen leak sensor is not wet"
