### PR TITLE
[en] Bump hassil to 1.5.1, remove "all" from light

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hassil==1.5.0
+hassil==1.5.1
 PyYAML==6.0.1
 voluptuous==0.13.1
 regex==2023.10.3

--- a/script/intentfest/parse.py
+++ b/script/intentfest/parse.py
@@ -40,6 +40,14 @@ def get_arguments() -> argparse.Namespace:
         type=str,
         help="Sentence(s) to parse",
     )
+    parser.add_argument(
+        "--context",
+        action="append",
+        nargs=2,
+        default=[],
+        metavar=("key", "value"),
+        help="Add key/value pair to context",
+    )
     return parser.parse_args()
 
 
@@ -68,9 +76,13 @@ def run() -> int:
         load_merged_responses(args.language).get("responses", {}).get("intents", {})
     )
 
+    intent_context = dict(args.context)
+
     # Parse sentences
     for sentence in args.sentence:
-        result = recognize(sentence, intents, slot_lists=slot_lists)
+        result = recognize(
+            sentence, intents, slot_lists=slot_lists, intent_context=intent_context
+        )
         output_dict = {"text": sentence, "match": result is not None}
         if result is not None:
             output_dict["intent"] = result.intent.name

--- a/sentences/en/light_HassTurnOff.yaml
+++ b/sentences/en/light_HassTurnOff.yaml
@@ -29,14 +29,15 @@ intents:
           domain: "light"
           name: "all"
 
-      # Turn off all lights in the same area as a satellite device
+      # Turn off lights in the same area as a satellite device
       - sentences:
-          - "<turn> off all[ the] lights<in_here>"
-          - "<turn> all[ the] lights( off;<in_here>)"
+          - "<turn> off[ the] lights<in_here>"
+          - "<turn>[ the] lights( off;<in_here>)"
         response: "lights_area"
         expansion_rules:
           in_here: "[[ in] here]"
         slots:
           domain: "light"
         requires_context:
-          area: null
+          area:
+            slot: true

--- a/sentences/en/light_HassTurnOn.yaml
+++ b/sentences/en/light_HassTurnOn.yaml
@@ -23,12 +23,13 @@ intents:
 
       # Turn on all lights in the same area as a satellite device
       - sentences:
-          - "<turn> on all[ the] lights<in_here>"
-          - "<turn> all[ the] lights( on;<in_here>)"
+          - "<turn> on[ the] lights<in_here>"
+          - "<turn>[ the] lights( on;<in_here>)"
         response: "lights_area"
         expansion_rules:
           in_here: "[[ in] here]"
         slots:
           domain: "light"
         requires_context:
-          area: null
+          area:
+            slot: true

--- a/tests/en/light_HassTurnOff.yaml
+++ b/tests/en/light_HassTurnOff.yaml
@@ -41,14 +41,15 @@ tests:
         name: all
 
   - sentences:
-      - "turn off all the lights"
-      - "turn off all the lights in here"
-      - "turn all the lights in here off"
-      - "turn all the lights off here"
+      - "turn off the lights"
+      - "turn off the lights in here"
+      - "turn the lights in here off"
+      - "turn the lights off here"
     intent:
       name: HassTurnOff
       context:
         area: Living Room
       slots:
         domain: light
+        area: Living Room
     response: "Turned off lights"

--- a/tests/en/light_HassTurnOn.yaml
+++ b/tests/en/light_HassTurnOn.yaml
@@ -32,14 +32,15 @@ tests:
     response: "Turned on lights"
 
   - sentences:
-      - "turn on all the lights"
-      - "turn on all the lights in here"
-      - "turn all the lights in here on"
-      - "turn all the lights on here"
+      - "turn on the lights"
+      - "turn on the lights in here"
+      - "turn the lights in here on"
+      - "turn the lights on here"
     intent:
       name: HassTurnOn
       context:
         area: Living Room
       slots:
         domain: light
+        area: Living Room
     response: "Turned on lights"


### PR DESCRIPTION
Removing "all" from "turn on/off all lights", as this will be used to turn off all lights in the house in the future.
Additionally, this bumps to hassil 1.5.1 to allow copying `area` from context to a slot with:

```yaml
requires_context:
  area:
    slot: true
```

This allows fine-grained control by the templates as to whether a context value should be copied to a slot and sent along to the intent.