### PR TITLE
[EL] Fix default response to HassTurnOn/HassTurnOff

### DIFF
--- a/responses/el/HassTurnOff.yaml
+++ b/responses/el/HassTurnOff.yaml
@@ -2,7 +2,7 @@ language: el
 responses:
   intents:
     HassTurnOff:
-      default: "Έκλεισαν τα φώτα στο {{ slots.name }}"
+      default: "Έκλεισε"
       lights_area: "Έκλεισαν τα φώτα"
       fans_area: "Έκλεισαν οι ανεμιστήρες"
       cover: "{{ slots.name }} έκλεισε"

--- a/responses/el/HassTurnOn.yaml
+++ b/responses/el/HassTurnOn.yaml
@@ -2,7 +2,7 @@ language: el
 responses:
   intents:
     HassTurnOn:
-      default: "Άνοιξαν τα φώτα στο {{ slots.name }}"
+      default: "Άνοιξε"
       lights_area: "Άνοιξαν τα φώτα"
       fans_area: "Άνοιξαν οι ανεμιστήρες"
       cover: "{{ slots.name }} άνοιξε"


### PR DESCRIPTION
The current default response is "Άνοιξαν τα φώτα στο {{ slots.name }}" ("Lights were turned on in {{ slots.name }}") resulting in nonsensical responses like "Άνοιξα τα φώτα στο καφετιέρα" ("Lights were turned on in coffee machine").

Change this to "Άνοιξε", to mimic what most other languages do.