### PR TITLE
[en] Don't produce <N>percent

### DIFF
--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -293,7 +293,7 @@ expansion_rules:
   name: "[the] {name}"
   area: "[the] {area}"
   what_is: "(what's|whats|what is)"
-  brightness: "{brightness}[ ][%|percent]"
+  brightness: "{brightness}[[ ]%| percent]"
   light: "[the] (light|lights|lighting)"
   turn: "(turn|switch|change)"
   temp: "(temp|temperature)"


### PR DESCRIPTION
Fix template to avoid incorrect sentences like "change X brightness to Npercent" without a space between `N` and percent.