### PR TITLE
[GL] Replace <name> expansion rule by <nome>

### DIFF
--- a/sentences/gl/_common.yaml
+++ b/sentences/gl/_common.yaml
@@ -47,7 +47,7 @@ lists:
       - in: "f"
         out: "fahrenheit"
 expansion_rules:
-  name: "[o | a] {name}"
+  nome: "[o | a | os | as] {name}"
   area: "[en | no | na | de | do | da] {area}"
   brightness: "{brightness}[%| porcento]"
   acende: "(acende | activa)"

--- a/sentences/gl/cover_HassTurnOff.yaml
+++ b/sentences/gl/cover_HassTurnOff.yaml
@@ -9,7 +9,7 @@ intents:
           device_class: garage
           domain: cover
       - sentences:
-          - pecha [a|as] <name> [<area>]
+          - pecha [a|as] <nome> [<area>]
         response: cover_area
         slots:
           device_class:

--- a/sentences/gl/cover_HassTurnOn.yaml
+++ b/sentences/gl/cover_HassTurnOn.yaml
@@ -18,12 +18,12 @@ intents:
             - shutter
           domain: cover
       # - sentences:
-      #     - abre <name>
+      #     - abre <nome>
       #   requires_context:
       #     domain: cover
       #   response: cover
       # - sentences:
-      #     - abre <name> <area>
+      #     - abre <nome> <area>
       #   requires_context:
       #     domain: cover
       #   response: cover_area

--- a/sentences/gl/homeassistant_HassTurnOff.yaml
+++ b/sentences/gl/homeassistant_HassTurnOff.yaml
@@ -3,5 +3,5 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - apaga <name> <area>
-          - desactiva <name> <area>
+          - apaga <nome> <area>
+          - desactiva <nome> <area>

--- a/sentences/gl/homeassistant_HassTurnOn.yaml
+++ b/sentences/gl/homeassistant_HassTurnOn.yaml
@@ -3,5 +3,5 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - acende <name>
-          - activa <name>
+          - acende <nome>
+          - activa <nome>

--- a/sentences/gl/light_HassLightSet.yaml
+++ b/sentences/gl/light_HassLightSet.yaml
@@ -3,9 +3,9 @@ intents:
   HassLightSet:
     data:
       - sentences:
-          - pon [o] brillo (de | da | do) <name> (a | ó) <brightness>
-          - pon <name> (ó | a) brillo <brightness>
-          - pon <name> a <brightness>
+          - pon [o] brillo (de | da | do) <nome> (a | ó) <brightness>
+          - pon <nome> (ó | a) brillo <brightness>
+          - pon <nome> a <brightness>
         response: brightness
       - sentences:
           - pon [o] brillo <area> [ó] <brightness>
@@ -13,9 +13,9 @@ intents:
           - pon <area> [ó] <brightness>
         response: brightness_area
       - sentences:
-          - pon [o] brillo [de] <name> [ó] <brightness>
+          - pon [o] brillo [de] <nome> [ó] <brightness>
         response: brightness
       - sentences:
-          - pon <name> [a | en] [cor] {color}
-          - pon [[a] cor de] <name> (a | en) {color}
+          - pon <nome> [a | en] [cor] {color}
+          - pon [[a] cor de] <nome> (a | en) {color}
         response: color


### PR DESCRIPTION
Seems to be a common practice to use the local language for the rules' names instead of english.