### PR TITLE
[en] Fix weather sentences without a name

### DIFF
--- a/sentences/en/weather_HassGetWeather.yaml
+++ b/sentences/en/weather_HassGetWeather.yaml
@@ -3,8 +3,10 @@ intents:
   HassGetWeather:
     data:
       - sentences:
-          - "<what_is>[ the] weather[ like][( for| in| at) <name>]"
-          - "<what_is>[ the] weather[( for| in| at) <name>] like"
+          - "<what_is>[ the] weather[ like]"
+      - sentences:
+          - "<what_is>[ the] weather[ like] (for|in|at) <name>"
+          - "<what_is>[ the] weather (for|in|at) <name>[ like]"
           - "<what_is>[ the] <name> weather[ like]"
         requires_context:
           domain: weather

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -61,6 +61,9 @@ def get_matched_states(
     if result.intent.name in ("HassClimateGetTemperature", "HassClimateSetTemperature"):
         # Match climate entities only
         states = [state for state in states if state.domain == "climate"]
+    elif result.intent.name in ("HassGetWeather",):
+        # Match weather entities only
+        states = [state for state in states if state.domain == "weather"]
 
     # Implement some matching logic from Home Assistant
     entity_name: Optional[str] = None

--- a/tests/en/weather_HassGetWeather.yaml
+++ b/tests/en/weather_HassGetWeather.yaml
@@ -1,6 +1,13 @@
 language: en
 tests:
   - sentences:
+      - "what's the weather?"
+      - "what is the weather like"
+    intent:
+      name: HassGetWeather
+    response: 47 °F and raining
+
+  - sentences:
       - "what's the weather like in london?"
       - "what is the weather in London like"
     intent:


### PR DESCRIPTION
Sentences like "what is the weather" were not working because I forgot to split them out. Additionally, the test intent "handling" logic needed to be updated to match weather entities.