### PR TITLE
[RO] Add optional "din area" for lights and generic HassTurnOn/Off

### DIFF
--- a/sentences/ro/homeassistant_HassTurnOff.yaml
+++ b/sentences/ro/homeassistant_HassTurnOff.yaml
@@ -3,7 +3,7 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "<opreste> <name>"
+          - "<opreste> <name> [<din_zona>]"
         excludes_context:
           domain:
             - light

--- a/sentences/ro/homeassistant_HassTurnOn.yaml
+++ b/sentences/ro/homeassistant_HassTurnOn.yaml
@@ -3,7 +3,7 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "<porneste> <name>"
+          - "<porneste> <name> [<din_zona>]"
         excludes_context:
           domain:
             - light

--- a/sentences/ro/light_HassTurnOff.yaml
+++ b/sentences/ro/light_HassTurnOff.yaml
@@ -3,7 +3,7 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "<opreste> <name>"
+          - "<opreste> [<lumina>] <name> [<din_zona>]"
         slots:
           domain: light
         requires_context:

--- a/sentences/ro/light_HassTurnOn.yaml
+++ b/sentences/ro/light_HassTurnOn.yaml
@@ -3,7 +3,7 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "<porneste> <name>"
+          - "<porneste> [<lumina>] <name> [<din_zona>]"
         slots:
           domain: light
         requires_context:


### PR DESCRIPTION
For consistency with covers, locks etc., I've added optional [in <area>] to HassTurnOn and HassTurnOff intents for the light domain and the generic homeassistant domain.

Now you can say things like `aprinde vezoza din dormitor`, whereas until now you could only say `aprinde veioza`.