### PR TITLE
[en] Add alternative sentences for scenes

### DIFF
--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -302,6 +302,7 @@ expansion_rules:
   close: "(close|shut|lower)"
   set: "(set|make|change|turn)"
   numeric_value_set: "(set|change|turn|increase|decrease|make)"
+  in: "(in|on|at)"
 
   # Questions
   what_is_the_class_of_name: "(<what_is> the <class> (of|in|from|(indicated|measured) by) <name> [in <area>]|<what_is> <name>['s] <class> [in <area>]|<what_is> <area> <name>['s] <class>)"

--- a/sentences/en/scene_HassTurnOn.yaml
+++ b/sentences/en/scene_HassTurnOn.yaml
@@ -12,9 +12,9 @@ intents:
         response: scene
       - sentences:
           - "[activate|<turn>] <area> <name> [scene] [on]"
-          - "[activate|<turn>] <name> [scene] (in|on|at) <area>"
+          - "[activate|<turn>] <name> [scene] <in> <area>"
           - "(change|transition) [to] <area> [to] <name> [scene]"
-          - "(change|transition) to <name> [scene] (in|on|at) <area>"
+          - "(change|transition) to <name> [scene] <in> <area>"
         slots:
           domain: scene
         response: scene

--- a/sentences/en/scene_HassTurnOn.yaml
+++ b/sentences/en/scene_HassTurnOn.yaml
@@ -4,8 +4,17 @@ intents:
     data:
       - sentences:
           - "[activate|<turn>] <name> [scene] [on]"
+          - "(change|transition) to <name> [scene]"
         requires_context:
           domain: scene
+        slots:
+          domain: scene
+        response: scene
+      - sentences:
+          - "[activate|<turn>] <area> <name> [scene] [on]"
+          - "[activate|<turn>] <name> [scene] (in|on|at) <area>"
+          - "(change|transition) [to] <area> [to] <name> [scene]"
+          - "(change|transition) to <name> [scene] (in|on|at) <area>"
         slots:
           domain: scene
         response: scene

--- a/sentences/en/scene_HassTurnOn.yaml
+++ b/sentences/en/scene_HassTurnOn.yaml
@@ -13,7 +13,7 @@ intents:
       - sentences:
           - "[activate|<turn>] <area> <name> [scene] [on]"
           - "[activate|<turn>] <name> [scene] <in> <area>"
-          - "(change|transition) [to] <area> [to] <name> [scene]"
+          - "(change|transition) ([to] <area> <name>|<area> to <name>) [scene]"
           - "(change|transition) to <name> [scene] <in> <area>"
         slots:
           domain: scene

--- a/tests/en/scene_HassTurnOn.yaml
+++ b/tests/en/scene_HassTurnOn.yaml
@@ -4,9 +4,28 @@ tests:
       - "activate party mode scene"
       - "turn party mode on"
       - "party mode on"
+      - "change to the party mode scene"
+      - "transition to party mode"
     intent:
       name: HassTurnOn
       slots:
+        domain: scene
+        name: "Party Mode"
+    response: "Activated"
+  - sentences:
+      - "activate kitchen party mode scene"
+      - "turn kitchen party mode on"
+      - "activate party mode in the kitchen"
+      - "activate party mode at the Kitchen"
+      - "kitchen party mode on"
+      - "change kitchen to the party mode scene"
+      - "transition to the kitchen party mode"
+      - "change to party mode at the kitchen"
+      - "transition to party mode in kitchen"
+    intent:
+      name: HassTurnOn
+      slots:
+        area: Kitchen
         domain: scene
         name: "Party Mode"
     response: "Activated"


### PR DESCRIPTION
Adds alternative sentences starting with `change` and `transition` to activate scenes. Additionally adds several alternatives to allow the activation of scenes with an area slot. 