### PR TITLE
[NL] Add person_HassGetState

### DIFF
--- a/responses/nl/HassGetState.yaml
+++ b/responses/nl/HassGetState.yaml
@@ -70,3 +70,12 @@ responses:
 
       how_many: |
         {{ query.matched | length }}
+
+      where: |
+        {% if state == "not_home" %}
+          {{ slots.name | capitalize }} is weg
+        {% elif state == "home" %}
+          {{ slots.name | capitalize }} is thuis
+        {% else %}
+          {{ slots.name | capitalize }} is bij {{ state.state }}
+        {% endif %}

--- a/responses/nl/HassGetState.yaml
+++ b/responses/nl/HassGetState.yaml
@@ -10,8 +10,17 @@ responses:
       one_yesno: |
         {% if query.matched %}
           Ja
+        {% elif state.state == 'no_home' %}
+          Nee, die is niet thuis
         {% else %}
           Nee, die is {{ state.state_with_unit }}
+        {% endif %}
+
+      one_zone: |
+        {% if query.matched %}
+          Ja
+        {% else %}
+          Nee, die is in de zone {{ state.state_with_unit }}
         {% endif %}
 
       bs_yesno: |
@@ -72,10 +81,10 @@ responses:
         {{ query.matched | length }}
 
       where: |
-        {% if state == "not_home" %}
-          {{ slots.name | capitalize }} is weg
-        {% elif state == "home" %}
+        {% if state.state == "not_home" %}
+          {{ slots.name | capitalize }} is niet thuis
+        {% elif state.state == "home" %}
           {{ slots.name | capitalize }} is thuis
         {% else %}
-          {{ slots.name | capitalize }} is bij {{ state.state }}
+          {{ slots.name | capitalize }} is in zone {{ state.state }}
         {% endif %}

--- a/responses/nl/HassGetState.yaml
+++ b/responses/nl/HassGetState.yaml
@@ -13,7 +13,7 @@ responses:
         {% elif state.state == 'not_home' %}
           Nee, die is niet thuis
         {% else %}
-          Nee, die is {{ state.state_with_unit }}
+          Nee, die is in zone {{ state.state }}
         {% endif %}
 
       one_zone: |

--- a/responses/nl/HassGetState.yaml
+++ b/responses/nl/HassGetState.yaml
@@ -10,15 +10,15 @@ responses:
       one_yesno: |
         {% if query.matched %}
           Ja
-        {% elif state.state == 'not_home' %}
-          Nee, die is niet thuis
         {% else %}
-          Nee, die is in zone {{ state.state }}
+          Nee, die is {{ state.state_with_unit }}
         {% endif %}
 
       one_zone: |
         {% if query.matched %}
           Ja
+        {% elif state.state == 'not_home' %}
+          Nee, die is niet thuis
         {% else %}
           Nee, die is in de zone {{ state.state_with_unit }}
         {% endif %}

--- a/responses/nl/HassGetState.yaml
+++ b/responses/nl/HassGetState.yaml
@@ -10,7 +10,7 @@ responses:
       one_yesno: |
         {% if query.matched %}
           Ja
-        {% elif state.state == 'no_home' %}
+        {% elif state.state == 'not_home' %}
           Nee, die is niet thuis
         {% else %}
           Nee, die is {{ state.state_with_unit }}

--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -310,6 +310,9 @@ lists:
   shopping_list_item:
     wildcard: true
 
+  zone:
+    wildcard: true
+
 expansion_rules:
   # generic expansion rules for sentences
   name: "[de|het] {name}"

--- a/sentences/nl/person_HassGetState.yaml
+++ b/sentences/nl/person_HassGetState.yaml
@@ -1,0 +1,61 @@
+language: nl
+intents:
+  HassGetState:
+    data:
+      # https://www.home-assistant.io/integrations/person/
+      - sentences:
+          - "waar [is|zijn] <name>"
+          - "waar bevind[t|en] <name> zich"
+        response: where
+        requires_context:
+          domain: person
+        slots:
+          domain: person
+
+      - sentences:
+          - "[is|zijn] <name> [<in>] [de|het] {zone:state}"
+        response: one_yesno
+        requires_context:
+          domain: person
+        slots:
+          domain: person
+      - sentences:
+          - "[is|zijn] <name> thuis"
+        response: one_yesno
+        requires_context:
+          domain: person
+        slots:
+          domain: person
+          state: home
+
+      - sentences:
+          - "[is|zijn] <name> [<in>] [de|het] {zone:state}"
+        response: one_yesno
+        requires_context:
+          domain: person
+        slots:
+          domain: person
+
+      - sentences:
+          - "is [er] iemand [<in>] [de|het] {zone:state}"
+        response: any
+        slots:
+          domain: person
+
+      - sentences:
+          - "is iedereen [<in>] [de|het] {zone:state}"
+        response: all
+        slots:
+          domain: person
+
+      - sentences:
+          - "wie (is|zijn) [er] [allemaal] [<in>] [de|het] {zone:state}"
+        response: which
+        slots:
+          domain: person
+
+      - sentences:
+          - "hoe[ ]veel mensen zijn [er] [<in>] [de|het] {zone:state}"
+        response: how_many
+        slots:
+          domain: person

--- a/sentences/nl/person_HassGetState.yaml
+++ b/sentences/nl/person_HassGetState.yaml
@@ -25,10 +25,9 @@ intents:
         response: one_zone
         requires_context:
           domain: person
-        excludes_context:
-          state: home
         slots:
           domain: person
+          state: not_home
       - sentences:
           - "[is|zijn] <name> [<in>] [de|het] [zone] {zone:state}"
         response: one_zone

--- a/sentences/nl/person_HassGetState.yaml
+++ b/sentences/nl/person_HassGetState.yaml
@@ -13,29 +13,44 @@ intents:
           domain: person
 
       - sentences:
-          - "[is|zijn] <name> [<in>] [de|het] {zone:state}"
-        response: one_yesno
-        requires_context:
-          domain: person
-        slots:
-          domain: person
-      - sentences:
           - "[is|zijn] <name> thuis"
-        response: one_yesno
+        response: one_zone
         requires_context:
           domain: person
         slots:
           domain: person
           state: home
-
       - sentences:
-          - "[is|zijn] <name> [<in>] [de|het] {zone:state}"
-        response: one_yesno
+          - "[is|zijn] <name> (niet thuis|weg)"
+        response: one_zone
         requires_context:
           domain: person
+        excludes_context:
+          state: home
+        slots:
+          domain: person
+      - sentences:
+          - "[is|zijn] <name> [<in>] [de|het] [zone] {zone:state}"
+        response: one_zone
+        requires_context:
+          domain: person
+        excludes_context:
+          state: home
         slots:
           domain: person
 
+      - sentences:
+          - "is [er] iemand thuis"
+        response: any
+        slots:
+          domain: person
+          state: home
+      - sentences:
+          - "is [er] iemand (niet thuis|weg)"
+        response: any
+        slots:
+          domain: person
+          state: not_home
       - sentences:
           - "is [er] iemand [<in>] [de|het] {zone:state}"
         response: any
@@ -43,17 +58,53 @@ intents:
           domain: person
 
       - sentences:
+          - "is iedereen thuis"
+        response: all
+        slots:
+          domain: person
+          state: home
+      - sentences:
+          - "is iedereen (niet thuis|weg)"
+        response: all
+        slots:
+          domain: person
+          state: not_home
+      - sentences:
           - "is iedereen [<in>] [de|het] {zone:state}"
         response: all
         slots:
           domain: person
 
       - sentences:
+          - "wie (is|zijn) [er] [allemaal] thuis"
+        response: which
+        slots:
+          domain: person
+          state: home
+      - sentences:
+          - "wie (is|zijn) [er] [allemaal] (niet thuis|weg)"
+        response: which
+        slots:
+          domain: person
+          state: not_home
+      - sentences:
           - "wie (is|zijn) [er] [allemaal] [<in>] [de|het] {zone:state}"
         response: which
         slots:
           domain: person
 
+      - sentences:
+          - "hoe[ ]veel mensen zijn [er] thuis"
+        response: how_many
+        slots:
+          domain: person
+          state: home
+      - sentences:
+          - "hoe[ ]veel mensen zijn [er] (niet thuis|weg)"
+        response: how_many
+        slots:
+          domain: person
+          state: not_home
       - sentences:
           - "hoe[ ]veel mensen zijn [er] [<in>] [de|het] {zone:state}"
         response: how_many

--- a/tests/nl/_fixtures.yaml
+++ b/tests/nl/_fixtures.yaml
@@ -727,3 +727,13 @@ entities:
     attributes:
       device_class: wind_speed
       unit_of_measurement: "km/h"
+
+  - name: "Joost"
+    id: "person.jospeh"
+    state: "home"
+  - name: "Ada"
+    id: "person.ada"
+    state: "Werk"
+  - name: "Piet"
+    id: "person.piet"
+    state: "not_home"

--- a/tests/nl/_fixtures.yaml
+++ b/tests/nl/_fixtures.yaml
@@ -733,7 +733,7 @@ entities:
     state: "home"
   - name: "Ada"
     id: "person.ada"
-    state: "Werk"
+    state: "werk"
   - name: "Piet"
     id: "person.piet"
     state: "not_home"

--- a/tests/nl/person_HassGetState.yaml
+++ b/tests/nl/person_HassGetState.yaml
@@ -8,16 +8,25 @@ tests:
       slots:
         domain: person
         name: Joost
-    response: "Joost is bij thuis"
-
+    response: "Joost is thuis"
   - sentences:
       - "waar is Ada"
+      - "waar bevindt Ada zich"
     intent:
       name: HassGetState
       slots:
         domain: person
         name: Ada
-    response: "Ada is bij Werk"
+    response: "Ada is in zone werk"
+  - sentences:
+      - "waar is Piet"
+      - "waar bevindt Piet zich"
+    intent:
+      name: HassGetState
+      slots:
+        domain: person
+        name: Piet
+    response: "Piet is niet thuis"
 
   - sentences:
       - "is Ada thuis"
@@ -26,8 +35,26 @@ tests:
       slots:
         domain: person
         name: Ada
-        state: thuis
-    response: "Nee, die is Werk"
+        state: home
+    response: "Nee, die is in de zone werk"
+  - sentences:
+      - "is Ada weg"
+    intent:
+      name: HassGetState
+      slots:
+        domain: person
+        name: Ada
+        state: not_home
+    response: "Nee, die is in de zone werk"
+  - sentences:
+      - "is Ada in de zone werk"
+    intent:
+      name: HassGetState
+      slots:
+        domain: person
+        name: Ada
+        state: werk
+    response: "Ja"
 
   - sentences:
       - "is er iemand thuis"
@@ -35,8 +62,24 @@ tests:
       name: HassGetState
       slots:
         domain: person
-        state: thuis
-    response: "Nee"
+        state: home
+    response: "Ja, Joost"
+  - sentences:
+      - "is er iemand niet thuis"
+    intent:
+      name: HassGetState
+      slots:
+        domain: person
+        state: not_home
+    response: "Ja, Piet"
+  - sentences:
+      - "is er iemand op het werk"
+    intent:
+      name: HassGetState
+      slots:
+        domain: person
+        state: werk
+    response: "Ja, Ada"
 
   - sentences:
       - "is iedereen thuis"
@@ -44,8 +87,24 @@ tests:
       name: HassGetState
       slots:
         domain: person
-        state: thuis
-    response: "Nee, Ada and Piet zijn niet thuis"
+        state: home
+    response: "Nee, Ada en Piet niet"
+  - sentences:
+      - "is iedereen weg"
+    intent:
+      name: HassGetState
+      slots:
+        domain: person
+        state: not_home
+    response: "Nee, Ada en Joost niet"
+  - sentences:
+      - "is iedereen op het werk"
+    intent:
+      name: HassGetState
+      slots:
+        domain: person
+        state: werk
+    response: "Nee, Joost en Piet niet"
 
   - sentences:
       - "wie is er thuis"
@@ -53,8 +112,25 @@ tests:
       name: HassGetState
       slots:
         domain: person
-        state: thuis
+        state: home
     response: "Joost"
+  - sentences:
+      - "wie is er niet thuis"
+      - "wie is er weg"
+    intent:
+      name: HassGetState
+      slots:
+        domain: person
+        state: not_home
+    response: "Piet"
+  - sentences:
+      - "wie is er op het werk"
+    intent:
+      name: HassGetState
+      slots:
+        domain: person
+        state: werk
+    response: "Ada"
 
   - sentences:
       - "hoeveel mensen zijn er thuis"
@@ -62,5 +138,21 @@ tests:
       name: HassGetState
       slots:
         domain: person
-        state: thuis
+        state: home
+    response: "1"
+  - sentences:
+      - "hoeveel mensen zijn er weg"
+    intent:
+      name: HassGetState
+      slots:
+        domain: person
+        state: not_home
+    response: "1"
+  - sentences:
+      - "hoeveel mensen zijn er op het werk"
+    intent:
+      name: HassGetState
+      slots:
+        domain: person
+        state: werk
     response: "1"

--- a/tests/nl/person_HassGetState.yaml
+++ b/tests/nl/person_HassGetState.yaml
@@ -1,0 +1,66 @@
+language: nl
+tests:
+  - sentences:
+      - "waar is Joost"
+      - "waar bevindt Joost zich"
+    intent:
+      name: HassGetState
+      slots:
+        domain: person
+        name: Joost
+    response: "Joost is bij thuis"
+
+  - sentences:
+      - "waar is Ada"
+    intent:
+      name: HassGetState
+      slots:
+        domain: person
+        name: Ada
+    response: "Ada is bij Werk"
+
+  - sentences:
+      - "is Ada thuis"
+    intent:
+      name: HassGetState
+      slots:
+        domain: person
+        name: Ada
+        state: thuis
+    response: "Nee, die is Werk"
+
+  - sentences:
+      - "is er iemand thuis"
+    intent:
+      name: HassGetState
+      slots:
+        domain: person
+        state: thuis
+    response: "Nee"
+
+  - sentences:
+      - "is iedereen thuis"
+    intent:
+      name: HassGetState
+      slots:
+        domain: person
+        state: thuis
+    response: "Nee, Ada and Piet zijn niet thuis"
+
+  - sentences:
+      - "wie is er thuis"
+    intent:
+      name: HassGetState
+      slots:
+        domain: person
+        state: thuis
+    response: "Joost"
+
+  - sentences:
+      - "hoeveel mensen zijn er thuis"
+    intent:
+      name: HassGetState
+      slots:
+        domain: person
+        state: thuis
+    response: "1"


### PR DESCRIPTION
I added specific sentences for the `not_home` test, for which I specifically check on that state.
I tried just excluding everybody at home, so persons in another zone like `werk` would also be returned, by using `excludes_context`  but this also returned the persons at home

intent
```yaml
      - sentences:
          - "[is|zijn] <name> (niet thuis|weg)"
        response: one_zone
        requires_context:
          domain: person
        excludes_context:
          state: home
        slots:
          domain: person
```

test (Joost has the state `home`)
```
@TheFes ➜ /workspaces/intents (nl_person_hasshetstate) $ python3 -m script.intentfest parse --language nl --sentence 'is Joost weg'
{
  "text": "is Joost weg",
  "match": true,
  "intent": "HassGetState",
  "slots": {
    "name": "Joost",
    "domain": "person"
  },
  "context": {
    "domain": "person"
  },
  "response_key": "one_zone",
  "response": "Ja"
}
```
