### PR TITLE
[cs] Adjust responses to follow style guide

### DIFF
--- a/responses/cs/HassClimateGetTemperature.yaml
+++ b/responses/cs/HassClimateGetTemperature.yaml
@@ -2,4 +2,4 @@ language: cs
 responses:
   intents:
     HassClimateGetTemperature:
-      default: "{{ state.state }} {{ 'stupeň' if state.state | float | abs == 1 else 'stupně' if state.state | float | abs in [2,3,4] else 'stupňů' }}"
+      default: "{{ state.state_with_unit }}"

--- a/responses/cs/HassClimateSetTemperature.yaml
+++ b/responses/cs/HassClimateSetTemperature.yaml
@@ -2,4 +2,4 @@ language: cs
 responses:
   intents:
     HassClimateSetTemperature:
-      default: "Teplota nastavena na {{ slots.temperature }} {{ 'stupeň' if state.state | float | abs == 1 else 'stupně' if state.state | float | abs in [2,3,4] else 'stupňů' }}"
+      default: "Teplota nastavena"

--- a/responses/cs/HassGetState.yaml
+++ b/responses/cs/HassGetState.yaml
@@ -21,9 +21,9 @@ responses:
         {% set present_simple = ('no', 'ná', 'né') %}
 
         {% if query.matched %}
-          Ano, {{ slots.name }} {{ 'se' if state.state_with_unit.endswith(present_continuous) else 'je' }} {{ state.state_with_unit }}
+          Ano
         {% else %}
-          Ne, {{ slots.name }} {{ 'se' if state.state_with_unit.endswith(present_continuous) else 'je' }} {{ state.state_with_unit }}
+          Ne, {{ state.state_with_unit }}
         {% endif %}
 
       any: |
@@ -48,7 +48,7 @@ responses:
         {% else %}
           {% set no_match = query.unmatched | map(attribute="name") | sort | list %}
           {% if no_match | length > 4 %}
-            Ne, {{ no_match[:3] | join(", ") }} a {{ (no_match | length - 3) }} další jsou {{ state.state_with_unit }}
+            Ne, {{ no_match[:3] | join(", ") }} a {{ (no_match | length - 3) }} další jsou {{ state.state_with_unit }}
           {%- else -%}
             Ne,
             {% for name in no_match -%}
@@ -60,7 +60,7 @@ responses:
 
       which: |
         {% if not query.matched %}
-          žádné
+          Žádné
         {% else: %}
           {% set match = query.matched | map(attribute="name") | sort | list %}
           {% if match | length > 4 %}
@@ -68,7 +68,7 @@ responses:
           {% else %}
             {%- for name in match -%}
               {% if not loop.first and not loop.last %}, {% elif loop.last and not loop.first %} a {% endif -%}
-              {{ name }} {{ 'je' if match | length == 1 else 'jsou'}} {{ state.state_with_unit }}
+              {{ name }}
             {%- endfor -%}
           {% endif %}
         {% endif %}

--- a/responses/cs/HassLightSet.yaml
+++ b/responses/cs/HassLightSet.yaml
@@ -2,13 +2,5 @@ language: cs
 responses:
   intents:
     HassLightSet:
-      brightness: "Jas {{ slots.name }} nastaven na {{ slots.brightness }}"
-      brightness_max: "Jas {{ slots.name }} nastaven na maximum"
-      brightness_min: "Jas {{ slots.name }} nastaven na minimum"
-
-      brightness_area: "Jas v {{ slots.area }} nastaven na {{ slots.brightness }}"
-      brightness_area_max: "Jas v {{ slots.area }} nastaven na maximum"
-      brightness_area_min: "Jas v {{ slots.area }} nastaven na minimum"
-
-      color: "Barva {{ slots.name }} nastavena na {{ slots.color }}"
-      color_area: "Barva v {{ slots.area }} nastavena na {{ slots.color }}"
+      brightness: "Jas nastaven"
+      color: "Barva nastavena"

--- a/responses/cs/HassTurnOff.yaml
+++ b/responses/cs/HassTurnOff.yaml
@@ -2,12 +2,11 @@ language: cs
 responses:
   intents:
     HassTurnOff:
-      default: "{{ slots.name }} vypnuto"
-      lights_area: "Světla v {{ slots.area }} byla zhasnuta"
-      fans_area: "Větráky v {{ slots.area }} byly vypnuty"
-      fan: "Větrák {{ slots.name }} vypnut"
-      light: "Světlo {{ slots.name }} bylo zhasnuto"
+      default: "Vypnuto"
+      lights_area: "Světla zhasnuta"
+      fan: "Větrák vypnut"
+      fans_area: "Větráky vypnuty"
+      light: "Zhasnuto"
       light_all: "Všechna světla byla zhasnuta"
-      cover: "{{ slots.name | capitalize }} zavřeno"
-      cover_area: "Stínění v {{ slots.area }} zavřeno"
-      garage: "Garážová vrata zavřena"
+      cover: "Zavřeno"
+      garage: "Vrata zavřena"

--- a/responses/cs/HassTurnOn.yaml
+++ b/responses/cs/HassTurnOn.yaml
@@ -2,11 +2,10 @@ language: cs
 responses:
   intents:
     HassTurnOn:
-      default: "{{ slots.name }} byl zapnut"
-      lights_area: "Světla v {{ slots.area }} byla rozsvícena"
-      fans_area: "Větráky v {{ slots.area }} byly zapnuty"
-      fan: "Větrák {{ slots.name }} byl zapnut"
-      light: "Světlo {{ slots.name }} bylo rozsvíceno"
-      cover: "{{ slots.name | capitalize }} otevřeno"
-      cover_area: "Stínění v {{ slots.area }} otevřeno"
-      garage: "Garážová vrata otevřena"
+      default: "Zapnuto"
+      lights_area: "Světla rozsvícena"
+      fans_area: "Větráky zapnuty"
+      fan: "Větrák zapnut"
+      light: "Rozsvíceno"
+      cover: "Otevřeno"
+      garage: "Vrata otevřena"

--- a/sentences/cs/cover_HassTurnOff.yaml
+++ b/sentences/cs/cover_HassTurnOff.yaml
@@ -39,4 +39,4 @@ intents:
             - shade
             - shutter
           domain: cover
-        response: cover_area
+        response: cover

--- a/sentences/cs/cover_HassTurnOn.yaml
+++ b/sentences/cs/cover_HassTurnOn.yaml
@@ -39,4 +39,4 @@ intents:
             - shade
             - shutter
           domain: cover
-        response: cover_area
+        response: cover

--- a/sentences/cs/light_HassLightSet.yaml
+++ b/sentences/cs/light_HassLightSet.yaml
@@ -12,7 +12,7 @@ intents:
           - "[jas] <area> (<zvysit>|<ztlumit>|<nastavit>|<zmenit>) [jas] <brightness>"
         slots:
           name: all
-        response: brightness_area
+        response: brightness
 
       # max intents
       - sentences:
@@ -21,11 +21,11 @@ intents:
           - "[jas] <area> (<zvysit>|<nastavit>|<zmenit>) [jas] [na] [{max:brightness}] [jas] [{max:brightness}]"
         slots:
           name: all
-        response: brightness_area_max
+        response: brightness
       - sentences:
           - "(<nastavit>|<zmenit>|<zvysit>) [jas] [na] {max:brightness} [jas] [u] {name}"
           - "[jas] [u] {name} (<nastavit>|<zvysit>|<zmenit>) [jas] [na] {max:brightness} [jas]"
-        response: brightness_max
+        response: brightness
 
         #min intents
       - sentences:
@@ -34,11 +34,11 @@ intents:
           - "[jas] <area> (<nastavit>|<zmenit>|<ztlumit>) [jas] [na] [{min:brightness}] [jas] [{min:brightness}]"
         slots:
           name: all
-        response: brightness_area_min
+        response: brightness
       - sentences:
           - "(<nastavit>|<zmenit>|<ztlumit>) [jas] [na] {min:brightness} [jas] [u] {name}"
           - "[jas] [u] {name} (<nastavit>|<ztlumit>|<zmenit>) [jas] [na] {min:brightness} [jas]"
-        response: brightness_min
+        response: brightness
 
       - sentences:
           - "(<nastavit>|<zmenit>) {color} [barvu] [na] {name}"
@@ -52,4 +52,4 @@ intents:
           - "<area> (<zmenit>|<nastavit>) [na] {color} [barvu]"
           - "<area> (<zmenit>|<nastavit>) barvu na {color}"
           - "Barvu <area> (<zmenit>|<nastavit>) na {color} [barvu]"
-        response: color_area
+        response: color

--- a/tests/cs/_fixtures.yaml
+++ b/tests/cs/_fixtures.yaml
@@ -79,7 +79,7 @@ entities:
     id: cover.garage_door
     area: garage
     state:
-      in: otevírá
+      in: otevírá se
       out: opening
     attributes:
       device_class: garage

--- a/tests/cs/cover_HassGetState.yaml
+++ b/tests/cs/cover_HassGetState.yaml
@@ -8,7 +8,7 @@ tests:
         domain: cover
         name: "Garáž"
         state: closed
-    response: "Ne, garáž se otevírá"
+    response: "Ne, otevírá se"
 
   - sentences:
       - "zavírá se garáž?"
@@ -18,7 +18,7 @@ tests:
         domain: cover
         name: "Garáž"
         state: closing
-    response: "Ne, garáž se otevírá"
+    response: "Ne, otevírá se"
 
   - sentences:
       - "jaký stav má žaluzie ložnice?"
@@ -67,7 +67,7 @@ tests:
         device_class: blind
         domain: cover
         state: open
-    response: "Přední roleta je otevřená"
+    response: "Přední roleta"
 
   - sentences:
       - "kolik rolet se zavírá"

--- a/tests/cs/cover_HassTurnOff.yaml
+++ b/tests/cs/cover_HassTurnOff.yaml
@@ -10,7 +10,7 @@ tests:
       context:
         device_class: blind
         domain: cover
-    response: "Žaluzie ložnice zavřeno"
+    response: "Zavřeno"
 
   - sentences:
       - "zavřít přední roleta"
@@ -22,7 +22,7 @@ tests:
       context:
         device_class: blind
         domain: cover
-    response: "Přední roleta zavřeno"
+    response: "Zavřeno"
 
   - sentences:
       - "zavři přední roletu"
@@ -34,7 +34,7 @@ tests:
       context:
         device_class: blind
         domain: cover
-    response: "Přední roletu zavřeno"
+    response: "Zavřeno"
 
   - sentences:
       - "zavřít přední roleta ložnice"
@@ -49,7 +49,7 @@ tests:
       context:
         device_class: blind
         domain: cover
-    response: "Přední roleta zavřeno"
+    response: "Zavřeno"
 
   - sentences:
       - "zavři přední roletu v ložnici"
@@ -64,7 +64,7 @@ tests:
       context:
         device_class: blind
         domain: cover
-    response: "Přední roletu zavřeno"
+    response: "Zavřeno"
 
   - sentences:
       - "zavři garáž"
@@ -78,7 +78,7 @@ tests:
       slots:
         device_class: garage
         domain: cover
-    response: "Garážová vrata zavřena"
+    response: "Vrata zavřena"
 
   - sentences:
       - "zavři roletu v kuchyni"
@@ -133,4 +133,4 @@ tests:
           - curtain
           - shutter
         domain: cover
-    response: "Stínění v kuchyni zavřeno"
+    response: "Zavřeno"

--- a/tests/cs/cover_HassTurnOn.yaml
+++ b/tests/cs/cover_HassTurnOn.yaml
@@ -10,7 +10,7 @@ tests:
       context:
         device_class: blind
         domain: cover
-    response: "Žaluzie ložnice otevřeno"
+    response: "Otevřeno"
 
   - sentences:
       - "otevřít přední roleta"
@@ -22,7 +22,7 @@ tests:
       context:
         device_class: blind
         domain: cover
-    response: "Přední roleta otevřeno"
+    response: "Otevřeno"
 
   - sentences:
       - "otevři přední roletu"
@@ -34,7 +34,7 @@ tests:
       context:
         device_class: blind
         domain: cover
-    response: "Přední roletu otevřeno"
+    response: "Otevřeno"
 
   - sentences:
       - "otevřít přední roleta ložnice"
@@ -49,7 +49,7 @@ tests:
       context:
         device_class: blind
         domain: cover
-    response: "Přední roleta otevřeno"
+    response: "Otevřeno"
 
   - sentences:
       - "otevři přední roletu v ložnici"
@@ -64,7 +64,7 @@ tests:
       context:
         device_class: blind
         domain: cover
-    response: "Přední roletu otevřeno"
+    response: "Otevřeno"
 
   - sentences:
       - "otevři garáž"
@@ -78,7 +78,7 @@ tests:
       slots:
         device_class: garage
         domain: cover
-    response: "Garážová vrata otevřena"
+    response: "Vrata otevřena"
 
   - sentences:
       - "otevři roletu v kuchyni"
@@ -153,4 +153,4 @@ tests:
           - curtain
           - shutter
         domain: cover
-    response: "Stínění v kuchyni otevřeno"
+    response: "Otevřeno"

--- a/tests/cs/fan_HassTurnOff.yaml
+++ b/tests/cs/fan_HassTurnOff.yaml
@@ -15,7 +15,7 @@ tests:
         domain: fan
         name: all
     response:
-      - Větráky v kuchyni byly vypnuty
+      - Větráky vypnuty
 
   - sentences:
       - vypni ventilátor v kuchyni

--- a/tests/cs/fan_HassTurnOn.yaml
+++ b/tests/cs/fan_HassTurnOn.yaml
@@ -15,7 +15,7 @@ tests:
         domain: fan
         name: all
     response:
-      - Větráky v kuchyni byly zapnuty
+      - Větráky zapnuty
   - sentences:
       - zapni ventilátor v kuchyni
       - v kuchyni zapni ventilátor
@@ -29,4 +29,4 @@ tests:
           - Kuchyni
           - Kuchyně
         domain: fan
-    response: Větrák byl zapnut
+    response: Větrák zapnut

--- a/tests/cs/light_HassLightSet.yaml
+++ b/tests/cs/light_HassLightSet.yaml
@@ -32,10 +32,7 @@ tests:
           - světlo v ložnici
           - světla v ložnici
     response:
-      - Jas lampičky v ložnici nastaven na 30
-      - Jas lampičku v ložnici nastaven na 30
-      - Jas lampičky v ložnici nastaven na 30%
-      - Jas lampičku v ložnici nastaven na 30%
+      - Jas nastaven
 
   - sentences:
       - Nastav jas v ložnici na 30%
@@ -53,8 +50,7 @@ tests:
           - Ložnici
           - Ložnicce
     response:
-      - Jas v ložnici nastaven na 30
-      - Jas v ložnici nastaven na 30%
+      - Jas nastaven
 
         #Min/Max tests
   - sentences:
@@ -73,7 +69,7 @@ tests:
           - Ložnicce
         name: all
     response:
-      - Jas v ložnici nastaven na minimum
+      - Jas nastaven
 
   - sentences:
       - Nastav jas v ložnici na maximum
@@ -92,7 +88,7 @@ tests:
           - Ložnicce
         name: all
     response:
-      - Jas v ložnici nastaven na maximum
+      - Jas nastaven
 
   - sentences:
       - Nastav maximální jas u lampičky v ložnici
@@ -117,7 +113,7 @@ tests:
           - světlo v ložnici
           - světla v ložnici
     response:
-      - Jas lampičky v ložnici nastaven na maximum
+      - Jas nastaven
 
   - sentences:
       - Nastav minimální jas u lampičky v ložnici
@@ -143,7 +139,7 @@ tests:
           - světlo v ložnici
           - světla v ložnici
     response:
-      - Jas lampičky v ložnici nastaven na minimum
+      - Jas nastaven
 
         #color
   - sentences:
@@ -165,9 +161,7 @@ tests:
           - světlo v ložnici
           - světla v ložnici
     response:
-      - Barva lampičky v ložnici nastavena na modrou
-      - Barva lampičku v ložnici nastavena na modrou
-      - Barva lampu v ložnici nastavena na modrou
+      - Barva nastavena
 
   - sentences:
       - Barvu v ložnici nastav na modrou
@@ -182,4 +176,4 @@ tests:
           - Ložnicce
         color: blue
     response:
-      - Barva v ložnici nastavena na modrou
+      - Barva nastavena

--- a/tests/cs/light_HassTurnOff.yaml
+++ b/tests/cs/light_HassTurnOff.yaml
@@ -13,14 +13,11 @@ tests:
           - Kuchyni
           - Kuchyně
         domain: light
-    response: "Světla v kuchyni byla zhasnuta"
+    response: "Světla zhasnuta"
 
   - sentences:
-      - "vypni světlo lampička v ložnici"
-      - "zhasni lampičku v ložnici"
       - "zhasni světlo lampička v ložnici"
       - "lampičku v ložnici zhasnout"
-      - "světlo lampička v ložnici vypnout"
     intent:
       name: HassTurnOff
       slots:
@@ -35,8 +32,7 @@ tests:
           - světlo v ložnici
           - světla v ložnici
     response:
-      - "Světlo lampička v ložnici bylo zhasnuto"
-      - "Světlo lampičku v ložnici bylo zhasnuto"
+      - "Zhasnuto"
 
   - sentences:
       - "vypni všechna světla"

--- a/tests/cs/light_HassTurnOn.yaml
+++ b/tests/cs/light_HassTurnOn.yaml
@@ -11,7 +11,7 @@ tests:
           - "lampa v obývacím pokoji"
           - "lampička v obývacím pokoji"
           - "lampičku v obývacím pokoji"
-    response: "Světlo lampička v obývacím pokoji bylo rozsvíceno"
+    response: "Rozsvíceno"
 
   - sentences:
       - "předsíň rozsviť"
@@ -23,7 +23,7 @@ tests:
       slots:
         domain: light
         name: předsíň
-    response: "Světlo předsíň bylo rozsvíceno"
+    response: "Rozsvíceno"
 
   - sentences:
       - "zapni všechna světla v obývacím pokoji"
@@ -38,5 +38,4 @@ tests:
           - Obývacím pokoji
           - obýváku
     response:
-      - "Světla v obývacím pokoji byla rozsvícena"
-      - "Světla v obýváku byla rozsvícena"
+      - "Světla rozsvícena"


### PR DESCRIPTION
This is rather a big change - it adjusts all responses to follow the official [response style guide](https://developers.home-assistant.io/docs/voice/intent-recognition/style-guide/). For English this was done in #1040 - this PR aligns (or tries to) the Czech language with that.

Although it seems detrimental by making the assistant less chatty, it improves maintainability and removes the need for adjusting for clumsy responses (with bad grammatical cases/tenses), such as those that can be seen in the removed test cases.