### PR TITLE
[EN] Add optional "in area" to light and generic HassTurnOn/Off

### DIFF
--- a/sentences/en/homeassistant_HassTurnOff.yaml
+++ b/sentences/en/homeassistant_HassTurnOff.yaml
@@ -3,9 +3,9 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "<turn> off <name>"
-          - "[<turn>] <name> [to] off"
-          - "deactivate <name>"
+          - "<turn> off (<area> <name>|<name> [in <area>])"
+          - "[<turn>] (<area> <name>|<name> [in <area>]) [to] off"
+          - "deactivate (<area> <name>|<name> [in <area>])"
         excludes_context:
           domain:
             - binary_sensor

--- a/sentences/en/homeassistant_HassTurnOn.yaml
+++ b/sentences/en/homeassistant_HassTurnOn.yaml
@@ -3,9 +3,9 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "<turn> on <name>"
-          - "[<turn>] <name> [to] on"
-          - "activate <name>"
+          - "<turn> on (<area> <name>|<name> [in <area>])"
+          - "[<turn>] (<area> <name>|<name> [in <area>]) [to] on"
+          - "activate (<area> <name>|<name> [in <area>])"
         excludes_context:
           domain:
             - binary_sensor

--- a/sentences/en/light_HassTurnOff.yaml
+++ b/sentences/en/light_HassTurnOff.yaml
@@ -3,9 +3,11 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "<turn> off <name> (light[s]|[light] switch[es])"
-          - "[<turn>] <name> (light[s]|[light] switch[es]) [to] off"
-          - "deactivate <name> (light[s]|[light] switch[es])"
+          - "<turn> off (<area> <name> <light_devices>|<name> <light_devices> [in <area>])"
+          - "[<turn>] (<area> <name> <light_devices>|<name> <light_devices> [in <area>]) [to] off"
+          - "deactivate (<area> <name> <light_devices>|<name> <light_devices> [in <area>])"
+        expansion_rules:
+          light_devices: "(light[s]|[light] switch[es])"
         requires_context:
           domain: "light"
       - sentences:

--- a/sentences/en/light_HassTurnOn.yaml
+++ b/sentences/en/light_HassTurnOn.yaml
@@ -3,9 +3,9 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "<turn> on <name> (light[s]|[light] switch[es])"
-          - "[<turn>] <name> (light[s]|[light] switch[es]) [to] on"
-          - "activate <name> (light[s]|[light] switch[es])"
+          - "<turn> on <name> (light[s]|[light] switch[es]) [in <area>]"
+          - "[<turn>] <name> (light[s]|[light] switch[es]) [in <area>] [to] on"
+          - "activate <name> (light[s]|[light] switch[es]) [in <area>]"
         requires_context:
           domain: "light"
       - sentences:

--- a/sentences/en/light_HassTurnOn.yaml
+++ b/sentences/en/light_HassTurnOn.yaml
@@ -3,9 +3,11 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "<turn> on <name> (light[s]|[light] switch[es]) [in <area>]"
-          - "[<turn>] <name> (light[s]|[light] switch[es]) [in <area>] [to] on"
-          - "activate <name> (light[s]|[light] switch[es]) [in <area>]"
+          - "<turn> on (<area> <name> <light_devices>|<name> <light_devices> [in <area>])"
+          - "[<turn>] (<area> <name> <light_devices>|<name> <light_devices> [in <area>]) [to] on"
+          - "activate (<area> <name> <light_devices>|<name> <light_devices> [in <area>])"
+        expansion_rules:
+          light_devices: "(light[s]|[light] switch[es])"
         requires_context:
           domain: "light"
       - sentences:


### PR DESCRIPTION
For consistency with covers, locks etc., I've added optional `[in <area>]` to HassTurnOn and HassTurnOff intents for the `light` domain and the generic `homeassistant` domain.

Now you can say things like `turn off the desk lamp in the office` or `turn off the office desk lamp`, whereas until now you could only say `turn off the desk lamp`