### PR TITLE
[EN] Add "current" as an optional temps attribute

### DIFF
--- a/sentences/en/climate_HassClimateGetTemperature.yaml
+++ b/sentences/en/climate_HassClimateGetTemperature.yaml
@@ -3,10 +3,10 @@ intents:
   HassClimateGetTemperature:
     data:
       - sentences:
-          - "<what_is> [the] <temp> [in <area>]"
+          - "<what_is> [the][ current] <temp> [in <area>]"
           - "how (hot | cold | warm | cool) is it [in <area>]"
           - "is it (hot | cold | warm | cool) [in <area>]"
-          - "<what_is> <area> <temp>"
-          - "<what_is> <name> <temp>"
-          - "<what_is>[ the] <temp>[ of] <name>"
+          - "<what_is> <area>[ current] <temp>"
+          - "<what_is> <name>[ current] <temp>"
+          - "<what_is>[ the][ current] <temp>[ of] <name>"
           - "how (hot | cold | warm | cool) is <name>"


### PR DESCRIPTION
Support sentences like "what is the name/area current temperature"