### PR TITLE
[DE] added 'et' option to 'schalten' expansion rule + test

### DIFF
--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -171,7 +171,7 @@ expansion_rules:
   alle: "((alle|sämtliche)[r]|jede[r|s|n]|<artikel> (ganze|komplette|sämtliche)[n]) [der]"
   schliessen: "(schlie(ß|ss)[e|en]|zumachen|zu machen)"
   öffnen: "(öffne[n]|aufmachen|auf machen)"
-  schalten: "(schalt[e|en])"
+  schalten: "(schalt[e|en|et])"
   machen: "(mach[e|en])"
   setzen: "(setz[e|en]|stell[e|en]|einstellen|änder[e|n]|veränder[e|n])"
   abdeckung: "<artikel> (Rollo[s]|Abdeckung[en]|Rolll(a|ä)den|Jalousie[n]|Raffstore[s]|Markise[n]|Vorh(a|ä)ng[e])"

--- a/tests/de/fan_HassTurnOff.yaml
+++ b/tests/de/fan_HassTurnOff.yaml
@@ -20,6 +20,24 @@ tests:
       - schalte im Wohnzimmer den Ventilator ab
       - schalte im Wohnzimmer die Ventilatoren ab
       - schalte im Wohnzimmer alle Ventilatoren ab
+      - schaltet den Ventilator im Wohnzimmer aus
+      - schaltet die Ventilatoren im Wohnzimmer aus
+      - schaltet alle Ventilatoren im Wohnzimmer aus
+      - schaltet den Ventilator im Wohnzimmer ab
+      - schaltet die Ventilatoren im Wohnzimmer ab
+      - schaltet alle Ventilatoren im Wohnzimmer ab
+      - schaltet in dem Wohnzimmer den Ventilator aus
+      - schaltet in dem Wohnzimmer die Ventilatoren aus
+      - schaltet in dem Wohnzimmer alle Ventilatoren aus
+      - schaltet in dem Wohnzimmer den Ventilator ab
+      - schaltet in dem Wohnzimmer die Ventilatoren ab
+      - schaltet in dem Wohnzimmer alle Ventilatoren ab
+      - schaltet im Wohnzimmer den Ventilator aus
+      - schaltet im Wohnzimmer die Ventilatoren aus
+      - schaltet im Wohnzimmer alle Ventilatoren aus
+      - schaltet im Wohnzimmer den Ventilator ab
+      - schaltet im Wohnzimmer die Ventilatoren ab
+      - schaltet im Wohnzimmer alle Ventilatoren ab
       - stoppe den Ventilator im Wohnzimmer
       - stoppe die Ventilatoren im Wohnzimmer
       - stoppe alle Ventilatoren im Wohnzimmer
@@ -61,6 +79,24 @@ tests:
       - schalte in dem Wohnzimmer den Lüfter ab
       - schalte in dem Wohnzimmer die Lüfter ab
       - schalte in dem Wohnzimmer alle Lüfter ab
+      - schaltet den Lüfter im Wohnzimmer aus
+      - schaltet die Lüfter im Wohnzimmer aus
+      - schaltet alle Lüfter im Wohnzimmer aus
+      - schaltet den Lüfter im Wohnzimmer ab
+      - schaltet die Lüfter im Wohnzimmer ab
+      - schaltet alle Lüfter im Wohnzimmer ab
+      - schaltet im Wohnzimmer den Lüfter aus
+      - schaltet im Wohnzimmer die Lüfter aus
+      - schaltet im Wohnzimmer alle Lüfter aus
+      - schaltet im Wohnzimmer den Lüfter ab
+      - schaltet im Wohnzimmer die Lüfter ab
+      - schaltet im Wohnzimmer alle Lüfter ab
+      - schaltet in dem Wohnzimmer den Lüfter aus
+      - schaltet in dem Wohnzimmer die Lüfter aus
+      - schaltet in dem Wohnzimmer alle Lüfter aus
+      - schaltet in dem Wohnzimmer den Lüfter ab
+      - schaltet in dem Wohnzimmer die Lüfter ab
+      - schaltet in dem Wohnzimmer alle Lüfter ab
       - stoppe den Lüfter im Wohnzimmer
       - stoppe die Lüfter im Wohnzimmer
       - stoppe alle Lüfter im Wohnzimmer
@@ -92,6 +128,7 @@ tests:
   - sentences:
       # Ventilator
       - schalte alle Ventilatoren aus
+      - schaltet alle Ventilatoren aus
       - stoppe alle Ventilatoren
       - stoppe alle Ventilatoren ab
       - alle Ventilatoren ausschalten
@@ -100,6 +137,7 @@ tests:
 
         # Lüfter
       - schalte alle Lüfter aus
+      - schaltet alle Lüfter aus
       - stoppe alle Lüfter
       - stoppe alle Lüfter ab
       - alle Lüfter ausschalten

--- a/tests/de/fan_HassTurnOn.yaml
+++ b/tests/de/fan_HassTurnOn.yaml
@@ -20,6 +20,24 @@ tests:
       - schalte im Wohnzimmer den Ventilator an
       - schalte im Wohnzimmer die Ventilatoren an
       - schalte im Wohnzimmer alle Ventilatoren an
+      - schaltet den Ventilator im Wohnzimmer ein
+      - schaltet die Ventilatoren im Wohnzimmer ein
+      - schaltet alle Ventilatoren im Wohnzimmer ein
+      - schaltet den Ventilator im Wohnzimmer an
+      - schaltet die Ventilatoren im Wohnzimmer an
+      - schaltet alle Ventilatoren im Wohnzimmer an
+      - schaltet in dem Wohnzimmer den Ventilator ein
+      - schaltet in dem Wohnzimmer die Ventilatoren ein
+      - schaltet in dem Wohnzimmer alle Ventilatoren ein
+      - schaltet in dem Wohnzimmer den Ventilator an
+      - schaltet in dem Wohnzimmer die Ventilatoren an
+      - schaltet in dem Wohnzimmer alle Ventilatoren an
+      - schaltet im Wohnzimmer den Ventilator ein
+      - schaltet im Wohnzimmer die Ventilatoren ein
+      - schaltet im Wohnzimmer alle Ventilatoren ein
+      - schaltet im Wohnzimmer den Ventilator an
+      - schaltet im Wohnzimmer die Ventilatoren an
+      - schaltet im Wohnzimmer alle Ventilatoren an
       - starte den Ventilator im Wohnzimmer
       - starte die Ventilatoren im Wohnzimmer
       - starte alle Ventilatoren im Wohnzimmer
@@ -100,6 +118,25 @@ tests:
       - schalte in dem Wohnzimmer den Lüfter an
       - schalte in dem Wohnzimmer die Lüfter an
       - schalte in dem Wohnzimmer alle Lüfter an
+
+      - schaltet den Lüfter im Wohnzimmer ein
+      - schaltet die Lüfter im Wohnzimmer ein
+      - schaltet alle Lüfter im Wohnzimmer ein
+      - schaltet den Lüfter im Wohnzimmer an
+      - schaltet die Lüfter im Wohnzimmer an
+      - schaltet alle Lüfter im Wohnzimmer an
+      - schaltet im Wohnzimmer den Lüfter ein
+      - schaltet im Wohnzimmer die Lüfter ein
+      - schaltet im Wohnzimmer alle Lüfter ein
+      - schaltet im Wohnzimmer den Lüfter an
+      - schaltet im Wohnzimmer die Lüfter an
+      - schaltet im Wohnzimmer alle Lüfter an
+      - schaltet in dem Wohnzimmer den Lüfter ein
+      - schaltet in dem Wohnzimmer die Lüfter ein
+      - schaltet in dem Wohnzimmer alle Lüfter ein
+      - schaltet in dem Wohnzimmer den Lüfter an
+      - schaltet in dem Wohnzimmer die Lüfter an
+      - schaltet in dem Wohnzimmer alle Lüfter an
       - starte den Lüfter im Wohnzimmer an
       - starte die Lüfter im Wohnzimmer an
       - starte alle Lüfter im Wohnzimmer an
@@ -161,6 +198,7 @@ tests:
   - sentences:
       # Ventilator
       - schalte alle Ventilatoren ein
+      - schaltet alle Ventilatoren ein
       - starte alle Ventilatoren
       - starte alle Ventilatoren an
       - mach alle Ventilatoren ein
@@ -174,6 +212,7 @@ tests:
         # Lüfter
       - schalte alle Lüfter ein
       - schalte alle Lüfter an
+      - schaltet alle Lüfter an
       - starte alle Lüfter
       - starte alle Lüfter an
       - mach alle Lüfter ein

--- a/tests/de/homeassistant_HassTurnOff.yaml
+++ b/tests/de/homeassistant_HassTurnOff.yaml
@@ -2,8 +2,10 @@ language: de
 tests:
   - sentences:
       - schalte die Schlafzimmerlampe aus
+      - schaltet die Schlafzimmerlampe aus
       - mach die Schlafzimmerlampe aus
       - schalte bitte die Schlafzimmerlampe aus
+      - schaltet bitte die Schlafzimmerlampe aus
       - bitte schalte die Schlafzimmerlampe aus
       - bitte die Schlafzimmerlampe ausschalten
       - Schlafzimmerlampe ausschalten

--- a/tests/de/homeassistant_HassTurnOn.yaml
+++ b/tests/de/homeassistant_HassTurnOn.yaml
@@ -2,6 +2,7 @@ language: de
 tests:
   - sentences:
       - schalte den Deckenventilator ein
+      - schaltet den Deckenventilator ein
       - schalte den Deckenventilator an
       - mache den Deckenventilator an
       - starte den Deckenventilator

--- a/tests/de/light_HassTurnOff.yaml
+++ b/tests/de/light_HassTurnOff.yaml
@@ -5,6 +5,10 @@ tests:
       - Schalte die Lichter in der Küche aus
       - Schalte alle Lichter in der Küche aus
       - Schalte in der Küche alle Lichter aus
+      - Schaltet das Licht in der Küche aus
+      - Schaltet die Lichter in der Küche aus
+      - Schaltet alle Lichter in der Küche aus
+      - Schaltet in der Küche alle Lichter aus
       - Mach das Licht in der Küche aus
       - Mach die Lichter in der Küche aus
       - Mach alle Lichter in der Küche aus
@@ -21,6 +25,10 @@ tests:
       - Schalte die Lichter in der Küche ab
       - Schalte alle Lichter in der Küche ab
       - Schalte in der Küche alle Lichter ab
+      - Schaltet das Licht in der Küche ab
+      - Schaltet die Lichter in der Küche ab
+      - Schaltet alle Lichter in der Küche ab
+      - Schaltet in der Küche alle Lichter ab
       - Mach das Licht in der Küche ab
       - Mach die Lichter in der Küche ab
       - Mach alle Lichter in der Küche ab
@@ -55,9 +63,11 @@ tests:
 
   - sentences:
       - Schalte alle Lichter aus
+      - Schaltet alle Lichter aus
       - Mach alle Lichter aus
       - Mache alle Lichter aus
       - Schalte alle Lichter ab
+      - Schaltet alle Lichter ab
       - Mach alle Lichter ab
       - Mache alle Lichter ab
       - Alle Lichter ausschalten
@@ -65,6 +75,7 @@ tests:
       - Mach mal alle Lampen aus
       - Mach die Lichter aus
       - Schalte die ganze Beleuchtung aus
+      - Schaltet die ganze Beleuchtung aus
       - Alle Lichter aus
     intent:
       name: HassTurnOff

--- a/tests/de/light_HassTurnOn.yaml
+++ b/tests/de/light_HassTurnOn.yaml
@@ -5,6 +5,10 @@ tests:
       - Schalte die Lichter in der Küche an
       - Schalte alle Lichter in der Küche an
       - Schalte in der Küche alle Lichter an
+      - Schaltet das Licht in der Küche an
+      - Schaltet die Lichter in der Küche an
+      - Schaltet alle Lichter in der Küche an
+      - Schaltet in der Küche alle Lichter an
       - Mach das Licht in der Küche an
       - Mach die Lichter in der Küche an
       - Mach alle Lichter in der Küche an
@@ -21,6 +25,10 @@ tests:
       - Schalte die Lichter in der Küche ein
       - Schalte alle Lichter in der Küche ein
       - Schalte in der Küche alle Lichter ein
+      - Schaltet das Licht in der Küche ein
+      - Schaltet die Lichter in der Küche ein
+      - Schaltet alle Lichter in der Küche ein
+      - Schaltet in der Küche alle Lichter ein
       - Mach das Licht in der Küche ein
       - Mach die Lichter in der Küche ein
       - Mach alle Lichter in der Küche ein
@@ -57,9 +65,11 @@ tests:
 
   - sentences:
       - Schalte alle Lichter an
+      - Schaltet alle Lichter an
       - Mach alle Lichter an
       - Mache alle Lichter an
       - Schalte alle Lichter ein
+      - Schaltet alle Lichter ein
       - Mach alle Lichter ein
       - Mache alle Lichter ein
       - Alle Lichter einschalten


### PR DESCRIPTION
I've added an 'et' option to the expansion_rule 'schalten' because whisper often understands 'schaltet' instead of 'schalte'.

ChrM3r