### PR TITLE
[RO] Fix temperature values for TTS

### DIFF
--- a/responses/ro/HassClimateGetTemperature.yaml
+++ b/responses/ro/HassClimateGetTemperature.yaml
@@ -4,10 +4,12 @@ responses:
     HassClimateGetTemperature:
       default: |
         {% set temperature = state_attr(state.entity_id, 'current_temperature') %}
-        {% if temperature | float | abs == 1 %}
-        {{ temperature }} grad
-        {% elif temperature == 0 or temperature | float % 1 != 0 or temperature | float % 100 | abs < 20 %}
-        {{ temperature }} grade
+        {% set temperature_ro = (temperature|string).replace(".", ",") %}
+        {% set temperature_num = temperature | float %}
+        {% if temperature_num | abs == 1 %}
+        {{ temperature_ro }} grad
+        {% elif temperature_num == 0 or temperature_num % 1 != 0 or temperature_num % 100 | abs < 20 %}
+        {{ temperature_ro }} grade
         {% else %}
-        {{ temperature }} de grade
+        {{ temperature_ro }} de grade
         {% endif %}

--- a/responses/ro/HassGetWeather.yaml
+++ b/responses/ro/HassGetWeather.yaml
@@ -21,4 +21,13 @@ responses:
           'windy': 'cu intensificări ale vântului',
           'windy-variant': 'înnorat, cu intensificări ale vântului'
         } %}
-        {{ state.attributes.get('temperature') }} {{ state.attributes.get('temperature_unit') }} {{ weather_condition.get((state.state | string).lower(), "") }}
+        {% set temperature = state.attributes.get('temperature') %}
+        {% set temperature_ro = (temperature|string).replace(".", ",") %}
+        {% set temperature_num = temperature | float %}
+        {% if temperature_num | abs == 1 %}
+        {{ temperature_ro }} grad
+        {% elif temperature_num == 0 or temperature_num % 1 != 0 or temperature_num % 100 | abs < 20 %}
+        {{ temperature_ro }} grade
+        {% else %}
+        {{ temperature_ro }} de grade
+        {% endif %} {{ weather_condition.get((state.state | string).lower(), "") }}

--- a/tests/ro/_fixtures.yaml
+++ b/tests/ro/_fixtures.yaml
@@ -63,7 +63,7 @@ entities:
   - name: "Caloriferul"
     id: climate.radiator
     attributes:
-      current_temperature: 21
+      current_temperature: 21.2
     area: bedroom
     state: "heat"
 
@@ -374,7 +374,7 @@ entities:
     id: "weather.bucuresti"
     state: "rainy"
     attributes:
-      temperature: "18"
+      temperature: "18.5"
       temperature_unit: "°C"
 
   - name: "Brasov"

--- a/tests/ro/climate_HassClimateGetTemperature.yaml
+++ b/tests/ro/climate_HassClimateGetTemperature.yaml
@@ -19,7 +19,7 @@ tests:
       name: HassClimateGetTemperature
       slots:
         area: "Dormitor"
-    response: "21 de grade"
+    response: "21,2 grade"
   - sentences:
       - "ce temperatura e"
       - "care e temperatura"
@@ -30,7 +30,7 @@ tests:
       name: HassClimateGetTemperature
       context:
         area: bedroom
-    response: "21 de grade"
+    response: "21,2 grade"
   - sentences:
       - "ce temperatura e in sufragerie"
       - "care e temperatura din sufragerie"

--- a/tests/ro/weather_HassGetWeather.yaml
+++ b/tests/ro/weather_HassGetWeather.yaml
@@ -6,7 +6,7 @@ tests:
       - "cat de frig este afara?"
     intent:
       name: HassGetWeather
-    response: 18 °C cu ploaie
+    response: 18,5 grade cu ploaie
 
   - sentences:
       - "cum e vremea la Bucuresti?"
@@ -16,7 +16,7 @@ tests:
       name: HassGetWeather
       slots:
         name: Bucuresti
-    response: 18 °C cu ploaie
+    response: 18,5 grade cu ploaie
 
   - sentences:
       - "cum este vremea in Brasov?"
@@ -26,4 +26,4 @@ tests:
       name: HassGetWeather
       slots:
         name: Brasov
-    response: 22 °C cu cer senin
+    response: 22 de grade cu cer senin


### PR DESCRIPTION
In Romanian, floating point numbers are formatted using a comma as a decimal separator

The TTS engines I've tested don't properly pronounce numeric values if a dot is used as a decimal separator. This PR aims to fix pronunciation issues with numerals in Romanian

Before: "-0.4 grade" -> "zero. patru grade"
After: "-0,4 grade" -> "minus zero virgula patru grade"