### PR TITLE
[cs] Fix light intents, add HassTurnOff for all lights

### DIFF
--- a/responses/cs/HassTurnOff.yaml
+++ b/responses/cs/HassTurnOff.yaml
@@ -7,6 +7,7 @@ responses:
       fans_area: "Větráky v {{ slots.area }} byly vypnuty"
       fan: "Větrák {{ slots.name }} vypnut"
       light: "Světlo {{ slots.name }} bylo zhasnuto"
+      light_all: "Všechna světla byla zhasnuta"
       cover: "{{ slots.name | capitalize }} zavřeno"
       cover_area: "Stínění v {{ slots.area }} zavřeno"
       garage: "Garážová vrata zavřena"

--- a/sentences/cs/light_HassTurnOff.yaml
+++ b/sentences/cs/light_HassTurnOff.yaml
@@ -3,8 +3,10 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "(<vypnout>|<zhasnout>) [světlo] {name}"
-          - "{name} (<vypnout>|<zhasnout>) [světlo]"
+          - "<zhasnout> [světlo] {name}"
+          - "<vypnout> světlo {name}"
+          - "{name} <zhasnout> [světlo]"
+          - "světlo {name} <vypnout>"
         slots:
           domain: light
         response: light
@@ -14,3 +16,10 @@ intents:
         slots:
           domain: light
         response: lights_area
+      - sentences:
+          - "(<vypnout>|<zhasnout>) [úplně] všechna světla"
+        response: "light_all"
+        slots:
+          domain: "light"
+          area: "all"
+          name: "all"

--- a/sentences/cs/light_HassTurnOn.yaml
+++ b/sentences/cs/light_HassTurnOn.yaml
@@ -3,8 +3,10 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "(<zapnout>|<rozsvitit>) [světlo] {name}"
-          - "{name} (<zapnout>|<rozsvitit>) [světlo]"
+          - "<rozsvitit> [světlo] {name}"
+          - "<zapnout> světlo {name}"
+          - "{name} <rozsvitit> [světlo]"
+          - "světlo {name} <zapnout>"
         slots:
           domain: light
         response: light

--- a/tests/cs/light_HassTurnOff.yaml
+++ b/tests/cs/light_HassTurnOff.yaml
@@ -16,8 +16,11 @@ tests:
     response: "Světla v kuchyni byla zhasnuta"
 
   - sentences:
+      - "vypni světlo lampička v ložnici"
+      - "zhasni lampičku v ložnici"
       - "zhasni světlo lampička v ložnici"
       - "lampičku v ložnici zhasnout"
+      - "světlo lampička v ložnici vypnout"
     intent:
       name: HassTurnOff
       slots:
@@ -34,3 +37,15 @@ tests:
     response:
       - "Světlo lampička v ložnici bylo zhasnuto"
       - "Světlo lampičku v ložnici bylo zhasnuto"
+
+  - sentences:
+      - "vypni všechna světla"
+      - "vypni úplně všechna světla"
+    intent:
+      name: HassTurnOff
+      slots:
+        domain: light
+        area: all
+        name: all
+    response:
+      - "Všechna světla byla zhasnuta"

--- a/tests/cs/light_HassTurnOn.yaml
+++ b/tests/cs/light_HassTurnOn.yaml
@@ -2,6 +2,7 @@ language: cs
 tests:
   - sentences:
       - "rozsviť světlo lampička v obývacím pokoji"
+      - "zapni světlo lampička v obývacím pokoji"
     intent:
       name: HassTurnOn
       slots:
@@ -15,6 +16,8 @@ tests:
   - sentences:
       - "předsíň rozsviť"
       - "rozsviť předsíň"
+      - "zapni světlo předsíň"
+      - "světlo předsíň zapni"
     intent:
       name: HassTurnOn
       slots:


### PR DESCRIPTION
This should workaround #1471 by adding word `světlo` to ambiguous intents . Commands `rozsviť/zhasni` can be still used without `světlo`, as they're not ambiguous.

Also `HassTurnOff` intent for "all lights" domain present in EN version has been added.