### PR TITLE
[SL] ClimateHassGetTemperature attribute fix, added sentences and tests

### DIFF
--- a/responses/sl/HassClimateGetTemperature.yaml
+++ b/responses/sl/HassClimateGetTemperature.yaml
@@ -2,4 +2,22 @@ language: sl
 responses:
   intents:
     HassClimateGetTemperature:
-      default: "{{ state_attr(state.entity_id, 'current_temperature') }}"
+      default: |
+        {% set temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature_abs = temperature | float | abs %}
+
+        {% if temperature_abs == 1 %}
+            {{ temperature }} stopinja
+        {% elif temperature == 0 or temperature | float % 1 != 0 or temperature | float % 100 | abs < 20 %}
+            {{ temperature }} stopinje
+        {% else %}
+            {{ temperature }} stopinj
+            {% if temperature | float % 1 != 0 %}
+                {% set decimal_part = temperature | string | regex_replace('\d+\.', '') %}
+                {% if decimal_part != '1' %}
+                    cela {{ decimal_part }} stopinje
+                {% else %}
+                    cela {{ decimal_part }} stopinja
+                {% endif %}
+            {% endif %}
+        {% endif %}

--- a/sentences/sl/climate_HassClimateGetTemperature.yaml
+++ b/sentences/sl/climate_HassClimateGetTemperature.yaml
@@ -9,3 +9,5 @@ intents:
           - "koliko stopinj je [[v|na] <area>]"
           - "povej mi <temp> [[v|na] <area>]"
           - "kakšna je [<area>] temperatura"
+          - "kakšna je [<area>] <temp>"
+          - "na koliko [stopinj] je [nastavljena] <temp> [[v|na] <area>]"

--- a/tests/sl/_fixtures.yaml
+++ b/tests/sl/_fixtures.yaml
@@ -191,14 +191,14 @@ entities:
     state: "17"
     area: "balcony"
     attributes:
-      unit_of_measurement: "°C"
+      current_temperature: 17
 
   - name: "temperatura dnevna soba"
     id: "sensor.living_room"
     state: "21"
     area: "living_room"
     attributes:
-      unit_of_measurement: "°C"
+      unit_of_measurement: "stopinj"
   #locks
   - name: "vhodna vrata"
     id: "lock.front_door"

--- a/tests/sl/climate_HassClimateGetTemperature.yaml
+++ b/tests/sl/climate_HassClimateGetTemperature.yaml
@@ -5,17 +5,18 @@ tests:
       - povej mi temperaturo?
     intent:
       name: HassClimateGetTemperature
-    response: "21"
+    response: "21 stopinj"
 
   - sentences:
       - kakšna je temperatura v dnevni sobi?
       - ali je vroče v dnevni sobi?
+      - na koliko stopinj je nastavljena temperatura v dnevni sobi?
     intent:
       name: HassClimateGetTemperature
       slots:
         area:
           - dnevni sobi
-    response: "21"
+    response: "21 stopinj"
 
   - sentences:
       - kakšna je temperatura na balkonu?
@@ -29,7 +30,8 @@ tests:
       - kakšna je zunanja temperatura?
       - kakšna je temperatura zunaj?
       - povej mi temperaturo zunaj?
+      - koliko stopinj je zunaj?
     intent:
       name: HassClimateGetTemperature
 
-    response: "21"
+    response: "21 stopinj"


### PR DESCRIPTION
Rewritten resonses.yaml Slovenian grammar accordingly for singular, dual and plural. Where decimals are the output is grammar compliant (3.7 degress - > 3.7 stopinj**e**). 
Added test and sentence.