### PR TITLE
Add HassNevermind (not yet supported in HA)

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -84,7 +84,7 @@ HassGetState:
       description: "List of states that matched everything except state name"
 
 HassNevermind:
-  supported: false
+  supported: true
   domain: homeassistant
   description: "Does nothing. Used to cancel a request"
 

--- a/intents.yaml
+++ b/intents.yaml
@@ -83,6 +83,11 @@ HassGetState:
     query.unmatched:
       description: "List of states that matched everything except state name"
 
+HassNevermind:
+  supported: false
+  domain: homeassistant
+  description: "Does nothing. Used to cancel a request"
+
 # -----------------------------------------------------------------------------
 # light
 # -----------------------------------------------------------------------------

--- a/sentences/en/homeassistant_HassNevermind.yaml
+++ b/sentences/en/homeassistant_HassNevermind.yaml
@@ -1,0 +1,7 @@
+language: en
+intents:
+  HassNevermind:
+    data:
+      - sentences:
+          - "nevermind"
+          - "never mind"

--- a/tests/en/homeassistant_HassNevermind.yaml
+++ b/tests/en/homeassistant_HassNevermind.yaml
@@ -1,0 +1,7 @@
+language: en
+tests:
+  - sentences:
+      - "nevermind"
+      - "never mind"
+    intent:
+      name: HassNevermind

--- a/tests/test_language_intents.py
+++ b/tests/test_language_intents.py
@@ -78,7 +78,7 @@ def do_test_language_sentences(
         ), f"File {file_name} should only contain sentences for intent {file_intent}"
 
         intent_schema = intent_schemas[intent_name]
-        slot_schema = intent_schema["slots"]
+        slot_schema = intent_schema.get("slots", {})
         slot_combinations = intent_schema.get("slot_combinations")
 
         for data in intent.data:

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -111,7 +111,7 @@ def do_test_language_sentences_file(
             ), f"For '{sentence}' expected intent {intent['name']}, got {result.intent.name}"
 
             matched_slots = {slot.name: slot.value for slot in result.entities.values()}
-            actual_slots = intent.get("slots", {})
+            actual_slots = intent.get("slots") or {}
 
             # Check for all match slots
             for match_name, match_value in matched_slots.items():


### PR DESCRIPTION
Add English support for a future HA intent: `HassNevermind`.
This intent does nothing, it's just used to be able to cancel a request by saying something like "nevermind".

Because this intent returns no slot values, some test code needed to be a bit more robust.