### PR TITLE
[EN] Context area aware intents

### DIFF
--- a/sentences/en/cover_HassTurnOff.yaml
+++ b/sentences/en/cover_HassTurnOff.yaml
@@ -21,3 +21,14 @@ intents:
         slots:
           domain: cover
         response: cover_device_class
+
+      - sentences:
+          - "<close> [the] {cover_classes:device_class}[<in_here>]"
+        expansion_rules:
+          in_here: "[ in] here"
+        slots:
+          domain: cover
+        response: cover_device_class
+        requires_context:
+          area:
+            slot: true

--- a/sentences/en/cover_HassTurnOn.yaml
+++ b/sentences/en/cover_HassTurnOn.yaml
@@ -21,3 +21,14 @@ intents:
         slots:
           domain: cover
         response: cover_device_class
+
+      - sentences:
+          - "<open> [the] {cover_classes:device_class}[<in_here>]"
+        expansion_rules:
+          in_here: "[ in] here"
+        slots:
+          domain: cover
+        response: cover_device_class
+        requires_context:
+          area:
+            slot: true

--- a/sentences/en/fan_HassTurnOff.yaml
+++ b/sentences/en/fan_HassTurnOff.yaml
@@ -21,3 +21,16 @@ intents:
         slots:
           domain: "fan"
           name: "all"
+
+      - sentences:
+          - "<turn> off[ all][ the] fan[s][<in_here>]"
+          - "<turn>[ all][ the] fan[s]( off;<in_here>)"
+          - "<turn>[ all][ the] fan[s] off"
+        response: "fans_area"
+        expansion_rules:
+          in_here: "[ in] here"
+        slots:
+          domain: fan
+        requires_context:
+          area:
+            slot: true

--- a/sentences/en/fan_HassTurnOn.yaml
+++ b/sentences/en/fan_HassTurnOn.yaml
@@ -12,3 +12,16 @@ intents:
           domain: "fan"
           name: "all"
         response: fans_area
+
+      - sentences:
+          - "<turn> on[ all][ the] fan[s][<in_here>]"
+          - "<turn>[ all][ the] fan[s]( on;<in_here>)"
+          - "<turn>[ all][ the] fan[s] on"
+        response: "fans_area"
+        expansion_rules:
+          in_here: "[ in] here"
+        slots:
+          domain: fan
+        requires_context:
+          area:
+            slot: true

--- a/sentences/en/light_HassLightSet.yaml
+++ b/sentences/en/light_HassLightSet.yaml
@@ -33,6 +33,16 @@ intents:
           name: "all"
         response: "brightness"
 
+      - sentences:
+          - "[<numeric_value_set>] [the] brightness to <brightness>"
+          - "[<numeric_value_set>] [the] brightness (<in_here>;to <brightness>)"
+        expansion_rules:
+          in_here: "[ in] here"
+        response: "brightness"
+        requires_context:
+          area:
+            slot: true
+
       # Max/Min brightness
       - sentences:
           - "[<numeric_value_set>] <name> brightness to [the] {brightness_level:brightness}"
@@ -51,6 +61,16 @@ intents:
           name: "all"
         response: "brightness"
 
+      - sentences:
+          - "[<numeric_value_set>] [the] brightness to [the] {brightness_level:brightness}"
+          - "[<numeric_value_set>] [the] brightness (<in_here>;to [the] {brightness_level:brightness})"
+        expansion_rules:
+          in_here: "[ in] here"
+        response: "brightness"
+        requires_context:
+          area:
+            slot: true
+
       # color
       - sentences:
           - "[<set>] <name> [color] [to] {color}"
@@ -64,3 +84,13 @@ intents:
         slots:
           name: "all"
         response: "color"
+
+      - sentences:
+          - "[<set>] [[the] color of] [all] <light> [to] {color}"
+          - "[<set>] [[the] color of] [all] <light> (<in_here>;[to] {color})"
+        expansion_rules:
+          in_here: "[ in] here"
+        response: "color"
+        requires_context:
+          area:
+            slot: true

--- a/sentences/en/light_HassTurnOff.yaml
+++ b/sentences/en/light_HassTurnOff.yaml
@@ -31,11 +31,12 @@ intents:
 
       # Turn off lights in the same area as a satellite device
       - sentences:
-          - "<turn> off[ the] lights<in_here>"
-          - "<turn>[ the] lights( off;<in_here>)"
+          - "<turn> off[ all] <light>[<in_here>]"
+          - "<turn>[ all] <light>( off;<in_here>)"
+          - "<turn>[ all] <light> off"
         response: "lights_area"
         expansion_rules:
-          in_here: "[[ in] here]"
+          in_here: "[ in] here"
         slots:
           domain: "light"
         requires_context:

--- a/sentences/en/light_HassTurnOn.yaml
+++ b/sentences/en/light_HassTurnOn.yaml
@@ -23,11 +23,12 @@ intents:
 
       # Turn on all lights in the same area as a satellite device
       - sentences:
-          - "<turn> on[ the] lights<in_here>"
-          - "<turn>[ the] lights( on;<in_here>)"
+          - "<turn> on[ all] <light>[<in_here>]"
+          - "<turn>[ all] <light>( on;<in_here>)"
+          - "<turn>[ all] <light> on"
         response: "lights_area"
         expansion_rules:
-          in_here: "[[ in] here]"
+          in_here: "[ in] here"
         slots:
           domain: "light"
         requires_context:

--- a/tests/en/cover_HassTurnOff.yaml
+++ b/tests/en/cover_HassTurnOff.yaml
@@ -61,3 +61,16 @@ tests:
         area: Bedroom
         domain: cover
         device_class: blind
+
+  - sentences:
+      - "close the curtains"
+      - "close the curtains in here"
+    intent:
+      name: HassTurnOff
+      context:
+        area: Living Room
+      slots:
+        domain: cover
+        area: Living Room
+        device_class: curtain
+    response: "Closed curtains"

--- a/tests/en/cover_HassTurnOff.yaml
+++ b/tests/en/cover_HassTurnOff.yaml
@@ -73,4 +73,4 @@ tests:
         domain: cover
         area: Living Room
         device_class: curtain
-    response: "Closed curtains"
+    response: "Closed the curtains"

--- a/tests/en/cover_HassTurnOn.yaml
+++ b/tests/en/cover_HassTurnOn.yaml
@@ -75,4 +75,3 @@ tests:
         area: Living Room
         device_class: curtain
     response: "Opened the curtains"
-

--- a/tests/en/cover_HassTurnOn.yaml
+++ b/tests/en/cover_HassTurnOn.yaml
@@ -62,3 +62,17 @@ tests:
         domain: cover
         device_class: blind
     response: "Opened the blinds"
+
+  - sentences:
+      - "open the curtains"
+      - "open the curtains in here"
+    intent:
+      name: HassTurnOn
+      context:
+        area: Living Room
+      slots:
+        domain: cover
+        area: Living Room
+        device_class: curtain
+    response: "Opened the curtains"
+

--- a/tests/en/fan_HassTurnOff.yaml
+++ b/tests/en/fan_HassTurnOff.yaml
@@ -44,4 +44,4 @@ tests:
       slots:
         domain: fan
         area: Living Room
-    response: "Turned off fans"
+    response: "Turned off the fans"

--- a/tests/en/fan_HassTurnOff.yaml
+++ b/tests/en/fan_HassTurnOff.yaml
@@ -30,3 +30,18 @@ tests:
       slots:
         domain: fan
         name: all
+
+  - sentences:
+      - "turn off all the fans"
+      - "turn off the fans in here"
+      - "turn all the fans off in here"
+      - "turn the fans here off"
+      - "turn the fans off"
+    intent:
+      name: HassTurnOff
+      context:
+        area: Living Room
+      slots:
+        domain: fan
+        area: Living Room
+    response: "Turned off fans"

--- a/tests/en/fan_HassTurnOn.yaml
+++ b/tests/en/fan_HassTurnOn.yaml
@@ -20,3 +20,18 @@ tests:
         domain: fan
         name: all
     response: Turned on the fans
+
+  - sentences:
+      - "turn on all the fans"
+      - "turn on the fans in here"
+      - "turn all the fans on in here"
+      - "turn the fans here on"
+      - "turn the fans on"
+    intent:
+      name: HassTurnOn
+      context:
+        area: Living Room
+      slots:
+        domain: fan
+        area: Living Room
+    response: "Turned on the fans"

--- a/tests/en/light_HassLightSet.yaml
+++ b/tests/en/light_HassLightSet.yaml
@@ -37,6 +37,19 @@ tests:
     response: "Brightness set"
 
   - sentences:
+      - "set the brightness to 50%"
+      - "change the brightness in here to 50 percent"
+      - "turn brightness to 50% in here"
+    intent:
+      name: HassLightSet
+      context:
+        area: Bedroom
+      slots:
+        brightness: 50
+        area: Bedroom
+    response: "Brightness set"
+
+  - sentences:
       - "set the bedroom lamp brightness to max"
       - "change the brightness of bedroom lamp to the highest"
       - "set the bedroom lamp to maximum brightness"
@@ -88,6 +101,19 @@ tests:
         name: all
     response: "Brightness set"
 
+  - sentences:
+      - "set the brightness to the max"
+      - "change the brightness in here to highest"
+      - "turn brightness to maximum in here"
+    intent:
+      name: HassLightSet
+      context:
+        area: Bedroom
+      slots:
+        brightness: 100
+        area: Bedroom
+    response: "Brightness set"
+
   # color
   - sentences:
       - "set the bedroom lamp color to red"
@@ -116,4 +142,17 @@ tests:
         color: red
         area: Bedroom
         name: all
+    response: "Color set"
+
+  - sentences:
+      - "make the lights red"
+      - "set the color of all lights in here to red"
+      - "make all the lights red in here"
+    intent:
+      name: HassLightSet
+      context:
+        area: Bedroom
+      slots:
+        color: red
+        area: Bedroom
     response: "Color set"

--- a/tests/en/light_HassTurnOff.yaml
+++ b/tests/en/light_HassTurnOff.yaml
@@ -53,3 +53,18 @@ tests:
         domain: light
         area: Living Room
     response: "Turned off the lights"
+
+  - sentences:
+      - "turn off all the lights"
+      - "turn off the light in here"
+      - "turn all the lighting off in here"
+      - "turn the light here off"
+      - "turn the lights off"
+    intent:
+      name: HassTurnOff
+      context:
+        area: Living Room
+      slots:
+        domain: light
+        area: Living Room
+    response: "Turned off the lights"

--- a/tests/en/light_HassTurnOn.yaml
+++ b/tests/en/light_HassTurnOn.yaml
@@ -44,3 +44,18 @@ tests:
         domain: light
         area: Living Room
     response: "Turned on the lights"
+
+  - sentences:
+      - "turn on all the lights"
+      - "turn on the light in here"
+      - "turn all the lighting on in here"
+      - "turn the light here on"
+      - "turn the lights on"
+    intent:
+      name: HassTurnOn
+      context:
+        area: Living Room
+      slots:
+        domain: light
+        area: Living Room
+    response: "Turned on the lights"


### PR DESCRIPTION
Added the area-aware ability to all action intents, not just `light_HassTurnXX` ones.

Also optimized the `light` sentences, as completely optional components in a permutation may result in duplicate matches.