### PR TITLE
[FR] Add skip words for more natural sentences

### DIFF
--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -329,6 +329,11 @@ expansion_rules:
   eclaire: (éclaire|éclairer|illumine|illuminer)
 skip_words:
   - "s'il te plaît"
+  - "stp"
+  - "please"
   - "merci"
   - "est ce que"
   - "est-ce que"
+  - "tu peux"
+  - "peux tu"
+  - "peux-tu"

--- a/tests/fr/light_HassTurnOn.yaml
+++ b/tests/fr/light_HassTurnOn.yaml
@@ -10,6 +10,7 @@ tests:
       - Lumière dans la cuisine
       - Lumière cuisine
       - Éclaire la cuisine
+      - Tu peux allumer les lumières de la cuisine
     intent:
       name: HassTurnOn
       slots:


### PR DESCRIPTION
Add more skip_words  in `_common.yaml` to allow more natural conversations with Assist (currently it's a bit too robotic):
 - stp
 - please
 - tu peux
 - peux tu
 - peux-tu