### PR TITLE
fix control lights of a room

### DIFF
--- a/sentences/fr/light_HassTurnOff.yaml
+++ b/sentences/fr/light_HassTurnOff.yaml
@@ -6,7 +6,6 @@ intents:
           - "<eteins> [toutes] (<lumiere> | <lumieres>) <dans> <area>"
         slots:
           domain: light
-          name: all
         response: lights
 
       - sentences:

--- a/sentences/fr/light_HassTurnOn.yaml
+++ b/sentences/fr/light_HassTurnOn.yaml
@@ -8,7 +8,6 @@ intents:
           - <eclaire> <area>
         slots:
           domain: light
-          name: all
         response: lights
 
       - sentences:

--- a/tests/fr/light_HassTurnOff.yaml
+++ b/tests/fr/light_HassTurnOff.yaml
@@ -1,6 +1,20 @@
 language: fr
 tests:
   - sentences:
+      - Éteindre les lumières du salon
+      - Éteins la lumière du salon
+      - Éteins les lumières dans le salon
+      - Éteins toutes les lumières dans le salon
+      - Désactiver la lumière du salon
+    intent:
+      name: HassTurnOff
+      slots:
+        area: salon
+        domain: light
+    response: Lumières éteintes
+
+  - sentences:
+      - Éteindre les lumières de la cuisine
       - Éteins la lumière de la cuisine
       - Éteins les lumières dans la cuisine
       - Éteins toutes les lumières dans la cuisine
@@ -10,7 +24,6 @@ tests:
       slots:
         area: cuisine
         domain: light
-        name: all
     response: Lumières éteintes
 
   - sentences:

--- a/tests/fr/light_HassTurnOff.yaml
+++ b/tests/fr/light_HassTurnOff.yaml
@@ -1,19 +1,6 @@
 language: fr
 tests:
   - sentences:
-      - Éteindre les lumières du salon
-      - Éteins la lumière du salon
-      - Éteins les lumières dans le salon
-      - Éteins toutes les lumières dans le salon
-      - Désactiver la lumière du salon
-    intent:
-      name: HassTurnOff
-      slots:
-        area: salon
-        domain: light
-    response: Lumières éteintes
-
-  - sentences:
       - Éteindre les lumières de la cuisine
       - Éteins la lumière de la cuisine
       - Éteins les lumières dans la cuisine

--- a/tests/fr/light_HassTurnOn.yaml
+++ b/tests/fr/light_HassTurnOn.yaml
@@ -1,22 +1,6 @@
 language: fr
 tests:
   - sentences:
-      - Allumer les lumières du salon
-      - Allume la lumière du salon
-      - Allumer les lumières dans le salon
-      - Allume toutes les lumières dans le salon
-      - Active la lumière du salon
-      - Lumières dans le salon
-      - Lumière dans le salon
-      - Lumière salon
-      - Éclaire le salon
-    intent:
-      name: HassTurnOn
-      slots:
-        area: salon
-        domain: light
-    response: Lumières allumées
-  - sentences:
       - Allumer les lumières de la cuisine
       - Allume la lumière de la cuisine
       - Allumer les lumières dans la cuisine

--- a/tests/fr/light_HassTurnOn.yaml
+++ b/tests/fr/light_HassTurnOn.yaml
@@ -1,6 +1,23 @@
 language: fr
 tests:
   - sentences:
+      - Allumer les lumières du salon
+      - Allume la lumière du salon
+      - Allumer les lumières dans le salon
+      - Allume toutes les lumières dans le salon
+      - Active la lumière du salon
+      - Lumières dans le salon
+      - Lumière dans le salon
+      - Lumière salon
+      - Éclaire le salon
+    intent:
+      name: HassTurnOn
+      slots:
+        area: salon
+        domain: light
+    response: Lumières allumées
+  - sentences:
+      - Allumer les lumières de la cuisine
       - Allume la lumière de la cuisine
       - Allumer les lumières dans la cuisine
       - Allume toutes les lumières dans la cuisine
@@ -14,7 +31,6 @@ tests:
       slots:
         area: cuisine
         domain: light
-        name: all
     response: Lumières allumées
 
   - sentences:


### PR DESCRIPTION
Following the issue https://github.com/home-assistant/intents/issues/1509, it seems that under some conditions the sentence in 
french "allumer les lumières du salon" is not recognized.
the problem comes from the setting **name: all** in _light_HassTurnOn.yaml_ and _light_HassTurnOff.yaml_

