### PR TITLE
[cs] Fix light intents clashing with generic HassTurnOn/Off

### DIFF
--- a/sentences/cs/light_HassTurnOff.yaml
+++ b/sentences/cs/light_HassTurnOff.yaml
@@ -3,10 +3,10 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "<zhasnout> [světlo] {name}"
-          - "<vypnout> světlo {name}"
-          - "{name} <zhasnout> [světlo]"
-          - "světlo {name} <vypnout>"
+          - "(<vypnout>|<zhasnout>) [světlo] {name}"
+          - "{name} (<vypnout>|<zhasnout>) [světlo]"
+        requires_context:
+          domain: light
         slots:
           domain: light
         response: light

--- a/sentences/cs/light_HassTurnOn.yaml
+++ b/sentences/cs/light_HassTurnOn.yaml
@@ -3,10 +3,10 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "<rozsvitit> [světlo] {name}"
-          - "<zapnout> světlo {name}"
-          - "{name} <rozsvitit> [světlo]"
-          - "světlo {name} <zapnout>"
+          - "(<zapnout>|<rozsvitit>) [světlo] {name}"
+          - "{name} (<zapnout>|<rozsvitit>) [světlo]"
+        requires_context:
+          domain: light
         slots:
           domain: light
         response: light

--- a/tests/cs/light_HassTurnOn.yaml
+++ b/tests/cs/light_HassTurnOn.yaml
@@ -2,7 +2,9 @@ language: cs
 tests:
   - sentences:
       - "rozsviť světlo lampička v obývacím pokoji"
+      - "rozsviť lampičku v obývacím pokoji"
       - "zapni světlo lampička v obývacím pokoji"
+      - "zapni lampičku v obývacím pokoji"
     intent:
       name: HassTurnOn
       slots:
@@ -14,10 +16,10 @@ tests:
     response: "Rozsvíceno"
 
   - sentences:
+      - "zapni předsíň"
       - "předsíň rozsviť"
       - "rozsviť předsíň"
       - "zapni světlo předsíň"
-      - "světlo předsíň zapni"
     intent:
       name: HassTurnOn
       slots:


### PR DESCRIPTION
This properly fixes #1471, which was caused by the missing `requires_context` definition for the whole time. Also removing the awkward Yoda-sounding variant introduced in #1525.