### PR TITLE
First pass a set timer for English

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -159,3 +159,71 @@ HassShoppingListAddItem:
     item:
       description: "Item to add"
       required: true
+
+# -----------------------------------------------------------------------------
+# timer
+# -----------------------------------------------------------------------------
+
+HassSetTimer:
+  supported: false
+  domain: timer
+  description: "Starts a new timer using a duration and optional name"
+  slots:
+    hours:
+      description: "Number of hours in the duration"
+      required: false
+    minutes:
+      description: "Number of minutes in the minutes"
+      required: false
+    seconds:
+      description: "Number of seconds in the duration"
+      required: false
+    text:
+      description: "User-provided name/description for the timer"
+      required: false
+  slot_combinations:
+    hours:
+      - "hours"
+    hours_minutes:
+      - "hours"
+      - "minutes"
+    hours_seconds:
+      - "hours"
+      - "seconds"
+    hours_minutes_seconds:
+      - "hours"
+      - "minutes"
+      - "seconds"
+    hours_text:
+      - "hours"
+      - "text"
+    hours_minutes_text:
+      - "hours"
+      - "minutes"
+      - "text"
+    hours_seconds_text:
+      - "hours"
+      - "seconds"
+      - "text"
+    hours_minutes_seconds_text:
+      - "hours"
+      - "minutes"
+      - "seconds"
+      - "text"
+    minutes:
+      - "minutes"
+    minutes_seconds:
+      - "minutes"
+      - "seconds"
+    minutes_text:
+      - "minutes"
+      - "text"
+    minutes_seconds_text:
+      - "minutes"
+      - "seconds"
+      - "text"
+    seconds:
+      - "seconds"
+    seconds_text:
+      - "seconds"
+      - "text"

--- a/responses/en/HassSetTimer.yaml
+++ b/responses/en/HassSetTimer.yaml
@@ -1,0 +1,45 @@
+language: en
+responses:
+  intents:
+    HassSetTimer:
+      started: |
+        {% if "hours" in slots: %}
+          {% if slots.hours.value == 1: %}
+            {% set hours = (slots.hours.value | string) + " hour" %}
+          {% else: %}
+            {% set hours = (slots.hours.value | string) + " hours" %}
+          {% endif %}
+        {% endif %}
+
+        {% if "minutes" in slots: %}
+          {% if slots.minutes.value == 1: %}
+            {% set minutes = "1 minute" %}
+          {% else: %}
+            {% set minutes = (slots.minutes.value | string) + " minutes" %}
+          {% endif %}
+        {% endif %}
+
+        {% if "seconds" in slots: %}
+          {% if slots.seconds.value == 1: %}
+            {% set seconds = "1 second" %}
+          {% else: %}
+            {% set seconds = (slots.seconds.value | string) + " seconds" %}
+          {% endif %}
+        {% endif %}
+
+        {% if ("hours" in slots) and ("minutes" in slots) and ("seconds" in slots): %}
+          {% set duration = hours + " and " + minutes + " and " + seconds %}
+        {% elif ("hours" in slots) and ("minutes" in slots): %}
+          {% set duration = hours + " and " + minutes %}
+        {% elif ("hours" in slots) and ("seconds" in slots): %}
+          {% set duration = hours + " and " + seconds %}
+        {% elif "hours" in slots: %}
+          {% set duration = hours %}
+        {% elif ("minutes" in slots) and ("seconds" in slots): %}
+          {% set duration = minutes + " and " + seconds %}
+        {% elif "minutes" in slots: %}
+          {% set duration = minutes %}
+        {% elif "seconds" in slots: %}
+          {% set duration = seconds %}
+        {% endif %}
+        Timer started for {{ duration }}

--- a/responses/en/HassSetTimer.yaml
+++ b/responses/en/HassSetTimer.yaml
@@ -28,7 +28,7 @@ responses:
         {% endif %}
 
         {% if ("hours" in slots) and ("minutes" in slots) and ("seconds" in slots): %}
-          {% set duration = hours + " and " + minutes + " and " + seconds %}
+          {% set duration = hours + ", " + minutes + " and " + seconds %}
         {% elif ("hours" in slots) and ("minutes" in slots): %}
           {% set duration = hours + " and " + minutes %}
         {% elif ("hours" in slots) and ("seconds" in slots): %}

--- a/responses/en/HassSetTimer.yaml
+++ b/responses/en/HassSetTimer.yaml
@@ -5,7 +5,7 @@ responses:
       started: |
         {% if "hours" in slots: %}
           {% if slots.hours.value == 1: %}
-            {% set hours = (slots.hours.value | string) + " hour" %}
+            {% set hours = "1 hour" %}
           {% else: %}
             {% set hours = (slots.hours.value | string) + " hours" %}
           {% endif %}

--- a/script/intentfest/parse.py
+++ b/script/intentfest/parse.py
@@ -12,6 +12,7 @@ from hassil.recognize import recognize
 from hassil.util import merge_dict, normalize_whitespace
 
 from shared import (
+    StringWithValue,
     get_areas,
     get_matched_states,
     get_slot_lists,
@@ -70,12 +71,17 @@ def run() -> int:
 
     # Parse sentences
     for sentence in args.sentence:
-        result = recognize(sentence, intents, slot_lists=slot_lists)
+        result = recognize(
+            sentence, intents, slot_lists=slot_lists, language=args.language
+        )
         output_dict = {"text": sentence, "match": result is not None}
         if result is not None:
             output_dict["intent"] = result.intent.name
             output_dict["slots"] = {
-                entity.name: entity.value for entity in result.entities_list
+                entity.name: StringWithValue(
+                    entity.text_clean or entity.value, value=entity.value
+                )
+                for entity in result.entities_list
             }
             output_dict["context"] = result.context
 

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 import yaml
 from voluptuous.humanize import validate_with_humanized_errors
 
-from shared import get_jinja2_environment
+from shared import StringWithValue, get_jinja2_environment
 
 from .const import (
     INTENTS_FILE,
@@ -507,7 +507,7 @@ def validate_language(
 
             possible_response_keys: set[str] = set()
             slots = {
-                slot_name: f"<{slot_name}>"
+                slot_name: StringWithValue(f"<{slot_name}>")
                 for slot_name in intent_schemas[intent_name].get("slots", {})
             }
             for response_key, response_template in intent_responses.items():

--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -289,6 +289,24 @@ lists:
   shopping_list_item:
     wildcard: true
 
+  hours:
+    range:
+      from: 1
+      to: 23
+
+  minutes:
+    range:
+      from: 1
+      to: 59
+
+  seconds:
+    range:
+      from: 1
+      to: 59
+
+  timer_text:
+    wildcard: true
+
 expansion_rules:
   name: "[the] {name}"
   area: "[the] {area}"
@@ -303,6 +321,9 @@ expansion_rules:
   set: "(set|make|change|turn)"
   numeric_value_set: "(set|change|turn|increase|decrease|make)"
   in: "(in|on|at)"
+  start: "(start|set|make|create)"
+  duration_simple: "({hours} (hour|hours)|{minutes} (minute|minutes)|{seconds} (second|seconds))"
+  timer_text: "(for|to|named|called) {timer_text:text}"
 
   # Questions
   what_is_the_class_of_name: "(<what_is> the <class> (of|in|from|(indicated|measured) by) <name> [in <area>]|<what_is> <name>['s] <class> [in <area>]|<what_is> <area> <name>['s] <class>)"

--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -322,7 +322,7 @@ expansion_rules:
   numeric_value_set: "(set|change|turn|increase|decrease|make)"
   in: "(in|on|at)"
   start: "(start|set|make|create)"
-  duration_simple: "({hours} (hour|hours)|{minutes} (minute|minutes)|{seconds} (second|seconds))"
+  duration_simple: "({hours} hour[s]|{minutes} minute[s]|{seconds} second[s])"
   timer_text: "(for|to|named|called) {timer_text:text}"
 
   # Questions

--- a/sentences/en/timer_HassSetTimer.yaml
+++ b/sentences/en/timer_HassSetTimer.yaml
@@ -1,0 +1,25 @@
+language: "en"
+intents:
+  HassSetTimer:
+    data:
+      # hours/minutes/seconds
+      - sentences:
+          - "<start>[ a] timer for <duration_simple>[ <timer_text>]"
+          - "<start>[ a] <duration_simple> timer[ <timer_text>]"
+        response: started
+
+      # half an hour
+      - sentences:
+          - "<start>[ a] timer for (a half hour|half an hour)[ <timer_text>]"
+          - "<start>[ a] half hour timer[ <timer_text>]"
+          - "<start>[ a] timer for {hours} and a half hours[ <timer_text>]"
+        response: started
+        slots:
+          minutes: 30
+
+      # half a minute
+      - sentences:
+          - "<start>[ a] timer for {minutes} and a half minutes[ <timer_text>]"
+        response: started
+        slots:
+          seconds: 30

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -53,6 +53,17 @@ class AreaEntry:
     aliases: Set[str] = field(default_factory=set)
 
 
+class StringWithValue(str):
+    def __new__(cls, text: str, value: Optional[Any] = None) -> "StringWithValue":
+        return super().__new__(cls, text)
+
+    def __init__(self, text: str, value: Optional[Any] = None) -> None:
+        if value is None:
+            self.value = text
+        else:
+            self.value = value
+
+
 def get_matched_states(
     states: List[State], areas: List[AreaEntry], result: RecognizeResult
 ) -> Tuple[List[State], List[State]]:
@@ -173,11 +184,17 @@ def render_response(
     return env.from_string(response_template).render(
         {
             "slots": {
-                entity.name: entity.text_clean or entity.value
+                entity.name: StringWithValue(
+                    entity.text_clean or entity.value, value=entity.value
+                )
                 for entity in result.entities_list
             },
             "state": state1,
-            "query": {"matched": matched, "unmatched": unmatched, "total_results": len(matched) + len(unmatched)},
+            "query": {
+                "matched": matched,
+                "unmatched": unmatched,
+                "total_results": len(matched) + len(unmatched),
+            },
         }
     )
 

--- a/tests/en/timer_HassSetTimer.yaml
+++ b/tests/en/timer_HassSetTimer.yaml
@@ -1,0 +1,63 @@
+language: en
+tests:
+  - sentences:
+      - "set a timer for two hours"
+      - "set a two hour timer"
+    intent:
+      name: HassSetTimer
+      slots:
+        hours: 2
+    response: "Timer started for 2 hours"
+
+  - sentences:
+      - "set a timer for 45 minutes named pizza"
+    intent:
+      name: HassSetTimer
+      slots:
+        minutes: 45
+        text: pizza
+    response: "Timer started for 45 minutes"
+
+  - sentences:
+      - "start a timer for half an hour"
+    intent:
+      name: HassSetTimer
+      slots:
+        minutes: 30
+    response: "Timer started for 30 minutes"
+
+  - sentences:
+      - "set a timer for two and a half hours"
+    intent:
+      name: HassSetTimer
+      slots:
+        hours: 2
+        minutes: 30
+    response: "Timer started for 2 hours and 30 minutes"
+
+  - sentences:
+      - "set a timer for five minutes"
+      - "make a 5 minute timer"
+    intent:
+      name: HassSetTimer
+      slots:
+        minutes: 5
+    response: "Timer started for 5 minutes"
+
+  - sentences:
+      - "create a timer for five and a half minutes"
+    intent:
+      name: HassSetTimer
+      slots:
+        minutes: 5
+        seconds: 30
+    response: "Timer started for 5 minutes and 30 seconds"
+
+  - sentences:
+      - "create a timer for 10 minutes to check the oven"
+    intent:
+      name: HassSetTimer
+      slots:
+        minutes: 10
+        text: "check the oven"
+    response: "Timer started for 10 minutes"

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -104,6 +104,7 @@ def do_test_language_sentences_file(
                 language_sentences,
                 slot_lists=slot_lists,
                 intent_context=intent_context,
+                language=language,
             )
             assert result is not None, f"Recognition failed for '{sentence}'"
             assert (


### PR DESCRIPTION
This is a draft intended for discussion on the upcoming `HassSetTimer` intent which starts a timer in Home Assistant for a duration (hours, minutes, seconds) with an optional text name.

This PR currently supports sentences like:
- set a timer for 5 minutes
- start a timer for 12 minutes named pizza
- create a half hour timer to check the oven

Some current restrictions:
- The text name of the timer must always be at the end
- Mixed hours/minutes/seconds are not supported ("set a timer for 3 hours and 20 minutes and 2 seconds"), though you can say "set a timer for 3 and a half hours"