### PR TITLE
Improve expansion rules for french intents

### DIFF
--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -305,9 +305,9 @@ lists:
 expansion_rules:
   # Common expansion rules
   pourcent: "(%| %| pourcent)"
+  degres: "(°| °| degré| degrés)"
   name: "[le |la |les |[l']]{name}"
   area: "[le |la |[l']]{area}"
-  temperature: "{temperature}[°| degrés] [{temperature_unit}]"
   regle: "(règle|régler|met|mets|mettre|ajuste|ajuster|change|changer)"
   allume: "(allume|allumer|active|activer|démarre|démarrer)"
   eteins: "((é|e)teint|(é|e)teins|(é|e)teindre|désactive|désactiver|stoppe|stopper|arrête|arrêter|coupe|couper)"

--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -303,13 +303,12 @@ lists:
     wildcard: true
 
 expansion_rules:
-  # Common expansion rules
   pourcent: "(%| %| pourcent)"
   degres: "(°| °| degré| degrés)"
   le: (le |la |les |l')
   regle: "(règle|régler|met|mets|mettre|ajuste|ajuster|change|changer)"
   allume: "(allume|allumer|active|activer|démarre|démarrer)"
-  eteins: "((é|e)teint|(é|e)teins|(é|e)teindre|désactive|désactiver|stoppe|stopper|arrête|arrêter|coupe|couper)"
+  eteins: "(éteint|eteint|éteins|eteins|éteindre|eteindre|désactive|désactiver|stoppe|stopper|arrête|arrêter|coupe|couper)"
   ferme: "(ferme|fermer|baisse|baisser)"
   ouvre: "(ouvre|ouvrir|monte|monter)"
   lumiere: "([la ](lumière|lampe)|[l']ampoule)"
@@ -319,7 +318,7 @@ expansion_rules:
   volet: "([le ](volet|store))"
   volets: "[les ](volets|stores)"
   garage: "([la ]porte (du |de )garage)|([le ]garage)"
-  fenetre: "(fen(e|ê)tre[s]|baie[s]|v(e|é)lux|lucarne[s])"
+  fenetre: "(fenetre[s]|fenêtre[s]|baie[s]|velux|vélux|lucarne[s])"
   dans: "(dans|du|de|à|au)"
   de: "(du|de)"
   yatil: "(y a[-][ ]t[-][']il|il y a)"

--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -303,9 +303,10 @@ lists:
     wildcard: true
 
 expansion_rules:
+  # Common expansion rules
+  pourcent: "(%| %| pourcent)"
   name: "[le |la |les |[l']]{name}"
   area: "[le |la |[l']]{area}"
-  brightness: "{brightness:brightness}[%| pourcent]"
   temperature: "{temperature}[°| degrés] [{temperature_unit}]"
   regle: "(règle|régler|met|mets|mettre|ajuste|ajuster|change|changer)"
   allume: "(allume|allumer|active|activer|démarre|démarrer)"

--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -306,8 +306,7 @@ expansion_rules:
   # Common expansion rules
   pourcent: "(%| %| pourcent)"
   degres: "(°| °| degré| degrés)"
-  name: "[le |la |les |[l']]{name}"
-  area: "[le |la |[l']]{area}"
+  le: (le |la |les |l')
   regle: "(règle|régler|met|mets|mettre|ajuste|ajuster|change|changer)"
   allume: "(allume|allumer|active|activer|démarre|démarrer)"
   eteins: "((é|e)teint|(é|e)teins|(é|e)teindre|désactive|désactiver|stoppe|stopper|arrête|arrêter|coupe|couper)"
@@ -333,7 +332,7 @@ expansion_rules:
   eclaire: (éclaire|éclairer|illumine|illuminer)
   quelest: "<quel> (est|sont)"
   # Questions
-  what_is_the_class_of_name: "<quelest> (le |la |l'|les )<class> [(indiqué[e][s]|mesuré[e][s]|renvoyé[e][s]|restant[e][s]|retourné[e][s]|utilisé[e][s]|produit[e][s]|consommé[e][s]|donné[e][s]) ][(par|<dans>|sur)] <name> [<dans> <area>]"
+  what_is_the_class_of_name: "<quelest> (le |la |l'|les )<class> [(indiqué[e][s]|mesuré[e][s]|renvoyé[e][s]|restant[e][s]|retourné[e][s]|utilisé[e][s]|produit[e][s]|consommé[e][s]|donné[e][s]) ][(par|<dans>|sur)] [<le>]{name} [<dans> [<le>]{area}]"
 
 skip_words:
   - "s'il te plaît"

--- a/sentences/fr/binary_sensor_HassGetState.yaml
+++ b/sentences/fr/binary_sensor_HassGetState.yaml
@@ -5,8 +5,8 @@ intents:
       # https://www.home-assistant.io/integrations/binary_sensor/
       # Battery
       - sentences:
-          - "[la|les] [batterie] [<de>] <name> [<dans> <area>] <estil> {bs_battery_states:state}"
-          - "[la|les] [batterie] [<de>] <name> <estil> {bs_battery_states:state} [<dans> <area>]"
+          - "[la|les] [batterie] [<de>] [<le>]{name} [<dans> [<le>]{area}] <estil> {bs_battery_states:state}"
+          - "[la|les] [batterie] [<de>] [<le>]{name} <estil> {bs_battery_states:state} [<dans> [<le>]{area}]"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -16,24 +16,24 @@ intents:
           device_class: battery
 
       - sentences:
-          - "Toute[s] [les] ((<capteur>|<appareil>)|batterie[s]) <estil> {bs_battery_states:state} [<dans> <area>]"
+          - "Toute[s] [les] ((<capteur>|<appareil>)|batterie[s]) <estil> {bs_battery_states:state} [<dans> [<le>]{area}]"
         response: all
         slots:
           domain: binary_sensor
           device_class: battery
 
       - sentences:
-          - "<quel> sont les ((<capteur>|<appareil>)||batterie[s]) [qui sont] {bs_battery_states:state} [<dans> <area>]"
-          - "<quel> ((<capteur>|<appareil>)||batterie[s]) <estil> {bs_battery_states:state} [<dans> <area>]"
-          - "liste les ((<capteur>|<appareil>)||batterie[s]) [qui sont] {bs_battery_states:state} [<dans> <area>]"
+          - "<quel> sont les ((<capteur>|<appareil>)||batterie[s]) [qui sont] {bs_battery_states:state} [<dans> [<le>]{area}]"
+          - "<quel> ((<capteur>|<appareil>)||batterie[s]) <estil> {bs_battery_states:state} [<dans> [<le>]{area}]"
+          - "liste les ((<capteur>|<appareil>)||batterie[s]) [qui sont] {bs_battery_states:state} [<dans> [<le>]{area}]"
         response: which
         slots:
           domain: binary_sensor
           device_class: battery
 
       - sentences:
-          - "Combien de ((<capteur>|<appareil>)||batterie[s]) [<estil>] {bs_battery_states:state} [<dans> <area>]"
-          - "Compte (les|le nombre de) ((<capteur>|<appareil>)|batterie[s]) [qui sont] {bs_battery_states:state} [<dans> <area>]"
+          - "Combien de ((<capteur>|<appareil>)||batterie[s]) [<estil>] {bs_battery_states:state} [<dans> [<le>]{area}]"
+          - "Compte (les|le nombre de) ((<capteur>|<appareil>)|batterie[s]) [qui sont] {bs_battery_states:state} [<dans> [<le>]{area}]"
         response: how_many
         slots:
           domain: binary_sensor
@@ -41,8 +41,8 @@ intents:
 
       # Battery charging
       - sentences:
-          - "[(la|le)] [((<capteur>|<appareil>)|batterie)] [<de>] <name> [<dans> <area>] <estil> {bs_battery_charging_states:state}"
-          - "[(la|le)] [((<capteur>|<appareil>)|batterie)] [<de>] <name> <estil> {bs_battery_charging_states:state} [<dans> <area>]"
+          - "[(la|le)] [((<capteur>|<appareil>)|batterie)] [<de>] [<le>]{name} [<dans> [<le>]{area}] <estil> {bs_battery_charging_states:state}"
+          - "[(la|le)] [((<capteur>|<appareil>)|batterie)] [<de>] [<le>]{name} <estil> {bs_battery_charging_states:state} [<dans> [<le>]{area}]"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -52,32 +52,32 @@ intents:
           device_class: battery_charging
 
       - sentences:
-          - "[<yatil>] des ((<capteur>|<appareil>)||batterie[s]) [(qui|en)] {bs_battery_charging_states:state} [<dans> <area>]"
-          - "[<yatil>] plusieurs ((<capteur>|<appareil>)||batterie[s]) [(qui|en|<estil>)] {bs_battery_charging_states:state} [<dans> <area>]"
-          - "Plusieurs ((<capteur>|<appareil>)||batterie[s]) [<estil>] {bs_battery_charging_states:state} [<dans> <area>]"
+          - "[<yatil>] des ((<capteur>|<appareil>)||batterie[s]) [(qui|en)] {bs_battery_charging_states:state} [<dans> [<le>]{area}]"
+          - "[<yatil>] plusieurs ((<capteur>|<appareil>)||batterie[s]) [(qui|en|<estil>)] {bs_battery_charging_states:state} [<dans> [<le>]{area}]"
+          - "Plusieurs ((<capteur>|<appareil>)||batterie[s]) [<estil>] {bs_battery_charging_states:state} [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: binary_sensor
           device_class: battery_charging
 
       - sentences:
-          - "<tous> [les] ((<capteur>|<appareil>)||batterie[s]) <estil> {bs_battery_charging_states:state} [<dans> <area>]"
+          - "<tous> [les] ((<capteur>|<appareil>)||batterie[s]) <estil> {bs_battery_charging_states:state} [<dans> [<le>]{area}]"
         response: all
         slots:
           domain: binary_sensor
           device_class: battery_charging
 
       - sentences:
-          - "<quel> [sont] [les] ((<capteur>|<appareil>)||batterie[s]) [qui] [sont] {bs_battery_charging_states:state} [<dans> <area>]"
-          - "liste les ((<capteur>|<appareil>)||batterie[s]) [qui sont] [en] {bs_battery_charging_states:state} [<dans> <area>]"
+          - "<quel> [sont] [les] ((<capteur>|<appareil>)||batterie[s]) [qui] [sont] {bs_battery_charging_states:state} [<dans> [<le>]{area}]"
+          - "liste les ((<capteur>|<appareil>)||batterie[s]) [qui sont] [en] {bs_battery_charging_states:state} [<dans> [<le>]{area}]"
         response: which
         slots:
           domain: binary_sensor
           device_class: battery_charging
 
       - sentences:
-          - "combien (de |d')((<capteur>|<appareil>)||batterie[s]) [sont] {bs_battery_charging_states:state} [<dans> <area>]"
-          - "compte (les |le nombre d('|e ))((<capteur>|<appareil>)||batterie[s]) [qui] [sont] {bs_battery_charging_states:state} [<dans> <area>]"
+          - "combien (de |d')((<capteur>|<appareil>)||batterie[s]) [sont] {bs_battery_charging_states:state} [<dans> [<le>]{area}]"
+          - "compte (les |le nombre d('|e ))((<capteur>|<appareil>)||batterie[s]) [qui] [sont] {bs_battery_charging_states:state} [<dans> [<le>]{area}]"
         response: how_many
         slots:
           domain: binary_sensor
@@ -85,8 +85,8 @@ intents:
 
       # Carbon monoxide
       - sentences:
-          - "[<yatil>] [<de>] <name> <estil> [au statut] {bs_carbon_monoxide_states:state} [<dans> <area>]"
-          - "[du] <name> <atil> été [au statut] {bs_carbon_monoxide_states:state} [<dans> <area>]"
+          - "[<yatil>] [<de>] [<le>]{name} <estil> [au statut] {bs_carbon_monoxide_states:state} [<dans> [<le>]{area}]"
+          - "[du] [<le>]{name} <atil> été [au statut] {bs_carbon_monoxide_states:state} [<dans> [<le>]{area}]"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -96,17 +96,17 @@ intents:
           device_class: carbon_monoxide
 
       - sentences:
-          - "[du] (CO|monoxyde [de carbone]) <estil> {bs_carbon_monoxide_states:state} [<dans> <area>]"
-          - "[du] (CO|monoxyde [de carbone]) <atil> été {bs_carbon_monoxide_states:state} [<dans> <area>]"
+          - "[du] (CO|monoxyde [de carbone]) <estil> {bs_carbon_monoxide_states:state} [<dans> [<le>]{area}]"
+          - "[du] (CO|monoxyde [de carbone]) <atil> été {bs_carbon_monoxide_states:state} [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: binary_sensor
           device_class: carbon_monoxide
 
       - sentences:
-          - "[<yatil>] [(un|le) capteur de] (monoxyde[ de carbone]|CO) [de] [{bs_carbon_monoxide_states:state}] [<dans> <area>]"
-          - "[<yatil>] [une alerte] [(de|au)] (monoxyde[ de carbone]|CO) [de] [{bs_carbon_monoxide_states:state}] [<dans> <area>]"
-          - "[Une] alerte [(de|au)] (monoxyde[ de carbone]|CO) [<atil> été {bs_carbon_monoxide_states:state}] [<dans> <area>]"
+          - "[<yatil>] [(un|le) capteur de] (monoxyde[ de carbone]|CO) [de] [{bs_carbon_monoxide_states:state}] [<dans> [<le>]{area}]"
+          - "[<yatil>] [une alerte] [(de|au)] (monoxyde[ de carbone]|CO) [de] [{bs_carbon_monoxide_states:state}] [<dans> [<le>]{area}]"
+          - "[Une] alerte [(de|au)] (monoxyde[ de carbone]|CO) [<atil> été {bs_carbon_monoxide_states:state}] [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: binary_sensor
@@ -114,15 +114,15 @@ intents:
           state: "on"
 
       - sentences:
-          - "<tous> [les] capteurs [de] (CO|monoxyde[ de carbone]) <estil> {bs_carbon_monoxide_states:state} [<dans> <area>]"
+          - "<tous> [les] capteurs [de] (CO|monoxyde[ de carbone]) <estil> {bs_carbon_monoxide_states:state} [<dans> [<le>]{area}]"
         response: all
         slots:
           domain: binary_sensor
           device_class: carbon_monoxide
 
       - sentences:
-          - "<quel> capteur[s] [de] (CO|monoxyde[de carbone]) <estil> {bs_carbon_monoxide_states:state} [<dans> <area>]"
-          - "Liste les capteur[s] [de] (CO|monoxyde[de carbone]) [qui sont] {bs_carbon_monoxide_states:state} [<dans> <area>]"
+          - "<quel> capteur[s] [de] (CO|monoxyde[de carbone]) <estil> {bs_carbon_monoxide_states:state} [<dans> [<le>]{area}]"
+          - "Liste les capteur[s] [de] (CO|monoxyde[de carbone]) [qui sont] {bs_carbon_monoxide_states:state} [<dans> [<le>]{area}]"
           - "Où du (CO|monoxyde[ de carbone]) <estil> {bs_carbon_monoxide_states:state}"
           - "Où du (CO|monoxyde[ de carbone]) <atil> été {bs_carbon_monoxide_states:state}"
         response: which
@@ -131,8 +131,8 @@ intents:
           device_class: carbon_monoxide
 
       - sentences:
-          - "combien de capteur[s] [de] (CO|monoxyde[de carbone]) [qui] [<estil>] {bs_carbon_monoxide_states:state} [<dans> <area>]"
-          - "compte (les |le nombre de) capteur[s] [de] (CO|monoxyde[de carbone]) [qui] [<estil>] {bs_carbon_monoxide_states:state} [<dans> <area>]"
+          - "combien de capteur[s] [de] (CO|monoxyde[de carbone]) [qui] [<estil>] {bs_carbon_monoxide_states:state} [<dans> [<le>]{area}]"
+          - "compte (les |le nombre de) capteur[s] [de] (CO|monoxyde[de carbone]) [qui] [<estil>] {bs_carbon_monoxide_states:state} [<dans> [<le>]{area}]"
         response: how_many
         slots:
           domain: binary_sensor
@@ -140,8 +140,8 @@ intents:
 
       # # Cold
       - sentences:
-          - "<name> [<dans> <area>] [<estil>] {bs_cold_states:state}"
-          - "<name> [<estil>] {bs_cold_states:state} [<dans> <area>]"
+          - "[<le>]{name} [<dans> [<le>]{area}] [<estil>] {bs_cold_states:state}"
+          - "[<le>]{name} [<estil>] {bs_cold_states:state} [<dans> [<le>]{area}]"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -151,8 +151,8 @@ intents:
           device_class: cold
 
       - sentences:
-          - "[<yatil>] [(certain[e][s]|des)] (<capteur>|<appareil>) [qui sont] {bs_cold_states:state} [<dans> <area>]"
-          - "[(certain[e][s]|des)] (<capteur>|<appareil>) [<estil>] {bs_cold_states:state} [<dans> <area>]"
+          - "[<yatil>] [(certain[e][s]|des)] (<capteur>|<appareil>) [qui sont] {bs_cold_states:state} [<dans> [<le>]{area}]"
+          - "[(certain[e][s]|des)] (<capteur>|<appareil>) [<estil>] {bs_cold_states:state} [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: binary_sensor
@@ -160,9 +160,9 @@ intents:
           state: "on"
 
       - sentences:
-          - "<quel> [sont] [les] (<capteur>|<appareil>) [qui sont] {bs_cold_states:state} [<dans> <area>]"
-          - "<quel> (<capteur>|<appareil>) [<estil>] {bs_cold_states:state} [<dans> <area>]"
-          - "Liste les (<capteur>|<appareil>) [qui sont] {bs_cold_states:state} [<dans> <area>]"
+          - "<quel> [sont] [les] (<capteur>|<appareil>) [qui sont] {bs_cold_states:state} [<dans> [<le>]{area}]"
+          - "<quel> (<capteur>|<appareil>) [<estil>] {bs_cold_states:state} [<dans> [<le>]{area}]"
+          - "Liste les (<capteur>|<appareil>) [qui sont] {bs_cold_states:state} [<dans> [<le>]{area}]"
         response: which
         slots:
           domain: binary_sensor
@@ -170,8 +170,8 @@ intents:
           state: "on"
 
       - sentences:
-          - "combien (de |d')(<capteur>|<appareil>) [<estil>] {bs_cold_states:state} [<dans> <area>]"
-          - "compte (les |le nombre d('|e ))(<capteur>|<appareil>) [qui sont] {bs_cold_states:state} [<dans> <area>]"
+          - "combien (de |d')(<capteur>|<appareil>) [<estil>] {bs_cold_states:state} [<dans> [<le>]{area}]"
+          - "compte (les |le nombre d('|e ))(<capteur>|<appareil>) [qui sont] {bs_cold_states:state} [<dans> [<le>]{area}]"
         response: how_many
         slots:
           domain: binary_sensor
@@ -180,8 +180,8 @@ intents:
 
       # # Connectivity
       - sentences:
-          - "<name> [<dans> <area>] [<estil>] {bs_connectivity_states:state}"
-          - "<name> [<estil>] {bs_connectivity_states:state} [<dans> <area>]"
+          - "[<le>]{name} [<dans> [<le>]{area}] [<estil>] {bs_connectivity_states:state}"
+          - "[<le>]{name} [<estil>] {bs_connectivity_states:state} [<dans> [<le>]{area}]"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -191,32 +191,32 @@ intents:
           device_class: connectivity
 
       - sentences:
-          - "[(certain[e][s]|des)] (<capteur>|<appareil>) [<estil>] {bs_connectivity_states:state} [<dans> <area>]"
-          - "[<yatil>] [(certain[e][s]|des)] (<capteur>|<appareil>) [qui sont] {bs_connectivity_states:state} [<dans> <area>]"
+          - "[(certain[e][s]|des)] (<capteur>|<appareil>) [<estil>] {bs_connectivity_states:state} [<dans> [<le>]{area}]"
+          - "[<yatil>] [(certain[e][s]|des)] (<capteur>|<appareil>) [qui sont] {bs_connectivity_states:state} [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: binary_sensor
           device_class: connectivity
 
       - sentences:
-          - "<tous> les (<capteur>|<appareil>) [<estil>] {bs_connectivity_states:state} [in <area>]"
+          - "<tous> les (<capteur>|<appareil>) [<estil>] {bs_connectivity_states:state} [in [<le>]{area}]"
         response: all
         slots:
           domain: binary_sensor
           device_class: connectivity
 
       - sentences:
-          - "<quel> (<capteur>|<appareil>) [<estil>] {bs_connectivity_states:state} [<dans> <area>]"
-          - "<quel> [sont les] (<capteur>|<appareil>) [qui sont] {bs_connectivity_states:state} [<dans> <area>]"
-          - "liste les (<capteur>|<appareil>) [qui sont] {bs_connectivity_states:state} [<dans> <area>]"
+          - "<quel> (<capteur>|<appareil>) [<estil>] {bs_connectivity_states:state} [<dans> [<le>]{area}]"
+          - "<quel> [sont les] (<capteur>|<appareil>) [qui sont] {bs_connectivity_states:state} [<dans> [<le>]{area}]"
+          - "liste les (<capteur>|<appareil>) [qui sont] {bs_connectivity_states:state} [<dans> [<le>]{area}]"
         response: which
         slots:
           domain: binary_sensor
           device_class: connectivity
 
       - sentences:
-          - "combien (de |d')(<capteur>|<appareil>) [<estil>] {bs_connectivity_states:state} [<dans> <area>]"
-          - "compte (les |le nombre d('|e ))(<capteur>|<appareil>) [qui sont] {bs_connectivity_states:state} [<dans> <area>]"
+          - "combien (de |d')(<capteur>|<appareil>) [<estil>] {bs_connectivity_states:state} [<dans> [<le>]{area}]"
+          - "compte (les |le nombre d('|e ))(<capteur>|<appareil>) [qui sont] {bs_connectivity_states:state} [<dans> [<le>]{area}]"
         response: how_many
         slots:
           domain: binary_sensor
@@ -224,7 +224,7 @@ intents:
 
       # # Door
       - sentences:
-          - "<name> <estil> {bs_door_states:state} [<dans> <area>]"
+          - "[<le>]{name} <estil> {bs_door_states:state} [<dans> [<le>]{area}]"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -235,8 +235,8 @@ intents:
 
       # # Garage door
       - sentences:
-          - "<name> [<de>] [garage] [<dans> <area>] <estil> {bs_garage_door_states:state}"
-          - "<name> [<de>] [garage] <estil> {bs_garage_door_states:state} [<dans> <area>]"
+          - "[<le>]{name} [<de>] [garage] [<dans> [<le>]{area}] <estil> {bs_garage_door_states:state}"
+          - "[<le>]{name} [<de>] [garage] <estil> {bs_garage_door_states:state} [<dans> [<le>]{area}]"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -246,32 +246,32 @@ intents:
           device_class: garage_door
 
       - sentences:
-          - "[<tous>] les portes [<de>] garage <estil> {bs_garage_door_states:state} [<dans> <area>]"
+          - "[<tous>] les portes [<de>] garage <estil> {bs_garage_door_states:state} [<dans> [<le>]{area}]"
         response: all
         slots:
           domain: binary_sensor
           device_class: garage_door
 
       - sentences:
-          - "[(certain[e][s]|des)] porte[s] <de> garage [<estil>] {bs_garage_door_states:state} [<dans> <area>]"
-          - "[<yatil>] [(certain[e][s]|des)] porte[s] <de> garage [qui sont] {bs_garage_door_states:state} [<dans> <area>]"
+          - "[(certain[e][s]|des)] porte[s] <de> garage [<estil>] {bs_garage_door_states:state} [<dans> [<le>]{area}]"
+          - "[<yatil>] [(certain[e][s]|des)] porte[s] <de> garage [qui sont] {bs_garage_door_states:state} [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: binary_sensor
           device_class: garage_door
 
       - sentences:
-          - "<quel> [sont] [les] porte[s] <de> garage [<estil>] {bs_garage_door_states:state} [<dans> <area>]"
-          - "<quel> [sont] [les] porte[s] <de> garage [qui sont] {bs_garage_door_states:state} [<dans> <area>]"
-          - "liste [les] porte[s] <de> garage [qui sont] {bs_garage_door_states:state} [<dans> <area>]"
+          - "<quel> [sont] [les] porte[s] <de> garage [<estil>] {bs_garage_door_states:state} [<dans> [<le>]{area}]"
+          - "<quel> [sont] [les] porte[s] <de> garage [qui sont] {bs_garage_door_states:state} [<dans> [<le>]{area}]"
+          - "liste [les] porte[s] <de> garage [qui sont] {bs_garage_door_states:state} [<dans> [<le>]{area}]"
         response: which
         slots:
           domain: binary_sensor
           device_class: garage_door
 
       - sentences:
-          - "combien de porte[s] <de> garage [<estil>] {bs_garage_door_states:state} [<dans> <area>]"
-          - "compte (les |le nombre de) porte[s] <de> garage [qui] [<estil>] {bs_garage_door_states:state} [<dans> <area>]"
+          - "combien de porte[s] <de> garage [<estil>] {bs_garage_door_states:state} [<dans> [<le>]{area}]"
+          - "compte (les |le nombre de) porte[s] <de> garage [qui] [<estil>] {bs_garage_door_states:state} [<dans> [<le>]{area}]"
         response: how_many
         slots:
           domain: binary_sensor
@@ -279,8 +279,8 @@ intents:
 
       # # Gas
       - sentences:
-          - "<name> <estil> {bs_gas_states:state} [<dans> <area>]"
-          - "<name> [<dans> <area>] <estil> {bs_gas_states:state}"
+          - "[<le>]{name} <estil> {bs_gas_states:state} [<dans> [<le>]{area}]"
+          - "[<le>]{name} [<dans> [<le>]{area}] <estil> {bs_gas_states:state}"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -290,18 +290,18 @@ intents:
           device_class: gas
 
       - sentences:
-          - "Du gaz <estil> {bs_gas_states:state} [<dans> <area>]"
-          - "Du gaz <atil> [été] {bs_gas_states:state} [<dans> <area>]"
+          - "Du gaz <estil> {bs_gas_states:state} [<dans> [<le>]{area}]"
+          - "Du gaz <atil> [été] {bs_gas_states:state} [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: binary_sensor
           device_class: gas
 
       - sentences:
-          - "[<yatil>] [(un|le) capteur de] gaz [(<estil>|de)] [{bs_gas_states:state}] [<dans> <area>]"
-          - "une alerte [(de|au)] gaz <atil> été [{bs_gas_states:state}] [<dans> <area>]"
-          - "[<yatil>] [une alerte] [(<de>|au)] gaz [de] [{bs_gas_states:state}] [<dans> <area>]"
-          - "une alerte [(de|au)] gaz <estil> [{bs_gas_states:state}] [<dans> <area>]"
+          - "[<yatil>] [(un|le) capteur de] gaz [(<estil>|de)] [{bs_gas_states:state}] [<dans> [<le>]{area}]"
+          - "une alerte [(de|au)] gaz <atil> été [{bs_gas_states:state}] [<dans> [<le>]{area}]"
+          - "[<yatil>] [une alerte] [(<de>|au)] gaz [de] [{bs_gas_states:state}] [<dans> [<le>]{area}]"
+          - "une alerte [(de|au)] gaz <estil> [{bs_gas_states:state}] [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: binary_sensor
@@ -309,17 +309,17 @@ intents:
           state: "on"
 
       - sentences:
-          - "[<tous>] [les] capteurs [de] gaz <estil> {bs_gas_states:state} [<dans> <area>]"
+          - "[<tous>] [les] capteurs [de] gaz <estil> {bs_gas_states:state} [<dans> [<le>]{area}]"
         response: all
         slots:
           domain: binary_sensor
           device_class: gas
 
       - sentences:
-          - "<quel> [sont les] capteur[s] [de] gaz [au statut] {bs_gas_states:state} [<dans> <area>]"
-          - "<quel> [sont les] capteur[s] [de] gaz [qui] [sont] {bs_gas_states:state} [<dans> <area>]"
-          - "<quel> capteur[s] [de] gaz <estil> {bs_gas_states:state} [<dans> <area>]"
-          - "liste les capteur[s] [de] gaz [qui sont] {bs_gas_states:state} [<dans> <area>]"
+          - "<quel> [sont les] capteur[s] [de] gaz [au statut] {bs_gas_states:state} [<dans> [<le>]{area}]"
+          - "<quel> [sont les] capteur[s] [de] gaz [qui] [sont] {bs_gas_states:state} [<dans> [<le>]{area}]"
+          - "<quel> capteur[s] [de] gaz <estil> {bs_gas_states:state} [<dans> [<le>]{area}]"
+          - "liste les capteur[s] [de] gaz [qui sont] {bs_gas_states:state} [<dans> [<le>]{area}]"
           - "Où du gaz <estil> {bs_gas_states:state} "
         response: which
         slots:
@@ -327,8 +327,8 @@ intents:
           device_class: gas
 
       - sentences:
-          - "combien de capteur[s] [de] gaz [<estil>] {bs_gas_states:state} [<dans> <area>]"
-          - "compte (les |le nombre de) capteur[s] [de] gaz [qui sont] {bs_gas_states:state} [<dans> <area>]"
+          - "combien de capteur[s] [de] gaz [<estil>] {bs_gas_states:state} [<dans> [<le>]{area}]"
+          - "compte (les |le nombre de) capteur[s] [de] gaz [qui sont] {bs_gas_states:state} [<dans> [<le>]{area}]"
         response: how_many
         slots:
           domain: binary_sensor
@@ -336,8 +336,8 @@ intents:
 
       # # Heat
       - sentences:
-          - "<name> [<dans> <area>] (<estil>|<atil> une température) {bs_heat_states:state}"
-          - "<name> (<estil>|<atil> une température) {bs_heat_states:state} [<dans> <area>]"
+          - "[<le>]{name} [<dans> [<le>]{area}] (<estil>|<atil> une température) {bs_heat_states:state}"
+          - "[<le>]{name} (<estil>|<atil> une température) {bs_heat_states:state} [<dans> [<le>]{area}]"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -347,9 +347,9 @@ intents:
           device_class: heat
 
       - sentences:
-          - "[<yatil>] [(certain[e][s]|des)] (<capteur>|<appareil>) [qui] {bs_heat_states:state} [<dans> <area>]"
-          - "[(certain[e][s]|des)] (<capteur>|<appareil>) [<estil>] {bs_heat_states:state} [<dans> <area>]"
-          - "[(certain[e][s]|des)] (<capteur>|<appareil>) {bs_heat_states:state}[(-il[s]|-elle[s])] [<dans> <area>]"
+          - "[<yatil>] [(certain[e][s]|des)] (<capteur>|<appareil>) [qui] {bs_heat_states:state} [<dans> [<le>]{area}]"
+          - "[(certain[e][s]|des)] (<capteur>|<appareil>) [<estil>] {bs_heat_states:state} [<dans> [<le>]{area}]"
+          - "[(certain[e][s]|des)] (<capteur>|<appareil>) {bs_heat_states:state}[(-il[s]|-elle[s])] [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: binary_sensor
@@ -357,16 +357,16 @@ intents:
           state: "on"
 
       - sentences:
-          - "[<tous>] [les] (<capteur>|<appareil>) <atil> une température {bs_heat_states:state} [<dans> <area>]"
+          - "[<tous>] [les] (<capteur>|<appareil>) <atil> une température {bs_heat_states:state} [<dans> [<le>]{area}]"
         response: all
         slots:
           domain: binary_sensor
           device_class: heat
 
       - sentences:
-          - "<quel> (<capteur>|<appareil>) [<estil>] {bs_heat_states:state} [<dans> <area>]"
-          - "<quel> sont les (<capteur>|<appareil>) [qui] [sont] {bs_heat_states:state} [<dans> <area>]"
-          - "liste les (<capteur>|<appareil>) [qui] [sont] {bs_heat_states:state} [<dans> <area>]"
+          - "<quel> (<capteur>|<appareil>) [<estil>] {bs_heat_states:state} [<dans> [<le>]{area}]"
+          - "<quel> sont les (<capteur>|<appareil>) [qui] [sont] {bs_heat_states:state} [<dans> [<le>]{area}]"
+          - "liste les (<capteur>|<appareil>) [qui] [sont] {bs_heat_states:state} [<dans> [<le>]{area}]"
         response: which
         slots:
           domain: binary_sensor
@@ -374,8 +374,8 @@ intents:
           state: "on"
 
       - sentences:
-          - "combien (de |d')(<capteur>|<appareil>) [<estil>] {bs_heat_states:state} [<dans> <area>]"
-          - "compte (les |le nombre d('|e ))(<capteur>|<appareil>) [de] [qui sont] {bs_heat_states:state} [<dans> <area>]"
+          - "combien (de |d')(<capteur>|<appareil>) [<estil>] {bs_heat_states:state} [<dans> [<le>]{area}]"
+          - "compte (les |le nombre d('|e ))(<capteur>|<appareil>) [de] [qui sont] {bs_heat_states:state} [<dans> [<le>]{area}]"
         response: how_many
         slots:
           domain: binary_sensor
@@ -384,7 +384,7 @@ intents:
 
       # # Light
       - sentences:
-          - "<name> <estil> {bs_light_states:state} [<dans> <area>]"
+          - "[<le>]{name} <estil> {bs_light_states:state} [<dans> [<le>]{area}]"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -394,32 +394,32 @@ intents:
           device_class: light
 
       - sentences:
-          - "[<yatil>] (une |des) lumière[s] {bs_light_states:state} [<dans> <area>]"
-          - "(une|des|de la) lumière[s] [<estil>] {bs_light_states:state} [<dans> <area>]"
+          - "[<yatil>] (une |des) lumière[s] {bs_light_states:state} [<dans> [<le>]{area}]"
+          - "(une|des|de la) lumière[s] [<estil>] {bs_light_states:state} [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: binary_sensor
           device_class: light
 
       - sentences:
-          - "<tous> les lumières <estil> {bs_light_states:state} [<dans> <area>]"
+          - "<tous> les lumières <estil> {bs_light_states:state} [<dans> [<le>]{area}]"
         response: all
         slots:
           domain: binary_sensor
           device_class: light
 
       - sentences:
-          - "<quel> [sont] [les] lumières [qui] [sont] {bs_light_states:state} [<dans> <area>]"
-          - "<quel> lumières [<estil>] {bs_light_states:state} [<dans> <area>]"
-          - "liste les lumières [qui sont] {bs_light_states:state} [<dans> <area>]"
+          - "<quel> [sont] [les] lumières [qui] [sont] {bs_light_states:state} [<dans> [<le>]{area}]"
+          - "<quel> lumières [<estil>] {bs_light_states:state} [<dans> [<le>]{area}]"
+          - "liste les lumières [qui sont] {bs_light_states:state} [<dans> [<le>]{area}]"
         response: which
         slots:
           domain: binary_sensor
           device_class: light
 
       - sentences:
-          - "combien de lumières [<estil>] {bs_light_states:state} [<dans> <area>]"
-          - "compte (les |le nombre de) lumières [qui] [sont] {bs_light_states:state} [<dans> <area>]"
+          - "combien de lumières [<estil>] {bs_light_states:state} [<dans> [<le>]{area}]"
+          - "compte (les |le nombre de) lumières [qui] [sont] {bs_light_states:state} [<dans> [<le>]{area}]"
         response: how_many
         slots:
           domain: binary_sensor
@@ -427,8 +427,8 @@ intents:
 
       # # Lock
       - sentences:
-          - "<name> [<dans> <area>] <estil> {bs_lock_states:state}"
-          - "<name> <estil> {bs_lock_states:state} [<dans> <area>]"
+          - "[<le>]{name} [<dans> [<le>]{area}] <estil> {bs_lock_states:state}"
+          - "[<le>]{name} <estil> {bs_lock_states:state} [<dans> [<le>]{area}]"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -439,8 +439,8 @@ intents:
 
       # # Moisture
       - sentences:
-          - "<name> [<dans> <area>] <estil> {bs_moisture_states:state}"
-          - "<name> <estil> {bs_moisture_states:state} [<dans> <area>]"
+          - "[<le>]{name} [<dans> [<le>]{area}] <estil> {bs_moisture_states:state}"
+          - "[<le>]{name} <estil> {bs_moisture_states:state} [<dans> [<le>]{area}]"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -450,39 +450,39 @@ intents:
           device_class: moisture
 
       - sentences:
-          - "(des|un[e]) (<capteur>|<appareil>) [de détection] [(d'|de )][(eau|innondation|fuite[s]|humidité)] [<estil>] {bs_moisture_states:state} [<dans> <area>]"
-          - "[<yatil>] (des|un[e]) (<capteur>|<appareil>) [de détection] [(d'|de )][(eau|innondation|fuite[s]|humidité)] [qui sont|de] {bs_moisture_states:state} [<dans> <area>]"
+          - "(des|un[e]) (<capteur>|<appareil>) [de détection] [(d'|de )][(eau|innondation|fuite[s]|humidité)] [<estil>] {bs_moisture_states:state} [<dans> [<le>]{area}]"
+          - "[<yatil>] (des|un[e]) (<capteur>|<appareil>) [de détection] [(d'|de )][(eau|innondation|fuite[s]|humidité)] [qui sont|de] {bs_moisture_states:state} [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: binary_sensor
           device_class: moisture
 
       - sentences:
-          - "[<yatil>] (des|un[e]) {bs_moisture_states:state} [<dans> <area>]"
+          - "[<yatil>] (des|un[e]) {bs_moisture_states:state} [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: binary_sensor
           device_class: moisture
 
       - sentences:
-          - "<tous> les (<capteur>|<appareil>) [de détection] [(d'|de )][(eau|innondation|fuite[s]|humidité)] <estil> {bs_moisture_states:state} [<dans> <area>]"
+          - "<tous> les (<capteur>|<appareil>) [de détection] [(d'|de )][(eau|innondation|fuite[s]|humidité)] <estil> {bs_moisture_states:state} [<dans> [<le>]{area}]"
         response: all
         slots:
           domain: binary_sensor
           device_class: moisture
 
       - sentences:
-          - "<quel> (<capteur>|<appareil>) [de détection] [(d'|de )][(eau|innondation|fuite[s]|humidité)] [<estil>] {bs_moisture_states:state} [<dans> <area>]"
-          - "<quel> [sont] [les] (<capteur>|<appareil>) [de détection] [(d'|de )][(eau|innondation|fuite[s]|humidité)] [qui sont] {bs_moisture_states:state} [<dans> <area>]"
-          - "liste les (<capteur>|<appareil>) [de détection] [(d'|de )][(eau|innondation|fuite[s]|humidité)] [qui sont] {bs_moisture_states:state} [<dans> <area>]"
+          - "<quel> (<capteur>|<appareil>) [de détection] [(d'|de )][(eau|innondation|fuite[s]|humidité)] [<estil>] {bs_moisture_states:state} [<dans> [<le>]{area}]"
+          - "<quel> [sont] [les] (<capteur>|<appareil>) [de détection] [(d'|de )][(eau|innondation|fuite[s]|humidité)] [qui sont] {bs_moisture_states:state} [<dans> [<le>]{area}]"
+          - "liste les (<capteur>|<appareil>) [de détection] [(d'|de )][(eau|innondation|fuite[s]|humidité)] [qui sont] {bs_moisture_states:state} [<dans> [<le>]{area}]"
         response: which
         slots:
           domain: binary_sensor
           device_class: moisture
 
       - sentences:
-          - "combien de (<capteur>|<appareil>) [de détection] [(d'|de )][(eau|innondation|fuite[s]|humidité)] [<estil>] {bs_moisture_states:state} [<dans> <area>]"
-          - "compte (les |le nombre d('|e ))(<capteur>|<appareil>) [de détection] [(d'|de )][(eau|innondation|fuite[s]|humidité)] [qui] [sont] {bs_moisture_states:state} [<dans> <area>]"
+          - "combien de (<capteur>|<appareil>) [de détection] [(d'|de )][(eau|innondation|fuite[s]|humidité)] [<estil>] {bs_moisture_states:state} [<dans> [<le>]{area}]"
+          - "compte (les |le nombre d('|e ))(<capteur>|<appareil>) [de détection] [(d'|de )][(eau|innondation|fuite[s]|humidité)] [qui] [sont] {bs_moisture_states:state} [<dans> [<le>]{area}]"
         response: how_many
         slots:
           domain: binary_sensor
@@ -490,8 +490,8 @@ intents:
 
       # # Motion
       - sentences:
-          - "<name> <estil> {bs_motion_states:state} [<dans> <area>]"
-          - "<name> [<dans> <area>] <estil> {bs_motion_states:state}"
+          - "[<le>]{name} <estil> {bs_motion_states:state} [<dans> [<le>]{area}]"
+          - "[<le>]{name} [<dans> [<le>]{area}] <estil> {bs_motion_states:state}"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -501,40 +501,40 @@ intents:
           device_class: motion
 
       - sentences:
-          - "[<yatil>] (des|un|du) [(capteur|détecteur)[s] de mouvement] {bs_motion_states:state} [<dans> <area>]"
+          - "[<yatil>] (des|un|du) [(capteur|détecteur)[s] de mouvement] {bs_motion_states:state} [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: binary_sensor
           device_class: motion
 
       - sentences:
-          - "(des|un|du) {bs_motion_states:state} [<estil>] [détecté[s]] [<dans> <area>]"
-          - "[<yatil>] (des|un|du) {bs_motion_states:state} [détecté[s]] [<dans> <area>]"
+          - "(des|un|du) {bs_motion_states:state} [<estil>] [détecté[s]] [<dans> [<le>]{area}]"
+          - "[<yatil>] (des|un|du) {bs_motion_states:state} [détecté[s]] [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: binary_sensor
           device_class: motion
 
       - sentences:
-          - "<tous> les (capteur|détecteur)[s] de mouvement <estil> {bs_motion_states:state} [<dans> <area>]"
+          - "<tous> les (capteur|détecteur)[s] de mouvement <estil> {bs_motion_states:state} [<dans> [<le>]{area}]"
         response: all
         slots:
           domain: binary_sensor
           device_class: motion
 
       - sentences:
-          - "<quel> (capteur|détecteur)[s] de mouvement [<estil>] {bs_motion_states:state} [<dans> <area>]"
-          - "<quel> [sont] [les] (capteur|détecteur)[s] de mouvement [qui sont] {bs_motion_states:state} [<dans> <area>]"
-          - "liste [sont] [les] (capteur|détecteur)[s] de mouvement [qui] [<estil>] {bs_motion_states:state} [<dans> <area>]"
-          - "Où du mouvement [<estil>] {bs_motion_states:state} [<dans> <area>]"
+          - "<quel> (capteur|détecteur)[s] de mouvement [<estil>] {bs_motion_states:state} [<dans> [<le>]{area}]"
+          - "<quel> [sont] [les] (capteur|détecteur)[s] de mouvement [qui sont] {bs_motion_states:state} [<dans> [<le>]{area}]"
+          - "liste [sont] [les] (capteur|détecteur)[s] de mouvement [qui] [<estil>] {bs_motion_states:state} [<dans> [<le>]{area}]"
+          - "Où du mouvement [<estil>] {bs_motion_states:state} [<dans> [<le>]{area}]"
         response: which
         slots:
           domain: binary_sensor
           device_class: motion
 
       - sentences:
-          - "combien de (capteur|détecteur)[s] de mouvement [<estil>] {bs_motion_states:state} [<dans> <area>]"
-          - "compte (les |le nombre de) (capteur|détecteur)[s] de mouvement [qui] [sont] {bs_motion_states:state} [<dans> <area>]"
+          - "combien de (capteur|détecteur)[s] de mouvement [<estil>] {bs_motion_states:state} [<dans> [<le>]{area}]"
+          - "compte (les |le nombre de) (capteur|détecteur)[s] de mouvement [qui] [sont] {bs_motion_states:state} [<dans> [<le>]{area}]"
         response: how_many
         slots:
           domain: binary_sensor
@@ -542,8 +542,8 @@ intents:
 
       # # Occupancy
       - sentences:
-          - "[le] [(capteur|détecteur)][s] [de] <name> <estil> {bs_occupancy_states:state} [<dans> <area>]"
-          - "[le] [(capteur|détecteur)][s] [de] <name> [<dans> <area>] <estil> {bs_occupancy_states:state}"
+          - "[le] [(capteur|détecteur)][s] [de] [<le>]{name} <estil> {bs_occupancy_states:state} [<dans> [<le>]{area}]"
+          - "[le] [(capteur|détecteur)][s] [de] [<le>]{name} [<dans> [<le>]{area}] <estil> {bs_occupancy_states:state}"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -553,16 +553,16 @@ intents:
           device_class: occupancy
 
       - sentences:
-          - "[<yatil>] (des|un|du) [(capteur|détecteur)[s] de présence] {bs_occupancy_states:state} [<dans> <area>]"
-          - "<area> <estil> {bs_occupancy_states:state}"
+          - "[<yatil>] (des|un|du) [(capteur|détecteur)[s] de présence] {bs_occupancy_states:state} [<dans> [<le>]{area}]"
+          - "[<le>]{area} <estil> {bs_occupancy_states:state}"
         response: any
         slots:
           domain: binary_sensor
           device_class: occupancy
 
       - sentences:
-          - "[<yatil>] (quelqu'un|(une|des) personne[s]) [de] [détecté[e]s] [<dans> <area>]"
-          - "(quelqu'un|(une|des) personne[s]) [<estil>] [détecté[e]s] [<dans> <area>]"
+          - "[<yatil>] (quelqu'un|(une|des) personne[s]) [de] [détecté[e]s] [<dans> [<le>]{area}]"
+          - "(quelqu'un|(une|des) personne[s]) [<estil>] [détecté[e]s] [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: binary_sensor
@@ -570,24 +570,24 @@ intents:
           state: "on"
 
       - sentences:
-          - "<tous> les (capteur|détecteur)[s] de présence <estil> {bs_occupancy_states:state} [<dans> <area>]"
+          - "<tous> les (capteur|détecteur)[s] de présence <estil> {bs_occupancy_states:state} [<dans> [<le>]{area}]"
         response: all
         slots:
           domain: binary_sensor
           device_class: occupancy
 
       - sentences:
-          - "<quel> (capteur|détecteur)[s] de présence [<estil>] {bs_occupancy_states:state} [<dans> <area>]"
-          - "<quel> sont les (capteur|détecteur)[s] de présence [qui] [sont] {bs_occupancy_states:state} [<dans> <area>]"
-          - "liste les (capteur|détecteur)[s] de présence [qui] [<estil>] {bs_occupancy_states:state} [<dans> <area>]"
+          - "<quel> (capteur|détecteur)[s] de présence [<estil>] {bs_occupancy_states:state} [<dans> [<le>]{area}]"
+          - "<quel> sont les (capteur|détecteur)[s] de présence [qui] [sont] {bs_occupancy_states:state} [<dans> [<le>]{area}]"
+          - "liste les (capteur|détecteur)[s] de présence [qui] [<estil>] {bs_occupancy_states:state} [<dans> [<le>]{area}]"
         response: which
         slots:
           domain: binary_sensor
           device_class: occupancy
 
       - sentences:
-          - "combien de (capteur|détecteur)[s] de présence [<estil>] {bs_occupancy_states:state} [<dans> <area>]"
-          - "compte (les |le nombre de) (capteur|détecteur)[s] de présence [qui] [sont] {bs_occupancy_states:state} [<dans> <area>]"
+          - "combien de (capteur|détecteur)[s] de présence [<estil>] {bs_occupancy_states:state} [<dans> [<le>]{area}]"
+          - "compte (les |le nombre de) (capteur|détecteur)[s] de présence [qui] [sont] {bs_occupancy_states:state} [<dans> [<le>]{area}]"
         response: how_many
         slots:
           domain: binary_sensor
@@ -595,7 +595,7 @@ intents:
 
       # # Opening
       - sentences:
-          - "<name> <estil> {bs_opening_states:state} [<dans> <area>]"
+          - "[<le>]{name} <estil> {bs_opening_states:state} [<dans> [<le>]{area}]"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -605,33 +605,33 @@ intents:
           device_class: opening
 
       - sentences:
-          - "[<yatil>] (des|un[e]) ouverture[s] [qui est] {bs_opening_states:state} [<dans> <area>]"
-          - "(des|un[e]) ouverture[s] [<estil>] {bs_opening_states:state} [<dans> <area>]"
+          - "[<yatil>] (des|un[e]) ouverture[s] [qui est] {bs_opening_states:state} [<dans> [<le>]{area}]"
+          - "(des|un[e]) ouverture[s] [<estil>] {bs_opening_states:state} [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: binary_sensor
           device_class: opening
 
       - sentences:
-          - "<tous> les ouverture[s] [<dans> <area>] <estil> {bs_opening_states:state}"
-          - "<tous> les ouverture[s] <estil> {bs_opening_states:state} [<dans> <area>]"
+          - "<tous> les ouverture[s] [<dans> [<le>]{area}] <estil> {bs_opening_states:state}"
+          - "<tous> les ouverture[s] <estil> {bs_opening_states:state} [<dans> [<le>]{area}]"
         response: all
         slots:
           domain: binary_sensor
           device_class: opening
 
       - sentences:
-          - "<quel> sont [les] ouverture[s] [qui sont] {bs_opening_states:state} [<dans> <area>]"
-          - "<quel> ouverture[s] [<estil>] {bs_opening_states:state} [<dans> <area>]"
-          - "liste les ouverture[s] [qui] [<estil>] {bs_opening_states:state} [<dans> <area>]"
+          - "<quel> sont [les] ouverture[s] [qui sont] {bs_opening_states:state} [<dans> [<le>]{area}]"
+          - "<quel> ouverture[s] [<estil>] {bs_opening_states:state} [<dans> [<le>]{area}]"
+          - "liste les ouverture[s] [qui] [<estil>] {bs_opening_states:state} [<dans> [<le>]{area}]"
         response: which
         slots:
           domain: binary_sensor
           device_class: opening
 
       - sentences:
-          - "combien d'ouverture[s] [<estil>] {bs_opening_states:state} [<dans> <area>]"
-          - "compte (les |le nombre d')ouverture[s] [qui] [sont] {bs_opening_states:state} [<dans> <area>]"
+          - "combien d'ouverture[s] [<estil>] {bs_opening_states:state} [<dans> [<le>]{area}]"
+          - "compte (les |le nombre d')ouverture[s] [qui] [sont] {bs_opening_states:state} [<dans> [<le>]{area}]"
         response: how_many
         slots:
           domain: binary_sensor
@@ -639,7 +639,7 @@ intents:
 
       # # Plug
       - sentences:
-          - "<name> <estil> {bs_plug_states:state} [<dans> <area>]"
+          - "[<le>]{name} <estil> {bs_plug_states:state} [<dans> [<le>]{area}]"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -649,33 +649,33 @@ intents:
           device_class: plug
 
       - sentences:
-          - "[<yatil>] (des|un[e]) (<capteur>|<appareil>) [qui est] {bs_plug_states:state} [<dans> <area>]"
-          - "(des|un[e]) (<capteur>|<appareil>) [<estil>] {bs_plug_states:state} [<dans> <area>]"
+          - "[<yatil>] (des|un[e]) (<capteur>|<appareil>) [qui est] {bs_plug_states:state} [<dans> [<le>]{area}]"
+          - "(des|un[e]) (<capteur>|<appareil>) [<estil>] {bs_plug_states:state} [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: binary_sensor
           device_class: plug
 
       - sentences:
-          - "<tous> les (<capteur>|<appareil>) [<dans> <area>] <estil> {bs_plug_states:state}"
-          - "<tous> les (<capteur>|<appareil>) <estil> {bs_plug_states:state} [<dans> <area>]"
+          - "<tous> les (<capteur>|<appareil>) [<dans> [<le>]{area}] <estil> {bs_plug_states:state}"
+          - "<tous> les (<capteur>|<appareil>) <estil> {bs_plug_states:state} [<dans> [<le>]{area}]"
         response: all
         slots:
           domain: binary_sensor
           device_class: plug
 
       - sentences:
-          - "<quel> sont [les] (<capteur>|<appareil>) [qui sont] {bs_plug_states:state} [<dans> <area>]"
-          - "<quel> (<capteur>|<appareil>) [<estil>] {bs_plug_states:state} [<dans> <area>]"
-          - "liste les (<capteur>|<appareil>) [qui] [<estil>] {bs_plug_states:state} [<dans> <area>]"
+          - "<quel> sont [les] (<capteur>|<appareil>) [qui sont] {bs_plug_states:state} [<dans> [<le>]{area}]"
+          - "<quel> (<capteur>|<appareil>) [<estil>] {bs_plug_states:state} [<dans> [<le>]{area}]"
+          - "liste les (<capteur>|<appareil>) [qui] [<estil>] {bs_plug_states:state} [<dans> [<le>]{area}]"
         response: which
         slots:
           domain: binary_sensor
           device_class: plug
 
       - sentences:
-          - "combien (d'|de )(<capteur>|<appareil>) [<estil>] {bs_plug_states:state} [<dans> <area>]"
-          - "compte (les |le nombre d')(<capteur>|<appareil>) [qui] [sont] {bs_plug_states:state} [<dans> <area>]"
+          - "combien (d'|de )(<capteur>|<appareil>) [<estil>] {bs_plug_states:state} [<dans> [<le>]{area}]"
+          - "compte (les |le nombre d')(<capteur>|<appareil>) [qui] [sont] {bs_plug_states:state} [<dans> [<le>]{area}]"
         response: how_many
         slots:
           domain: binary_sensor
@@ -683,7 +683,7 @@ intents:
 
       # # Power
       - sentences:
-          - "<name> <estil> {bs_power_states:state} [<dans> <area>]"
+          - "[<le>]{name} <estil> {bs_power_states:state} [<dans> [<le>]{area}]"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -693,33 +693,33 @@ intents:
           device_class: power
 
       - sentences:
-          - "[<yatil>] (des|un[e]) (<capteur>|<appareil>) [qui est] {bs_power_states:state}[<dans> <area>]"
-          - "(des|un[e]) (<capteur>|<appareil>) [<estil>] {bs_power_states:state} [<dans> <area>]"
+          - "[<yatil>] (des|un[e]) (<capteur>|<appareil>) [qui est] {bs_power_states:state}[<dans> [<le>]{area}]"
+          - "(des|un[e]) (<capteur>|<appareil>) [<estil>] {bs_power_states:state} [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: binary_sensor
           device_class: power
 
       - sentences:
-          - "<tous> les (<capteur>|<appareil>) [<dans> <area>] <estil> {bs_power_states:state}"
-          - "<tous> les (<capteur>|<appareil>) <estil> {bs_power_states:state} [<dans> <area>]"
+          - "<tous> les (<capteur>|<appareil>) [<dans> [<le>]{area}] <estil> {bs_power_states:state}"
+          - "<tous> les (<capteur>|<appareil>) <estil> {bs_power_states:state} [<dans> [<le>]{area}]"
         response: all
         slots:
           domain: binary_sensor
           device_class: power
 
       - sentences:
-          - "<quel> sont [les] (<capteur>|<appareil>) [qui sont] {bs_power_states:state} [<dans> <area>]"
-          - "<quel> (<capteur>|<appareil>) [<estil>] {bs_power_states:state} [<dans> <area>]"
-          - "liste les (<capteur>|<appareil>) [qui] [<estil>] {bs_power_states:state} [<dans> <area>]"
+          - "<quel> sont [les] (<capteur>|<appareil>) [qui sont] {bs_power_states:state} [<dans> [<le>]{area}]"
+          - "<quel> (<capteur>|<appareil>) [<estil>] {bs_power_states:state} [<dans> [<le>]{area}]"
+          - "liste les (<capteur>|<appareil>) [qui] [<estil>] {bs_power_states:state} [<dans> [<le>]{area}]"
         response: which
         slots:
           domain: binary_sensor
           device_class: power
 
       - sentences:
-          - "combien (d'|de )(<capteur>|<appareil>) [<estil>] {bs_power_states:state} [<dans> <area>]"
-          - "compte (les |le nombre d')(<capteur>|<appareil>) [qui] [sont] {bs_power_states:state} [<dans> <area>]"
+          - "combien (d'|de )(<capteur>|<appareil>) [<estil>] {bs_power_states:state} [<dans> [<le>]{area}]"
+          - "compte (les |le nombre d')(<capteur>|<appareil>) [qui] [sont] {bs_power_states:state} [<dans> [<le>]{area}]"
         response: how_many
         slots:
           domain: binary_sensor
@@ -727,7 +727,7 @@ intents:
 
       # # Presence
       - sentences:
-          - "<name> <estil> {bs_presence_states:state} [<dans> <area>]"
+          - "[<le>]{name} <estil> {bs_presence_states:state} [<dans> [<le>]{area}]"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -737,33 +737,33 @@ intents:
           device_class: presence
 
       - sentences:
-          - "[<yatil>] (des|un[e]) (<capteur>|<appareil>) [qui est] {bs_presence_states:state} [<dans> <area>]"
-          - "(des|un[e]) (<capteur>|<appareil>) [<estil>] {bs_presence_states:state} [<dans> <area>]"
+          - "[<yatil>] (des|un[e]) (<capteur>|<appareil>) [qui est] {bs_presence_states:state} [<dans> [<le>]{area}]"
+          - "(des|un[e]) (<capteur>|<appareil>) [<estil>] {bs_presence_states:state} [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: binary_sensor
           device_class: presence
 
       - sentences:
-          - "<tous> les (<capteur>|<appareil>) [<dans> <area>] <estil> {bs_presence_states:state}"
-          - "<tous> les (<capteur>|<appareil>) <estil> {bs_presence_states:state} [<dans> <area>]"
+          - "<tous> les (<capteur>|<appareil>) [<dans> [<le>]{area}] <estil> {bs_presence_states:state}"
+          - "<tous> les (<capteur>|<appareil>) <estil> {bs_presence_states:state} [<dans> [<le>]{area}]"
         response: all
         slots:
           domain: binary_sensor
           device_class: presence
 
       - sentences:
-          - "<quel> sont [les] (<capteur>|<appareil>) [qui sont] {bs_presence_states:state} [<dans> <area>]"
-          - "<quel> (<capteur>|<appareil>) [<estil>] {bs_presence_states:state} [<dans> <area>]"
-          - "liste les (<capteur>|<appareil>) [qui] [<estil>] {bs_presence_states:state} [<dans> <area>]"
+          - "<quel> sont [les] (<capteur>|<appareil>) [qui sont] {bs_presence_states:state} [<dans> [<le>]{area}]"
+          - "<quel> (<capteur>|<appareil>) [<estil>] {bs_presence_states:state} [<dans> [<le>]{area}]"
+          - "liste les (<capteur>|<appareil>) [qui] [<estil>] {bs_presence_states:state} [<dans> [<le>]{area}]"
         response: which
         slots:
           domain: binary_sensor
           device_class: presence
 
       - sentences:
-          - "combien (d'|de )(<capteur>|<appareil>) [<estil>] {bs_presence_states:state} [<dans> <area>]"
-          - "compte (les |le nombre d')(<capteur>|<appareil>) [qui] [sont] {bs_presence_states:state} [<dans> <area>]"
+          - "combien (d'|de )(<capteur>|<appareil>) [<estil>] {bs_presence_states:state} [<dans> [<le>]{area}]"
+          - "compte (les |le nombre d')(<capteur>|<appareil>) [qui] [sont] {bs_presence_states:state} [<dans> [<le>]{area}]"
         response: how_many
         slots:
           domain: binary_sensor
@@ -771,8 +771,8 @@ intents:
 
       # # Problem
       - sentences:
-          - "<name> <atil> un problème [<dans> <area>]"
-          - "<yatil> un problème avec <name> [<dans> <area>]"
+          - "[<le>]{name} <atil> un problème [<dans> [<le>]{area}]"
+          - "<yatil> un problème avec [<le>]{name} [<dans> [<le>]{area}]"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -783,9 +783,9 @@ intents:
           state: "on"
 
       - sentences:
-          - "<quel> sont [les] (<capteur>|<appareil>) [qui ont] un problème [<dans> <area>]"
-          - "<quel> (<capteur>|<appareil>) [<atil>] un problème [<dans> <area>]"
-          - "liste les (<capteur>|<appareil>) [qui ont] un problème [<dans> <area>]"
+          - "<quel> sont [les] (<capteur>|<appareil>) [qui ont] un problème [<dans> [<le>]{area}]"
+          - "<quel> (<capteur>|<appareil>) [<atil>] un problème [<dans> [<le>]{area}]"
+          - "liste les (<capteur>|<appareil>) [qui ont] un problème [<dans> [<le>]{area}]"
         response: which
         slots:
           domain: binary_sensor
@@ -794,8 +794,8 @@ intents:
 
       # # Running
       - sentences:
-          - "<name> <estil> {bs_running_states:state} [<dans> <area>]"
-          - "<name> {bs_running_states:state}-t-(il|elle) [<dans> <area>]"
+          - "[<le>]{name} <estil> {bs_running_states:state} [<dans> [<le>]{area}]"
+          - "[<le>]{name} {bs_running_states:state}-t-(il|elle) [<dans> [<le>]{area}]"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -805,35 +805,35 @@ intents:
           device_class: running
 
       - sentences:
-          - "[<yatil>] (des|un[e]) (<capteur>|<appareil>) [qui est] {bs_running_states:state} [<dans> <area>]"
-          - "(des|un[e]) (<capteur>|<appareil>) [<estil>] {bs_running_states:state} [<dans> <area>]"
-          - "(des|un[e]) (<capteur>|<appareil>) {bs_running_states:state}-(il[s]|elle[s]) [<dans> <area>]"
+          - "[<yatil>] (des|un[e]) (<capteur>|<appareil>) [qui est] {bs_running_states:state} [<dans> [<le>]{area}]"
+          - "(des|un[e]) (<capteur>|<appareil>) [<estil>] {bs_running_states:state} [<dans> [<le>]{area}]"
+          - "(des|un[e]) (<capteur>|<appareil>) {bs_running_states:state}-(il[s]|elle[s]) [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: binary_sensor
           device_class: running
 
       - sentences:
-          - "<tous> les (<capteur>|<appareil>) [<dans> <area>] <estil> {bs_running_states:state}"
-          - "<tous> les (<capteur>|<appareil>) <estil> {bs_running_states:state} [<dans> <area>]"
+          - "<tous> les (<capteur>|<appareil>) [<dans> [<le>]{area}] <estil> {bs_running_states:state}"
+          - "<tous> les (<capteur>|<appareil>) <estil> {bs_running_states:state} [<dans> [<le>]{area}]"
         response: all
         slots:
           domain: binary_sensor
           device_class: running
 
       - sentences:
-          - "<quel> sont [les] (<capteur>|<appareil>) [qui sont] {bs_running_states:state} [<dans> <area>]"
-          - "<quel> (<capteur>|<appareil>) [<estil>] {bs_running_states:state} [<dans> <area>]"
-          - "<quel> (<capteur>|<appareil>) {bs_running_states:state}-(il[s]|elle[s]) [<dans> <area>]"
-          - "liste les (<capteur>|<appareil>) [qui] [<estil>] {bs_running_states:state} [<dans> <area>]"
+          - "<quel> sont [les] (<capteur>|<appareil>) [qui sont] {bs_running_states:state} [<dans> [<le>]{area}]"
+          - "<quel> (<capteur>|<appareil>) [<estil>] {bs_running_states:state} [<dans> [<le>]{area}]"
+          - "<quel> (<capteur>|<appareil>) {bs_running_states:state}-(il[s]|elle[s]) [<dans> [<le>]{area}]"
+          - "liste les (<capteur>|<appareil>) [qui] [<estil>] {bs_running_states:state} [<dans> [<le>]{area}]"
         response: which
         slots:
           domain: binary_sensor
           device_class: running
 
       - sentences:
-          - "combien (d'|de )(<capteur>|<appareil>) [<estil>] {bs_running_states:state} [<dans> <area>]"
-          - "compte (les |le nombre d')(<capteur>|<appareil>) [qui] [sont] {bs_running_states:state} [<dans> <area>]"
+          - "combien (d'|de )(<capteur>|<appareil>) [<estil>] {bs_running_states:state} [<dans> [<le>]{area}]"
+          - "compte (les |le nombre d')(<capteur>|<appareil>) [qui] [sont] {bs_running_states:state} [<dans> [<le>]{area}]"
         response: how_many
         slots:
           domain: binary_sensor
@@ -841,7 +841,7 @@ intents:
 
       # # Safety
       - sentences:
-          - "<name> <estil> {bs_safety_states:state} [<dans> <area>]"
+          - "[<le>]{name} <estil> {bs_safety_states:state} [<dans> [<le>]{area}]"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -852,8 +852,8 @@ intents:
 
       # # Smoke
       - sentences:
-          - "<name> <estil> {bs_smoke_states:state} [<dans> <area>]"
-          - "<name> [<dans> <area>] <estil> {bs_smoke_states:state}"
+          - "[<le>]{name} <estil> {bs_smoke_states:state} [<dans> [<le>]{area}]"
+          - "[<le>]{name} [<dans> [<le>]{area}] <estil> {bs_smoke_states:state}"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -863,19 +863,19 @@ intents:
           device_class: smoke
 
       - sentences:
-          - "De la fumée <estil> {bs_smoke_states:state} [<dans> <area>]"
-          - "De la fumée <atil> [été] {bs_smoke_states:state} [<dans> <area>]"
+          - "De la fumée <estil> {bs_smoke_states:state} [<dans> [<le>]{area}]"
+          - "De la fumée <atil> [été] {bs_smoke_states:state} [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: binary_sensor
           device_class: smoke
 
       - sentences:
-          - "[<yatil>] [(un|le) capteur de] fumée [(<estil>|de)] [{bs_smoke_states:state}] [<dans> <area>]"
-          - "une alerte incendie <atil> été [{bs_smoke_states:state}] [<dans> <area>]"
-          - "[<yatil>] <de> la fumée [de] [{bs_smoke_states:state}] [<dans> <area>]"
-          - "[<yatil>] une alerte incendie [{bs_smoke_states:state}] [<dans> <area>]"
-          - "une alerte incendie <estil> [{bs_smoke_states:state}] [<dans> <area>]"
+          - "[<yatil>] [(un|le) capteur de] fumée [(<estil>|de)] [{bs_smoke_states:state}] [<dans> [<le>]{area}]"
+          - "une alerte incendie <atil> été [{bs_smoke_states:state}] [<dans> [<le>]{area}]"
+          - "[<yatil>] <de> la fumée [de] [{bs_smoke_states:state}] [<dans> [<le>]{area}]"
+          - "[<yatil>] une alerte incendie [{bs_smoke_states:state}] [<dans> [<le>]{area}]"
+          - "une alerte incendie <estil> [{bs_smoke_states:state}] [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: binary_sensor
@@ -883,17 +883,17 @@ intents:
           state: "on"
 
       - sentences:
-          - "[<tous>] [les] capteurs [de] fumée <estil> {bs_smoke_states:state} [<dans> <area>]"
+          - "[<tous>] [les] capteurs [de] fumée <estil> {bs_smoke_states:state} [<dans> [<le>]{area}]"
         response: all
         slots:
           domain: binary_sensor
           device_class: smoke
 
       - sentences:
-          - "<quel> [sont les] capteur[s] [de] fumée [au statut] {bs_smoke_states:state} [<dans> <area>]"
-          - "<quel> [sont les] capteur[s] [de] fumée [qui] [sont] {bs_smoke_states:state} [<dans> <area>]"
-          - "<quel> capteur[s] [de] fumée <estil> {bs_smoke_states:state} [<dans> <area>]"
-          - "liste les capteur[s] [de] fumée [qui sont] {bs_smoke_states:state} [<dans> <area>]"
+          - "<quel> [sont les] capteur[s] [de] fumée [au statut] {bs_smoke_states:state} [<dans> [<le>]{area}]"
+          - "<quel> [sont les] capteur[s] [de] fumée [qui] [sont] {bs_smoke_states:state} [<dans> [<le>]{area}]"
+          - "<quel> capteur[s] [de] fumée <estil> {bs_smoke_states:state} [<dans> [<le>]{area}]"
+          - "liste les capteur[s] [de] fumée [qui sont] {bs_smoke_states:state} [<dans> [<le>]{area}]"
           - "Où de la fumée <estil> {bs_smoke_states:state} "
         response: which
         slots:
@@ -901,8 +901,8 @@ intents:
           device_class: smoke
 
       - sentences:
-          - "combien de capteur[s] [de] fumée [<estil>] {bs_smoke_states:state} [<dans> <area>]"
-          - "compte (les |le nombre de) capteur[s] [de] fumée [qui sont] {bs_smoke_states:state} [<dans> <area>]"
+          - "combien de capteur[s] [de] fumée [<estil>] {bs_smoke_states:state} [<dans> [<le>]{area}]"
+          - "compte (les |le nombre de) capteur[s] [de] fumée [qui sont] {bs_smoke_states:state} [<dans> [<le>]{area}]"
         response: how_many
         slots:
           domain: binary_sensor
@@ -910,8 +910,8 @@ intents:
 
       # # Sound
       - sentences:
-          - "<name> <estil> {bs_sound_states:state} [<dans> <area>]"
-          - "<name> [<dans> <area>] <estil> {bs_sound_states:state}"
+          - "[<le>]{name} <estil> {bs_sound_states:state} [<dans> [<le>]{area}]"
+          - "[<le>]{name} [<dans> [<le>]{area}] <estil> {bs_sound_states:state}"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -921,19 +921,19 @@ intents:
           device_class: sound
 
       - sentences:
-          - "(Du bruit|Un son) <estil> {bs_sound_states:state} [<dans> <area>]"
-          - "(Du bruit|Un son) <atil> [été] {bs_sound_states:state} [<dans> <area>]"
+          - "(Du bruit|Un son) <estil> {bs_sound_states:state} [<dans> [<le>]{area}]"
+          - "(Du bruit|Un son) <atil> [été] {bs_sound_states:state} [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: binary_sensor
           device_class: sound
 
       - sentences:
-          - "[<yatil>] [(un|le) capteur de] (son|bruit) [(<estil>|de)] [{bs_sound_states:state}] [<dans> <area>]"
-          - "une sirène <atil> été [{bs_sound_states:state}] [<dans> <area>]"
-          - "[<yatil>] du (son|bruit) [de] [{bs_sound_states:state}] [<dans> <area>]"
-          - "[<yatil>] une sirène [{bs_sound_states:state}] [<dans> <area>]"
-          - "une sirène <estil> [{bs_sound_states:state}] [<dans> <area>]"
+          - "[<yatil>] [(un|le) capteur de] (son|bruit) [(<estil>|de)] [{bs_sound_states:state}] [<dans> [<le>]{area}]"
+          - "une sirène <atil> été [{bs_sound_states:state}] [<dans> [<le>]{area}]"
+          - "[<yatil>] du (son|bruit) [de] [{bs_sound_states:state}] [<dans> [<le>]{area}]"
+          - "[<yatil>] une sirène [{bs_sound_states:state}] [<dans> [<le>]{area}]"
+          - "une sirène <estil> [{bs_sound_states:state}] [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: binary_sensor
@@ -941,17 +941,17 @@ intents:
           state: "on"
 
       - sentences:
-          - "[<tous>] [les] capteurs [de] (son|bruit) <estil> {bs_sound_states:state} [<dans> <area>]"
+          - "[<tous>] [les] capteurs [de] (son|bruit) <estil> {bs_sound_states:state} [<dans> [<le>]{area}]"
         response: all
         slots:
           domain: binary_sensor
           device_class: sound
 
       - sentences:
-          - "<quel> [sont les] capteur[s] de (son|bruit) [au statut] {bs_sound_states:state} [<dans> <area>]"
-          - "<quel> [sont les] capteur[s] de (son|bruit) [qui] [sont] {bs_sound_states:state} [<dans> <area>]"
-          - "<quel> capteur[s] de (son|bruit) <estil> {bs_sound_states:state} [<dans> <area>]"
-          - "liste les capteur[s] de (son|bruit)[qui sont] {bs_sound_states:state} [<dans> <area>]"
+          - "<quel> [sont les] capteur[s] de (son|bruit) [au statut] {bs_sound_states:state} [<dans> [<le>]{area}]"
+          - "<quel> [sont les] capteur[s] de (son|bruit) [qui] [sont] {bs_sound_states:state} [<dans> [<le>]{area}]"
+          - "<quel> capteur[s] de (son|bruit) <estil> {bs_sound_states:state} [<dans> [<le>]{area}]"
+          - "liste les capteur[s] de (son|bruit)[qui sont] {bs_sound_states:state} [<dans> [<le>]{area}]"
           - "Où du (son|bruit) <estil> {bs_sound_states:state}"
         response: which
         slots:
@@ -959,8 +959,8 @@ intents:
           device_class: sound
 
       - sentences:
-          - "combien de capteur[s] de (son|bruit) [<estil>] {bs_sound_states:state} [<dans> <area>]"
-          - "compte (les |le nombre de) capteur[s] de (son|bruit) [qui sont] {bs_sound_states:state} [<dans> <area>]"
+          - "combien de capteur[s] de (son|bruit) [<estil>] {bs_sound_states:state} [<dans> [<le>]{area}]"
+          - "compte (les |le nombre de) capteur[s] de (son|bruit) [qui sont] {bs_sound_states:state} [<dans> [<le>]{area}]"
         response: how_many
         slots:
           domain: binary_sensor
@@ -968,8 +968,8 @@ intents:
 
       # # Tamper
       - sentences:
-          - "<name> <estil> {bs_tamper_states:state} [<dans> <area>]"
-          - "<name> [<dans> <area>] <estil> {bs_tamper_states:state}"
+          - "[<le>]{name} <estil> {bs_tamper_states:state} [<dans> [<le>]{area}]"
+          - "[<le>]{name} [<dans> [<le>]{area}] <estil> {bs_tamper_states:state}"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -980,8 +980,8 @@ intents:
 
       # # Update
       - sentences:
-          - "<name> <estil> {bs_update_states:state} [<dans> <area>]"
-          - "<name> [<dans> <area>] <estil> {bs_update_states:state}"
+          - "[<le>]{name} <estil> {bs_update_states:state} [<dans> [<le>]{area}]"
+          - "[<le>]{name} [<dans> [<le>]{area}] <estil> {bs_update_states:state}"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -991,9 +991,9 @@ intents:
           device_class: update
 
       - sentences:
-          - "[<yatil>] (une|des) mise[s] à jour [de (firmware|driver|pilote|logiciel)[s]] [de] {bs_update_states:state} [<dans> <area>]"
-          - "(une|des) mise[s] à jour [de (firmware|driver|pilote|logiciel)[s]] <estil> {bs_update_states:state} [<dans> <area>]"
-          - "[<yatil> une] {bs_update_states:state} [<dans> <area>]"
+          - "[<yatil>] (une|des) mise[s] à jour [de (firmware|driver|pilote|logiciel)[s]] [de] {bs_update_states:state} [<dans> [<le>]{area}]"
+          - "(une|des) mise[s] à jour [de (firmware|driver|pilote|logiciel)[s]] <estil> {bs_update_states:state} [<dans> [<le>]{area}]"
+          - "[<yatil> une] {bs_update_states:state} [<dans> [<le>]{area}]"
 
         response: any
         slots:
@@ -1002,9 +1002,9 @@ intents:
           state: "on"
 
       - sentences:
-          - "<quel> [sont les] mise[s] à jour [de (firmware|logiciel)] {bs_update_states:state} [<dans> <area>]"
-          - "<quel> mise[s] à jour [de (firmware[s]|logiciel[le][s])] <estil> {bs_update_states:state} [<dans> <area>]"
-          - "liste les mises à jour [de (firmware[s]|logiciel[le][s])] [qui sont] {bs_update_states:state} [<dans> <area>]"
+          - "<quel> [sont les] mise[s] à jour [de (firmware|logiciel)] {bs_update_states:state} [<dans> [<le>]{area}]"
+          - "<quel> mise[s] à jour [de (firmware[s]|logiciel[le][s])] <estil> {bs_update_states:state} [<dans> [<le>]{area}]"
+          - "liste les mises à jour [de (firmware[s]|logiciel[le][s])] [qui sont] {bs_update_states:state} [<dans> [<le>]{area}]"
         response: which
         slots:
           domain: binary_sensor
@@ -1012,8 +1012,8 @@ intents:
           state: "on"
 
       - sentences:
-          - "combien de mises à jour [de (firmware[s]|logiciel[le][s])] [<estil>] {bs_update_states:state} [<dans> <area>]"
-          - "compte (les |le nombre de) mises à jour [de (firmware[s]|logiciel[le][s])] [qui sont] {bs_update_states:state} [<dans> <area>]"
+          - "combien de mises à jour [de (firmware[s]|logiciel[le][s])] [<estil>] {bs_update_states:state} [<dans> [<le>]{area}]"
+          - "compte (les |le nombre de) mises à jour [de (firmware[s]|logiciel[le][s])] [qui sont] {bs_update_states:state} [<dans> [<le>]{area}]"
         response: how_many
         slots:
           domain: binary_sensor
@@ -1022,8 +1022,8 @@ intents:
 
       # # Vibration
       - sentences:
-          - "<name> {bs_vibration_states:state}[-t-(il|elle)] [<dans> <area>]"
-          - "<name> [<dans> <area>] <estil> [entrain de] {bs_vibration_states:state}"
+          - "[<le>]{name} {bs_vibration_states:state}[-t-(il|elle)] [<dans> [<le>]{area}]"
+          - "[<le>]{name} [<dans> [<le>]{area}] <estil> [entrain de] {bs_vibration_states:state}"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -1033,7 +1033,7 @@ intents:
           device_class: vibration
 
       - sentences:
-          - "(un[e]|du|de[s]|quelque chose) [(<capteur>|<appareil>)] vibre[nt][-t][-(il|elle)] [<dans> <area>]"
+          - "(un[e]|du|de[s]|quelque chose) [(<capteur>|<appareil>)] vibre[nt][-t][-(il|elle)] [<dans> [<le>]{area}]"
         response: any
         requires_context:
           domain: binary_sensor
@@ -1045,7 +1045,7 @@ intents:
 
       # # Window
       - sentences:
-          - "<name> <estil> {bs_window_states:state} [in <area>]"
+          - "[<le>]{name} <estil> {bs_window_states:state} [in [<le>]{area}]"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -1055,33 +1055,33 @@ intents:
           device_class: window
 
       - sentences:
-          - "[<yatil>] (des|un[e]) <fenetre> [qui sont] {bs_window_states:state} [<dans> <area>]"
-          - "(des|un[e]) <fenetre> [<estil>] {bs_window_states:state} [<dans> <area>]"
+          - "[<yatil>] (des|un[e]) <fenetre> [qui sont] {bs_window_states:state} [<dans> [<le>]{area}]"
+          - "(des|un[e]) <fenetre> [<estil>] {bs_window_states:state} [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: binary_sensor
           device_class: window
 
       - sentences:
-          - "<tous> les <fenetre> <estil> {bs_window_states:state} [<dans> <area>]"
-          - "<tous> les <fenetre> [<dans> <area>] <estil> {bs_window_states:state}"
+          - "<tous> les <fenetre> <estil> {bs_window_states:state} [<dans> [<le>]{area}]"
+          - "<tous> les <fenetre> [<dans> [<le>]{area}] <estil> {bs_window_states:state}"
         response: all
         slots:
           domain: binary_sensor
           device_class: window
 
       - sentences:
-          - "<quel> [sont] [les] <fenetre> [qui sont] {bs_window_states:state} [<dans> <area>]"
-          - "<quel> <fenetre> [<estil>] {bs_window_states:state} [<dans> <area>]"
-          - "liste les <fenetre> [qui sont] {bs_window_states:state} [<dans> <area>]"
+          - "<quel> [sont] [les] <fenetre> [qui sont] {bs_window_states:state} [<dans> [<le>]{area}]"
+          - "<quel> <fenetre> [<estil>] {bs_window_states:state} [<dans> [<le>]{area}]"
+          - "liste les <fenetre> [qui sont] {bs_window_states:state} [<dans> [<le>]{area}]"
         response: which
         slots:
           domain: binary_sensor
           device_class: window
 
       - sentences:
-          - "combien de <fenetre> [<estil>] {bs_window_states:state} [<dans> <area>]"
-          - "compte les <fenetre> [qui] [sont] {bs_window_states:state} [<dans> <area>]"
+          - "combien de <fenetre> [<estil>] {bs_window_states:state} [<dans> [<le>]{area}]"
+          - "compte les <fenetre> [qui] [sont] {bs_window_states:state} [<dans> [<le>]{area}]"
         response: how_many
         slots:
           domain: binary_sensor

--- a/sentences/fr/climate_HassClimateGetTemperature.yaml
+++ b/sentences/fr/climate_HassClimateGetTemperature.yaml
@@ -3,5 +3,5 @@ intents:
   HassClimateGetTemperature:
     data:
       - sentences:
-          - "Quelle est la température [<dans>] [<area>]"
-          - "Combien fait-il [<dans>] [<area>]"
+          - "Quelle est la température [<dans>] [[<le>]{area}]"
+          - "Combien fait-il [<dans>] [[<le>]{area}]"

--- a/sentences/fr/climate_HassClimateSetTemperature.yaml
+++ b/sentences/fr/climate_HassClimateSetTemperature.yaml
@@ -3,6 +3,6 @@ intents:
   HassClimateSetTemperature:
     data:
       - sentences:
-          - "<regle> [la] température à <temperature>"
-          - "<regle> [la] température à <temperature> <dans> <area>"
-          - "<regle> [la] température <dans> <area> à <temperature>"
+          - "<regle> [la] température à {temperature}<degres>[ ][{temperature_unit}]"
+          - "<regle> [la] température à {temperature}<degres>[ ][{temperature_unit}] <dans> <area>"
+          - "<regle> [la] température <dans> <area> à {temperature}<degres>[ ][{temperature_unit}]"

--- a/sentences/fr/climate_HassClimateSetTemperature.yaml
+++ b/sentences/fr/climate_HassClimateSetTemperature.yaml
@@ -4,5 +4,5 @@ intents:
     data:
       - sentences:
           - "<regle> [la] température à {temperature}<degres>[ ][{temperature_unit}]"
-          - "<regle> [la] température à {temperature}<degres>[ ][{temperature_unit}] <dans> <area>"
-          - "<regle> [la] température <dans> <area> à {temperature}<degres>[ ][{temperature_unit}]"
+          - "<regle> [la] température à {temperature}<degres>[ ][{temperature_unit}] <dans> [<le>]{area}"
+          - "<regle> [la] température <dans> [<le>]{area} à {temperature}<degres>[ ][{temperature_unit}]"

--- a/sentences/fr/cover_HassGetState.yaml
+++ b/sentences/fr/cover_HassGetState.yaml
@@ -3,7 +3,7 @@ intents:
   HassGetState:
     data:
       - sentences:
-          - "<name> (est|est-il) {cover_states:state} [dans <area>]"
+          - "[<le>]{name} (est|est-il) {cover_states:state} [dans [<le>]{area}]"
         response: one_yesno
         requires_context:
           domain: cover
@@ -11,31 +11,31 @@ intents:
           domain: cover
 
       - sentences:
-          - "[Y a-t-il][il y a] (des|certains) {cover_classes:device_class} {cover_states:state} [dans <area>]"
+          - "[Y a-t-il][il y a] (des|certains) {cover_classes:device_class} {cover_states:state} [dans [<le>]{area}]"
         response: any
         slots:
           domain: cover
 
       - sentences:
-          - "certains des {cover_classes:device_class} [<dans>] [<area>] [sont-ils] {cover_states:state}"
+          - "certains des {cover_classes:device_class} [<dans>] [[<le>]{area}] [sont-ils] {cover_states:state}"
         response: any
         slots:
           domain: cover
 
       - sentences:
-          - "tous [les] {cover_classes:device_class} [sont|sont-ils] {cover_states:state} [<dans> <area>]"
+          - "tous [les] {cover_classes:device_class} [sont|sont-ils] {cover_states:state} [<dans> [<le>]{area}]"
         response: all
         slots:
           domain: cover
 
       - sentences:
-          - "(quel|quels) {cover_classes:device_class} (sont) {cover_states:state} [<dans> <area>]"
+          - "(quel|quels) {cover_classes:device_class} (sont) {cover_states:state} [<dans> [<le>]{area}]"
         response: which
         slots:
           domain: cover
 
       - sentences:
-          - "combien [Y a-t-il][il y a] de {cover_classes:device_class} [(sont|sont-ils|de)] {cover_states:state} [<dans> <area>]"
+          - "combien [Y a-t-il][il y a] de {cover_classes:device_class} [(sont|sont-ils|de)] {cover_states:state} [<dans> [<le>]{area}]"
         response: how_many
         slots:
           domain: cover

--- a/sentences/fr/cover_HassTurnOff.yaml
+++ b/sentences/fr/cover_HassTurnOff.yaml
@@ -9,7 +9,7 @@ intents:
           device_class: garage
           domain: cover
       - sentences:
-          - <ferme> [tous] (<volets>|<volet>) <dans> <area>
+          - <ferme> [tous] (<volets>|<volet>) <dans> [<le>]{area}
         response: covers
         slots:
           device_class:

--- a/sentences/fr/cover_HassTurnOn.yaml
+++ b/sentences/fr/cover_HassTurnOn.yaml
@@ -9,7 +9,7 @@ intents:
           device_class: garage
           domain: cover
       - sentences:
-          - <ouvre> [tous] (<volets>|<volet>) <dans> <area>
+          - <ouvre> [tous] (<volets>|<volet>) <dans> [<le>]{area}
         response: covers
         slots:
           device_class:

--- a/sentences/fr/fan_HassTurnOff.yaml
+++ b/sentences/fr/fan_HassTurnOff.yaml
@@ -3,13 +3,13 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "<eteins> [tous] <ventilateurs> <dans> [<area>]"
+          - "<eteins> [tous] <ventilateurs> <dans> [[<le>]{area}]"
         slots:
           domain: fan
           name: all
         response: fans
       - sentences:
-          - "<eteins> <ventilateur> [<dans>] [<area>]"
+          - "<eteins> <ventilateur> [<dans>] [[<le>]{area}]"
         slots:
           domain: fan
         response: fans

--- a/sentences/fr/fan_HassTurnOn.yaml
+++ b/sentences/fr/fan_HassTurnOn.yaml
@@ -3,13 +3,13 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "<allume> [tous] (<ventilateur> | <ventilateurs>) <dans> [<area>]"
+          - "<allume> [tous] (<ventilateur> | <ventilateurs>) <dans> [[<le>]{area}]"
         slots:
           domain: fan
           name: all
         response: fans
       - sentences:
-          - "<allume> (<ventilateur> | <ventilateurs>) [<dans>] [<area>]"
+          - "<allume> (<ventilateur> | <ventilateurs>) [<dans>] [[<le>]{area}]"
         slots:
           domain: fan
         response: fans

--- a/sentences/fr/homeassistant_HassGetState.yaml
+++ b/sentences/fr/homeassistant_HassGetState.yaml
@@ -3,10 +3,10 @@ intents:
   HassGetState:
     data:
       - sentences:
-          - <quel> est [(l'(e|é)tat|le statut|la valeur) de] <name> [<dans> <area>]
-          - dans <quel> (e|é)tat est <name> [<dans> <area>]
-          - comment (va|est) <name> [<dans> <area>]
-          - donne(-| )moi [(l'(e|é)tat|le statut|la valeur) de] <name> [<dans> <area>]
+          - <quel> est [(l'(e|é)tat|le statut|la valeur) de] [<le>]{name} [<dans> [<le>]{area}]
+          - dans <quel> (e|é)tat est [<le>]{name} [<dans> [<le>]{area}]
+          - comment (va|est) [<le>]{name} [<dans> [<le>]{area}]
+          - donne(-| )moi [(l'(e|é)tat|le statut|la valeur) de] [<le>]{name} [<dans> [<le>]{area}]
         response: one
         excludes_context:
           domain:
@@ -14,25 +14,25 @@ intents:
             - script
 
       - sentences:
-          - <name> [<dans> <area>] <estil> {on_off_states:state}
+          - "[<le>]{name} [<dans> [<le>]{area}] <estil> {on_off_states:state}"
         response: one_yesno
         excludes_context:
           domain:
             - cover
 
       - sentences:
-          - certain[e]s {on_off_domains:domain} [<estil>] {on_off_states:state} [<dans> <area>]
+          - certain[e]s {on_off_domains:domain} [<estil>] {on_off_states:state} [<dans> [<le>]{area}]
         response: any
 
       - sentences:
-          - <tous> les {on_off_domains:domain} <estil> {on_off_states:state} [<dans> <area>]
+          - <tous> les {on_off_domains:domain} <estil> {on_off_states:state} [<dans> [<le>]{area}]
         response: all
 
       - sentences:
-          - <quel> sont les {on_off_domains:domain} {on_off_states:state} [<dans> <area>]
+          - <quel> sont les {on_off_domains:domain} {on_off_states:state} [<dans> [<le>]{area}]
         response: which
 
       - sentences:
-          - combien <yatil> de {on_off_domains:domain} [d']{on_off_states:state} [<dans> <area>]
-          - combien de {on_off_domains:domain} [<estil>] [d']{on_off_states:state} [<dans> <area>]
+          - combien <yatil> de {on_off_domains:domain} [d']{on_off_states:state} [<dans> [<le>]{area}]
+          - combien de {on_off_domains:domain} [<estil>] [d']{on_off_states:state} [<dans> [<le>]{area}]
         response: how_many

--- a/sentences/fr/homeassistant_HassGetState.yaml
+++ b/sentences/fr/homeassistant_HassGetState.yaml
@@ -3,10 +3,10 @@ intents:
   HassGetState:
     data:
       - sentences:
-          - <quel> est [(l'(e|é)tat|le statut|la valeur) de] [<le>]{name} [<dans> [<le>]{area}]
-          - dans <quel> (e|é)tat est [<le>]{name} [<dans> [<le>]{area}]
+          - <quel> est [(l'(état|etat)|le statut|la valeur) de] [<le>]{name} [<dans> [<le>]{area}]
+          - dans <quel> (état|etat) est [<le>]{name} [<dans> [<le>]{area}]
           - comment (va|est) [<le>]{name} [<dans> [<le>]{area}]
-          - donne(-| )moi [(l'(e|é)tat|le statut|la valeur) de] [<le>]{name} [<dans> [<le>]{area}]
+          - donne(-| )moi [(l'(état|etat)|le statut|la valeur) de] [<le>]{name} [<dans> [<le>]{area}]
         response: one
         excludes_context:
           domain:

--- a/sentences/fr/homeassistant_HassTurnOff.yaml
+++ b/sentences/fr/homeassistant_HassTurnOff.yaml
@@ -3,11 +3,11 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - <eteins> <name>
-          - <eteins> <name> <dans> <area>
+          - <eteins> [<le>]{name}
+          - <eteins> [<le>]{name} <dans> [<le>]{area}
       - sentences:
-          - <ferme> <name>
+          - <ferme> [<le>]{name}
         response: covers
       - sentences:
-          - <ferme> <name> <dans> <area>
+          - <ferme> [<le>]{name} <dans> [<le>]{area}
         response: covers

--- a/sentences/fr/homeassistant_HassTurnOn.yaml
+++ b/sentences/fr/homeassistant_HassTurnOn.yaml
@@ -3,11 +3,11 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - <allume> <name>
-          - <allume> <name> <dans> <area>
+          - <allume> [<le>]{name}
+          - <allume> [<le>]{name} <dans> [<le>]{area}
       - sentences:
-          - <ouvre> <name>
+          - <ouvre> [<le>]{name}
         response: covers
       - sentences:
-          - <ouvre> <name> <dans> <area>
+          - <ouvre> [<le>]{name} <dans> [<le>]{area}
         response: covers

--- a/sentences/fr/light_HassLightSet.yaml
+++ b/sentences/fr/light_HassLightSet.yaml
@@ -4,39 +4,39 @@ intents:
     data:
       # brightness (name)
       - sentences:
-          - "<regle> [la] luminosité [<de>] <name> [à] <brightness>"
-          - "<regle> <name> [à] <brightness> [de] luminosité"
-          - "<allume> <name> [à] <brightness>"
-          - "luminosité [<de>] <name> [à] <brightness>"
-          - "<name> <brightness>"
-          - "<name> <brightness> luminosité"
-          - "<name> luminosité <brightness>"
-          - "(augmente|baisse) [la] (luminosité|lumière) [<de>] <name> [à] <brightness>"
+          - "<regle> [la] luminosité [<de>] <name> [à] {brightness}<pourcent>"
+          - "<regle> <name> [à] {brightness}<pourcent> [de] luminosité"
+          - "<allume> <name> [à] {brightness}<pourcent>"
+          - "luminosité [<de>] <name> [à] {brightness}<pourcent>"
+          - "<name> {brightness}<pourcent>"
+          - "<name> {brightness}<pourcent> luminosité"
+          - "<name> luminosité {brightness}<pourcent>"
+          - "(augmente|baisse) [la] (luminosité|lumière) [<de>] <name> [à] {brightness}<pourcent>"
         response: brightness
 
       # brightness (area)
       - sentences:
-          - "<regle> [la] luminosité [<dans>] <area> [à] <brightness>"
-          - "<regle> <area> [à] <brightness> [de] luminosité"
-          - "luminosité [<dans>] <area> [à] <brightness>"
-          - "<area> luminosité <brightness>"
-          - "<area> <brightness> luminosité"
-          - "(allume|augmente|baisse) [la] (luminosité|lumière) [<de>] <area> [à] <brightness>"
-          - "<allume> [toutes] [<lumieres>] [<de>] <area> [avec la luminosité|avec la lumière] [à] <brightness>"
+          - "<regle> [la] luminosité [<dans>] <area> [à] {brightness}<pourcent>"
+          - "<regle> <area> [à] {brightness}<pourcent> [de] luminosité"
+          - "luminosité [<dans>] <area> [à] {brightness}<pourcent>"
+          - "<area> luminosité {brightness}<pourcent>"
+          - "<area> {brightness}<pourcent> luminosité"
+          - "(allume|augmente|baisse) [la] (luminosité|lumière) [<de>] <area> [à] {brightness}<pourcent>"
+          - "<allume> [toutes] [<lumieres>] [<de>] <area> [avec la luminosité|avec la lumière] [à] {brightness}<pourcent>"
         response: brightness
         slots:
           name: all
 
       # brightness (name + area)
       - sentences:
-          - "<regle> [la] luminosité [<de>] <name> [<dans>] <area> [à] <brightness>"
-          - "<regle> <name> [<dans>] <area> [à] <brightness> [de] luminosité"
-          - "<allume> <name> [<dans>] <area> [à] <brightness>"
-          - "luminosité [<de>] <name> [<dans>] <area> [à] <brightness>"
-          - "<name> [<dans>] <area> <brightness>"
-          - "<name> [<dans>] <area> <brightness> luminosité"
-          - "<name> [<dans>] <area> luminosité <brightness>"
-          - "(augmente|baisse) [la] (luminosité|lumière) [<de>] <name> [dans] <area> [à] <brightness>"
+          - "<regle> [la] luminosité [<de>] <name> [<dans>] <area> [à] {brightness}<pourcent>"
+          - "<regle> <name> [<dans>] <area> [à] {brightness}<pourcent> [de] luminosité"
+          - "<allume> <name> [<dans>] <area> [à] {brightness}<pourcent>"
+          - "luminosité [<de>] <name> [<dans>] <area> [à] {brightness}<pourcent>"
+          - "<name> [<dans>] <area> {brightness}<pourcent>"
+          - "<name> [<dans>] <area> {brightness}<pourcent> luminosité"
+          - "<name> [<dans>] <area> luminosité {brightness}<pourcent>"
+          - "(augmente|baisse) [la] (luminosité|lumière) [<de>] <name> [dans] <area> [à] {brightness}<pourcent>"
         response: brightness
 
       # color (name)

--- a/sentences/fr/light_HassLightSet.yaml
+++ b/sentences/fr/light_HassLightSet.yaml
@@ -4,60 +4,60 @@ intents:
     data:
       # brightness (name)
       - sentences:
-          - "<regle> [la] luminosité [<de>] <name> [à] {brightness}<pourcent>"
-          - "<regle> <name> [à] {brightness}<pourcent> [de] luminosité"
-          - "<allume> <name> [à] {brightness}<pourcent>"
-          - "luminosité [<de>] <name> [à] {brightness}<pourcent>"
-          - "<name> {brightness}<pourcent>"
-          - "<name> {brightness}<pourcent> luminosité"
-          - "<name> luminosité {brightness}<pourcent>"
-          - "(augmente|baisse) [la] (luminosité|lumière) [<de>] <name> [à] {brightness}<pourcent>"
+          - "<regle> [la] luminosité [<de>] [<le>]{name} [à] {brightness}<pourcent>"
+          - "<regle> [<le>]{name} [à] {brightness}<pourcent> [de] luminosité"
+          - "<allume> [<le>]{name} [à] {brightness}<pourcent>"
+          - "luminosité [<de>] [<le>]{name} [à] {brightness}<pourcent>"
+          - "[<le>]{name} {brightness}<pourcent>"
+          - "[<le>]{name} {brightness}<pourcent> luminosité"
+          - "[<le>]{name} luminosité {brightness}<pourcent>"
+          - "(augmente|baisse) [la] (luminosité|lumière) [<de>] [<le>]{name} [à] {brightness}<pourcent>"
         response: brightness
 
       # brightness (area)
       - sentences:
-          - "<regle> [la] luminosité [<dans>] <area> [à] {brightness}<pourcent>"
-          - "<regle> <area> [à] {brightness}<pourcent> [de] luminosité"
-          - "luminosité [<dans>] <area> [à] {brightness}<pourcent>"
-          - "<area> luminosité {brightness}<pourcent>"
-          - "<area> {brightness}<pourcent> luminosité"
-          - "(allume|augmente|baisse) [la] (luminosité|lumière) [<de>] <area> [à] {brightness}<pourcent>"
-          - "<allume> [toutes] [<lumieres>] [<de>] <area> [avec la luminosité|avec la lumière] [à] {brightness}<pourcent>"
+          - "<regle> [la] luminosité [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
+          - "<regle> [<le>]{area} [à] {brightness}<pourcent> [de] luminosité"
+          - "luminosité [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
+          - "[<le>]{area} luminosité {brightness}<pourcent>"
+          - "[<le>]{area} {brightness}<pourcent> luminosité"
+          - "(allume|augmente|baisse) [la] (luminosité|lumière) [<de>] [<le>]{area} [à] {brightness}<pourcent>"
+          - "<allume> [toutes] [<lumieres>] [<de>] [<le>]{area} [avec la luminosité|avec la lumière] [à] {brightness}<pourcent>"
         response: brightness
         slots:
           name: all
 
       # brightness (name + area)
       - sentences:
-          - "<regle> [la] luminosité [<de>] <name> [<dans>] <area> [à] {brightness}<pourcent>"
-          - "<regle> <name> [<dans>] <area> [à] {brightness}<pourcent> [de] luminosité"
-          - "<allume> <name> [<dans>] <area> [à] {brightness}<pourcent>"
-          - "luminosité [<de>] <name> [<dans>] <area> [à] {brightness}<pourcent>"
-          - "<name> [<dans>] <area> {brightness}<pourcent>"
-          - "<name> [<dans>] <area> {brightness}<pourcent> luminosité"
-          - "<name> [<dans>] <area> luminosité {brightness}<pourcent>"
-          - "(augmente|baisse) [la] (luminosité|lumière) [<de>] <name> [dans] <area> [à] {brightness}<pourcent>"
+          - "<regle> [la] luminosité [<de>] [<le>]{name} [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
+          - "<regle> [<le>]{name} [<dans>] [<le>]{area} [à] {brightness}<pourcent> [de] luminosité"
+          - "<allume> [<le>]{name} [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
+          - "luminosité [<de>] [<le>]{name} [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
+          - "[<le>]{name} [<dans>] [<le>]{area} {brightness}<pourcent>"
+          - "[<le>]{name} [<dans>] [<le>]{area} {brightness}<pourcent> luminosité"
+          - "[<le>]{name} [<dans>] [<le>]{area} luminosité {brightness}<pourcent>"
+          - "(augmente|baisse) [la] (luminosité|lumière) [<de>] [<le>]{name} [dans] [<le>]{area} [à] {brightness}<pourcent>"
         response: brightness
 
       # color (name)
       - sentences:
-          - "<regle> [la couleur] [<de>] <name> [en] {color}"
-          - "<regle> <name> [avec la couleur | de couleur | en] {color}"
-          - "<allume> <name> [avec la couleur | de couleur | en] {color}"
+          - "<regle> [la couleur] [<de>] [<le>]{name} [en] {color}"
+          - "<regle> [<le>]{name} [avec la couleur | de couleur | en] {color}"
+          - "<allume> [<le>]{name} [avec la couleur | de couleur | en] {color}"
         response: color
 
       # color (area)
       - sentences:
-          - "<regle> [la couleur] [<de>] [toutes] [<lumieres>] [<de>] <area> [en] {color}"
-          - "<regle> [la couleur] [des] [<lumieres>] [<dans>] <area> [en] {color}"
-          - "<regle> [toutes] [<lumieres>] [<de>] <area> [avec la couleur | de couleur | en] {color}"
-          - "<allume> [toutes] [<lumieres>] [<de>] <area> [avec la couleur | de couleur | en] {color}"
+          - "<regle> [la couleur] [<de>] [toutes] [<lumieres>] [<de>] [<le>]{area} [en] {color}"
+          - "<regle> [la couleur] [des] [<lumieres>] [<dans>] [<le>]{area} [en] {color}"
+          - "<regle> [toutes] [<lumieres>] [<de>] [<le>]{area} [avec la couleur | de couleur | en] {color}"
+          - "<allume> [toutes] [<lumieres>] [<de>] [<le>]{area} [avec la couleur | de couleur | en] {color}"
         slots:
           name: all
         response: color
 
       # color (name + area)
       - sentences:
-          - <regle> [la couleur de] <name> [<dans>] <area> [avec la couleur |
+          - <regle> [la couleur de] [<le>]{name} [<dans>] [<le>]{area} [avec la couleur |
             de couleur | en] {color}
         response: color

--- a/sentences/fr/light_HassTurnOff.yaml
+++ b/sentences/fr/light_HassTurnOff.yaml
@@ -3,7 +3,7 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "<eteins> [toutes] (<lumiere> | <lumieres>) <dans> <area>"
+          - "<eteins> [toutes] (<lumiere> | <lumieres>) <dans> [<le>]{area}"
         slots:
           domain: light
         response: lights

--- a/sentences/fr/light_HassTurnOn.yaml
+++ b/sentences/fr/light_HassTurnOn.yaml
@@ -3,9 +3,9 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - <allume> [<tous>] (<lumiere> | <lumieres>) [<dans>] <area>
-          - (lumières|lumière) [<dans>] <area>
-          - <eclaire> <area>
+          - <allume> [<tous>] (<lumiere> | <lumieres>) [<dans>] [<le>]{area}
+          - (lumières|lumière) [<dans>] [<le>]{area}
+          - <eclaire> [<le>]{area}
         slots:
           domain: light
         response: lights

--- a/sentences/fr/lock_HassGetState.yaml
+++ b/sentences/fr/lock_HassGetState.yaml
@@ -3,7 +3,7 @@ intents:
   HassGetState:
     data:
       - sentences:
-          - "<name> (est|est-elle) {lock_states:state} [à clé|à clef] [<dans> <area>]"
+          - "[<le>]{name} (est|est-elle) {lock_states:state} [à clé|à clef] [<dans> [<le>]{area}]"
         response: one_yesno
         requires_context:
           domain: lock
@@ -11,25 +11,25 @@ intents:
           domain: lock
 
       - sentences:
-          - "(y a-t-il|il y a) (des|une) porte[s] [de] {lock_states:state} [<dans> <area>]"
+          - "(y a-t-il|il y a) (des|une) porte[s] [de] {lock_states:state} [<dans> [<le>]{area}]"
         response: any
         slots:
           domain: lock
 
       - sentences:
-          - "Toutes les porte[s] (sont|sont-elles) {lock_states:state} [<dans> <area>]"
+          - "Toutes les porte[s] (sont|sont-elles) {lock_states:state} [<dans> [<le>]{area}]"
         response: all
         slots:
           domain: lock
 
       - sentences:
-          - "(quelles|quelle) porte[s] (sont|est) {lock_states:state} [<dans> <area>]"
+          - "(quelles|quelle) porte[s] (sont|est) {lock_states:state} [<dans> [<le>]{area}]"
         response: which
         slots:
           domain: lock
 
       - sentences:
-          - "combien de porte[s] sont {lock_states:state} [<dans> <area>]"
+          - "combien de porte[s] sont {lock_states:state} [<dans> [<le>]{area}]"
         response: how_many
         slots:
           domain: lock

--- a/sentences/fr/lock_HassTurnOff.yaml
+++ b/sentences/fr/lock_HassTurnOff.yaml
@@ -3,13 +3,13 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "déverrouille[(z|r)] <name> [<dans> <area>]"
+          - "déverrouille[(z|r)] [<le>]{name} [<dans> [<le>]{area}]"
         requires_context:
           domain: lock
         response: lock
 
       - sentences:
-          - "déverrouille[(z|r)] [<tous>] [(la|le[s])] [(porte[s]|serrure[s]|verrou[s])] [<dans>] <area>"
+          - "déverrouille[(z|r)] [<tous>] [(la|le[s])] [(porte[s]|serrure[s]|verrou[s])] [<dans>] [<le>]{area}"
         slots:
           domain: "lock"
           name: "all"

--- a/sentences/fr/lock_HassTurnOn.yaml
+++ b/sentences/fr/lock_HassTurnOn.yaml
@@ -3,14 +3,14 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "verrouille[(z|r)] <name> [<dans> <area>]"
+          - "verrouille[(z|r)] [<le>]{name} [<dans> [<le>]{area}]"
         requires_context:
           domain: lock
         response: lock
 
       - sentences:
-          - "verrouille[(z|r)] [<tous>] [(la|le[s])] [(porte[s]|serrure[s]|verrou[s])] [<dans>] <area>"
-          - "verrouille[(z|r)] [<tous>] (la|le[s]) (porte[s]|serrure[s]|verrou[s]) [<dans> <area>]"
+          - "verrouille[(z|r)] [<tous>] [(la|le[s])] [(porte[s]|serrure[s]|verrou[s])] [<dans>] [<le>]{area}"
+          - "verrouille[(z|r)] [<tous>] (la|le[s]) (porte[s]|serrure[s]|verrou[s]) [<dans> [<le>]{area}]"
         slots:
           domain: "lock"
           name: "all"

--- a/sentences/fr/person_HassGetState.yaml
+++ b/sentences/fr/person_HassGetState.yaml
@@ -4,7 +4,7 @@ intents:
     data:
       # https://www.home-assistant.io/integrations/person/
       - sentences:
-          - "o(u|ù) est <name>"
+          - "o(u|ù) est [<le>]{name}"
         response: where
         requires_context:
           domain: person
@@ -12,7 +12,7 @@ intents:
           domain: person
 
       - sentences:
-          - "<name> <estil> (<dans>|à|au) [(le|la|l')] {zone:state}"
+          - "[<le>]{name} <estil> (<dans>|à|au) [(le|la|l')] {zone:state}"
         response: one_yesno
         requires_context:
           domain: person

--- a/sentences/fr/scene_HassTurnOn.yaml
+++ b/sentences/fr/scene_HassTurnOn.yaml
@@ -3,7 +3,7 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "[Exécute|Joue] [la] [scène] <name>"
+          - "[Exécute|Joue] [la] [scène] [<le>]{name}"
         requires_context:
           domain: scene
         slots:

--- a/sentences/fr/script_HassTurnOn.yaml
+++ b/sentences/fr/script_HassTurnOn.yaml
@@ -3,7 +3,7 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "[Lance|Démarre|Exécute] [le] [script] <name>"
+          - "[Lance|Démarre|Exécute] [le] [script] [<le>]{name}"
         requires_context:
           domain: script
         slots:

--- a/sentences/fr/sensor_HassGetState.yaml
+++ b/sentences/fr/sensor_HassGetState.yaml
@@ -94,7 +94,7 @@ intents:
           domain: sensor
           device_class: current
         expansion_rules:
-          class: "[quantité de] courant [(é|e)lectrique]"
+          class: "[quantité de] courant [(électrique|electrique)]"
 
       # # Data rate
       - sentences:
@@ -409,7 +409,7 @@ intents:
           domain: sensor
           device_class: precipitation
         expansion_rules:
-          class: "[cumul|quantité|niveau de ](pr(e|é)cipitation[s]|pluie|neige)"
+          class: "[cumul|quantité|niveau de ]((précipitation|precipitation)[s]|pluie|neige)"
 
       # Precipitation intensity
       - sentences:
@@ -422,7 +422,7 @@ intents:
           domain: sensor
           device_class: precipitation_intensity
         expansion_rules:
-          class: "intensité de (pr(e|é)cipitation[s]|pluie|neige)"
+          class: "intensité de ((précipitation|precipitation)[s]|pluie|neige)"
 
       # Pressure
       - sentences:
@@ -448,7 +448,7 @@ intents:
           domain: sensor
           device_class: reactive_power
         expansion_rules:
-          class: "puissance r(é|e)active"
+          class: "puissance (réactive|reactive)"
 
       # Signal strength
       - sentences:
@@ -513,7 +513,7 @@ intents:
           domain: sensor
           device_class: temperature
         expansion_rules:
-          class: "temp(e|é)rature"
+          class: "(température|temperature)"
 
       # # Skipping Timestamp
 

--- a/sentences/fr/sensor_HassGetState.yaml
+++ b/sentences/fr/sensor_HassGetState.yaml
@@ -45,8 +45,8 @@ intents:
       # Battery
       - sentences:
           - "<what_is_the_class_of_name>"
-          - "combien de batterie <name> <atil>"
-          - "combien de batterie reste-il dans <name>"
+          - "combien de batterie [<le>]{name} <atil>"
+          - "combien de batterie reste-il dans [<le>]{name}"
         response: default
         requires_context:
           domain: sensor
@@ -125,7 +125,7 @@ intents:
       # Date
       - sentences:
           - "<what_is_the_class_of_name>"
-          - "(Quand|Quel[l][e]) est [(le|la) prochain[e]] [(évènement|date)] [de] <name>"
+          - "(Quand|Quel[l][e]) est [(le|la) prochain[e]] [(évènement|date)] [de] [<le>]{name}"
         response: default
         requires_context:
           domain: sensor

--- a/sentences/fr/weather_HassGetWeather.yaml
+++ b/sentences/fr/weather_HassGetWeather.yaml
@@ -7,8 +7,8 @@ intents:
           - "(Donne[s]( |-)moi|Dis( |-)moi) le temps qu'il fait"
           - "Quel temps fait-il"
       - sentences:
-          - "(<quelest>|donne[s][-moi]) (le|la|les) (temps|météo) (pour|à) <name>"
-          - "(Donne-moi|Dis-moi) le temps qu'il fait à <name>"
-          - "Quel temps fait-il à <name>"
+          - "(<quelest>|donne[s][-moi]) (le|la|les) (temps|météo) (pour|à) [<le>]{name}"
+          - "(Donne-moi|Dis-moi) le temps qu'il fait à [<le>]{name}"
+          - "Quel temps fait-il à [<le>]{name}"
         requires_context:
           domain: weather


### PR DESCRIPTION
Co-worked with @jlpouffier to improve expansions rules

### 1. Remove variable names from every expansion rules to have better readability of each sentence

**Before**
```yaml
sentences: 
  - allume la lumière dans <area>
```
Area variable is hidden in the expansion rule
**After**
```yaml
sentences: 
  - allume la lumière dans [<le>]{area}
```
Area variable is now explicit in the sentence

### 2. Remove the fully optional expansion rules, so that we have more flexibility and readability

**Before**
```yaml
sentences: 
  - allume la lumière dans <le>{area}
```
We don't know that "le" is optional because it's hidden in the expansion rule

**After**
```yaml
sentences: 
  - allume la lumière dans [<le>]{area}
```
We know that "le" is optional because it's explicit in the sentence

### 3. Disambiguate words with accent

**Before**
```yaml
expansion_rules:
  fenetre: "(fen(e|ê)tre[s]|baie[s]|v(e|é)lux|lucarne[s])"
```

**After**
```yaml
expansion_rules:
  fenetre: "(fenetre[s]|fenêtre[s]|baie[s]|velux|vélux|lucarne[s])"
```