### PR TITLE
Simlpify french responses for the cover domain

### DIFF
--- a/responses/fr/HassTurnOff.yaml
+++ b/responses/fr/HassTurnOff.yaml
@@ -5,6 +5,6 @@ responses:
       default: "éteint"
       lights: "Lumières éteintes"
       fans: "Ventilateurs éteints"
-      covers: "Ouvrants fermés"
+      covers: "Fermé"
       cover_device_class: "{{ slots.device_class }} fermé"
       lock: "Ouvert"

--- a/responses/fr/HassTurnOff.yaml
+++ b/responses/fr/HassTurnOff.yaml
@@ -5,6 +5,6 @@ responses:
       default: "éteint"
       lights: "Lumières éteintes"
       fans: "Ventilateurs éteints"
-      covers: "Fermé"
+      covers: "Fermés"
       cover_device_class: "{{ slots.device_class }} fermé"
       lock: "Ouvert"

--- a/responses/fr/HassTurnOn.yaml
+++ b/responses/fr/HassTurnOn.yaml
@@ -5,7 +5,7 @@ responses:
       default: "Allumé"
       lights: "Lumières allumées"
       fans: "Ventilateurs allumés"
-      covers: "Ouvrants ouverts"
+      covers: "Ouvert"
       cover_device_class: "{{ slots.device_class }} ouvert"
       lock: "Fermé"
       scene: "Activée"

--- a/responses/fr/HassTurnOn.yaml
+++ b/responses/fr/HassTurnOn.yaml
@@ -5,7 +5,7 @@ responses:
       default: "Allumé"
       lights: "Lumières allumées"
       fans: "Ventilateurs allumés"
-      covers: "Ouvert"
+      covers: "Ouverts"
       cover_device_class: "{{ slots.device_class }} ouvert"
       lock: "Fermé"
       scene: "Activée"

--- a/tests/fr/cover_HassTurnOff.yaml
+++ b/tests/fr/cover_HassTurnOff.yaml
@@ -30,7 +30,7 @@ tests:
           - curtain
           - shutter
         domain: cover
-    response: Ouvrants fermés
+    response: Fermé
   - sentences:
       - ferme tous les stores
       - baisser tous les stores

--- a/tests/fr/cover_HassTurnOff.yaml
+++ b/tests/fr/cover_HassTurnOff.yaml
@@ -30,7 +30,7 @@ tests:
           - curtain
           - shutter
         domain: cover
-    response: Fermé
+    response: Fermés
   - sentences:
       - ferme tous les stores
       - baisser tous les stores

--- a/tests/fr/cover_HassTurnOn.yaml
+++ b/tests/fr/cover_HassTurnOn.yaml
@@ -30,7 +30,7 @@ tests:
           - curtain
           - shutter
         domain: cover
-    response: Ouvert
+    response: Ouverts
   - sentences:
       - ouvre tous les stores
       - monter tous les stores

--- a/tests/fr/cover_HassTurnOn.yaml
+++ b/tests/fr/cover_HassTurnOn.yaml
@@ -30,7 +30,7 @@ tests:
           - curtain
           - shutter
         domain: cover
-    response: Ouvrants ouverts
+    response: Ouvert
   - sentences:
       - ouvre tous les stores
       - monter tous les stores

--- a/tests/fr/homeassistant_HassTurnOff.yaml
+++ b/tests/fr/homeassistant_HassTurnOff.yaml
@@ -33,7 +33,7 @@ tests:
       name: HassTurnOff
       slots:
         name: rideau gauche
-    response: "Ouvrants fermés"
+    response: "Fermé"
   - sentences:
       - ferme le rideau gauche du salon
       - baisser le rideau gauche du salon
@@ -42,7 +42,7 @@ tests:
       slots:
         name: rideau gauche
         area: salon
-    response: "Ouvrants fermés"
+    response: "Fermé"
   - sentences:
       - ferme la porte du garage
       - baisser la porte du garage
@@ -69,7 +69,7 @@ tests:
           - curtain
           - shutter
         domain: cover
-    response: "Ouvrants fermés"
+    response: "Fermé"
   - sentences:
       - baisse tous les stores
       - fermer tous les volets

--- a/tests/fr/homeassistant_HassTurnOff.yaml
+++ b/tests/fr/homeassistant_HassTurnOff.yaml
@@ -33,7 +33,7 @@ tests:
       name: HassTurnOff
       slots:
         name: rideau gauche
-    response: "Fermé"
+    response: "Fermés"
   - sentences:
       - ferme le rideau gauche du salon
       - baisser le rideau gauche du salon
@@ -42,7 +42,7 @@ tests:
       slots:
         name: rideau gauche
         area: salon
-    response: "Fermé"
+    response: "Fermés"
   - sentences:
       - ferme la porte du garage
       - baisser la porte du garage
@@ -69,7 +69,7 @@ tests:
           - curtain
           - shutter
         domain: cover
-    response: "Fermé"
+    response: "Fermés"
   - sentences:
       - baisse tous les stores
       - fermer tous les volets

--- a/tests/fr/homeassistant_HassTurnOn.yaml
+++ b/tests/fr/homeassistant_HassTurnOn.yaml
@@ -32,7 +32,7 @@ tests:
       name: HassTurnOn
       slots:
         name: rideau gauche
-    response: "Ouvert"
+    response: "Ouverts"
   - sentences:
       - ouvre le rideau gauche du salon
       - monter le rideau gauche du salon
@@ -41,7 +41,7 @@ tests:
       slots:
         name: rideau gauche
         area: salon
-    response: "Ouvert"
+    response: "Ouverts"
   - sentences:
       - ouvre la porte du garage
       - monter la porte du garage
@@ -71,7 +71,7 @@ tests:
           - curtain
           - shutter
         domain: cover
-    response: "Ouvert"
+    response: "Ouverts"
   - sentences:
       - ouvre tous les stores
       - monter tous les volets

--- a/tests/fr/homeassistant_HassTurnOn.yaml
+++ b/tests/fr/homeassistant_HassTurnOn.yaml
@@ -32,7 +32,7 @@ tests:
       name: HassTurnOn
       slots:
         name: rideau gauche
-    response: "Ouvrants ouverts"
+    response: "Ouvert"
   - sentences:
       - ouvre le rideau gauche du salon
       - monter le rideau gauche du salon
@@ -41,7 +41,7 @@ tests:
       slots:
         name: rideau gauche
         area: salon
-    response: "Ouvrants ouverts"
+    response: "Ouvert"
   - sentences:
       - ouvre la porte du garage
       - monter la porte du garage
@@ -71,7 +71,7 @@ tests:
           - curtain
           - shutter
         domain: cover
-    response: "Ouvrants ouverts"
+    response: "Ouvert"
   - sentences:
       - ouvre tous les stores
       - monter tous les volets


### PR DESCRIPTION
I made a mistake when I tried to simplify the French responses on https://github.com/home-assistant/intents/pull/1374

For the cover domain, I kept the generic word for cover `Ouvrants`.
But the opening and closing sentences became very unnatural
- `Ouvrants ouverts`
- `Ouvrant fermés`

I checked how English dealt with this issue, as cover is also a very unusual name in the English dictionary, and they just ommit the word altogether.

So I decided to align French with English for that response too
- `Ferme less volets > Fermé`
- `Ouvre les rideaux > Ouvert`
