### PR TITLE
[en] Add sentences for turning lights on/off in the area of a satellite device

### DIFF
--- a/script/test
+++ b/script/test
@@ -16,4 +16,4 @@ if [ -d "${venv}" ]; then
 fi
 
 python3 -m script.intentfest validate
-pytest -vv
+pytest -vv "$@"

--- a/sentences/en/light_HassTurnOff.yaml
+++ b/sentences/en/light_HassTurnOff.yaml
@@ -28,3 +28,13 @@ intents:
         slots:
           domain: "light"
           name: "all"
+
+      # Turn off all lights in the same area as a satellite device
+      - sentences:
+          - "<turn> off all[ the| my] lights"
+          - "<turn> all[ the| my] lights off"
+        response: "lights_area"
+        slots:
+          domain: "light"
+        requires_context:
+          area: null

--- a/sentences/en/light_HassTurnOn.yaml
+++ b/sentences/en/light_HassTurnOn.yaml
@@ -20,3 +20,13 @@ intents:
         slots:
           domain: "light"
         response: "lights_area"
+
+      # Turn on all lights in the same area as a satellite device
+      - sentences:
+          - "<turn> on all[ the| my] lights"
+          - "<turn> all[ the| my] lights on"
+        response: "lights_area"
+        slots:
+          domain: "light"
+        requires_context:
+          area: null

--- a/tests/en/light_HassTurnOff.yaml
+++ b/tests/en/light_HassTurnOff.yaml
@@ -39,3 +39,14 @@ tests:
       slots:
         domain: light
         name: all
+
+  - sentences:
+      - "turn off all the lights"
+      - "turn all my lights off"
+    intent:
+      name: HassTurnOff
+      context:
+        area: Living Room
+      slots:
+        domain: light
+    response: "Turned off lights"

--- a/tests/en/light_HassTurnOn.yaml
+++ b/tests/en/light_HassTurnOn.yaml
@@ -30,3 +30,14 @@ tests:
         area: Living Room
         domain: light
     response: "Turned on lights"
+
+  - sentences:
+      - "turn on all the lights"
+      - "turn all my lights on"
+    intent:
+      name: HassTurnOn
+      context:
+        area: Living Room
+      slots:
+        domain: light
+    response: "Turned on lights"


### PR DESCRIPTION
Adds English sentences that will turn lights on/off in the area of a satellite device. This uses:

```yaml
requires_context:
    area: null
```

to force Home Assistant to supply an area before the sentences will match. A future PR for HA Core will include the area from a satellite device as `intent_context` during recognition.