### PR TITLE
Getting room temperature does not work in Italian language

### DIFF
--- a/sentences/it/climate_HassClimateGetTemperature.yaml
+++ b/sentences/it/climate_HassClimateGetTemperature.yaml
@@ -6,3 +6,5 @@ intents:
           - "[<what_is>] <temp> [c'è] [(<in> | <of> | <the>)] [<area>]"
           - "[quanto] [(è | c'è | fa)] (caldo | freddo) [(<in> | <the>)] [<area>]"
           - "quanto (caldo | freddo) [(è | c'è | fa)] [(<in>|<the>) <area>]"
+          - "qual è la temperatura [in <area>]"
+          - "che temperatura c'è [in <area>]"


### PR DESCRIPTION
Getting room temperature does not work in Italian language the way a native speaker would expect.