### PR TITLE
[fr] Light intents rework 20231221

### DIFF
--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -313,6 +313,8 @@ expansion_rules:
 
   # Verbs
   regle: "(règle|régler|met|mets|mettre|ajuste|ajuster|change|changer)"
+  augmente: "(augmente|augmenter|monte|monter)"
+  diminue: "(diminue|diminuer|baisse|baisser)"
   allume: "(allume|allumer|active|activer|démarre|démarrer)"
   eteins: "(éteint|eteint|éteins|eteins|éteindre|eteindre|désactive|désactiver|stoppe|stopper|arrête|arrêter|coupe|couper)"
   ferme: "(ferme|fermer|baisse|baisser)"

--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -308,7 +308,7 @@ expansion_rules:
   degres: "(°| °| degré| degrés)"
   le: (le |la |les |l')
   dans: "(dans|du|de|à|au)"
-  de: "(du|de)"
+  de: "(du|de|des)"
   tous: "(tout|tous|toute[s])"
 
   # Verbs

--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -303,34 +303,40 @@ lists:
     wildcard: true
 
 expansion_rules:
+  #Common rules
   pourcent: "(%| %| pourcent)"
   degres: "(°| °| degré| degrés)"
   le: (le |la |les |l')
+  dans: "(dans|du|de|à|au)"
+  de: "(du|de)"
+  tous: "(tout|tous|toute[s])"
+
+  # Verbs
   regle: "(règle|régler|met|mets|mettre|ajuste|ajuster|change|changer)"
   allume: "(allume|allumer|active|activer|démarre|démarrer)"
   eteins: "(éteint|eteint|éteins|eteins|éteindre|eteindre|désactive|désactiver|stoppe|stopper|arrête|arrêter|coupe|couper)"
   ferme: "(ferme|fermer|baisse|baisser)"
   ouvre: "(ouvre|ouvrir|monte|monter)"
-  lumiere: "([la ](lumière|lampe)|[l']ampoule)"
-  lumieres: "[les ](lumières|lampes|ampoules)"
+  eclaire: (éclaire|éclairer|illumine|illuminer)
+
+  # Domains and Things
+  lumiere: "(lumière|lampe|ampoule)"
+  lumieres: "(lumières|lampes|ampoules)"
   ventilateur: "[le ](ventilateur|brasseur d'air)"
   ventilateurs: "[les ](ventilateurs|brasseurs d'air)"
   volet: "([le ](volet|store))"
   volets: "[les ](volets|stores)"
   garage: "([la ]porte (du |de )garage)|([le ]garage)"
   fenetre: "(fenetre[s]|fenêtre[s]|baie[s]|velux|vélux|lucarne[s])"
-  dans: "(dans|du|de|à|au)"
-  de: "(du|de)"
+  appareil: "(appareil|machine|équipement)[s]"
+
+  # Questions
   yatil: "(y a[-][ ]t[-][']il|il y a)"
   estil: "(est|sont)[-][ ][(il[s]|elle[s])]"
   atil: "(ont|a)[-][ ][t][ ][-][(il[s]|elle[s])]"
   quel: "quel[le][s]"
   capteur: "(capteur|sonde|détecteur)[s]"
-  appareil: "(appareil|machine|équipement)[s]"
-  tous: "(tout|tous|toute[s])"
-  eclaire: (éclaire|éclairer|illumine|illuminer)
   quelest: "<quel> (est|sont)"
-  # Questions
   what_is_the_class_of_name: "<quelest> (le |la |l'|les )<class> [(indiqué[e][s]|mesuré[e][s]|renvoyé[e][s]|restant[e][s]|retourné[e][s]|utilisé[e][s]|produit[e][s]|consommé[e][s]|donné[e][s]) ][(par|<dans>|sur)] [<le>]{name} [<dans> [<le>]{area}]"
 
 skip_words:

--- a/sentences/fr/cover_HassTurnOn.yaml
+++ b/sentences/fr/cover_HassTurnOn.yaml
@@ -3,6 +3,17 @@ intents:
   HassTurnOn:
     data:
       - sentences:
+          - <ouvre> [<le>]{name}
+        requires_context:
+          domain: cover
+        response: covers
+      - sentences:
+          - <ouvre> [<le>]{name} <dans> [<le>]{area}
+        requires_context:
+          domain: cover
+        response: covers
+
+      - sentences:
           - <ouvre> <garage>
         response: cover_device_class
         slots:

--- a/sentences/fr/homeassistant_HassTurnOn.yaml
+++ b/sentences/fr/homeassistant_HassTurnOn.yaml
@@ -5,9 +5,3 @@ intents:
       - sentences:
           - <allume> [<le>]{name}
           - <allume> [<le>]{name} <dans> [<le>]{area}
-      - sentences:
-          - <ouvre> [<le>]{name}
-        response: covers
-      - sentences:
-          - <ouvre> [<le>]{name} <dans> [<le>]{area}
-        response: covers

--- a/sentences/fr/light_HassLightSet.yaml
+++ b/sentences/fr/light_HassLightSet.yaml
@@ -4,7 +4,7 @@ intents:
     data:
       # brightness (name)
       - sentences:
-          # Règle la luminosité de la statue aà 50%
+          # Règle la luminosité de la statue à 50%
           - "(<regle>|<augmente>|<diminue>) [la] luminosité [<de>] [<le>]{name} [à] {brightness}<pourcent>"
           # Allume la lumière du mirroir à 70%
           - "(<allume>|<regle>|<augmente>|<diminue>) [<le>](<lumiere>|<lumieres>) [<de>] [<le>]{name} [à] {brightness}<pourcent>"

--- a/sentences/fr/light_HassLightSet.yaml
+++ b/sentences/fr/light_HassLightSet.yaml
@@ -39,7 +39,7 @@ intents:
           # Bureau à 50 de luminosité
           - "[<le>]{area} [à] {brightness}<pourcent> [de] luminosité"
           # Règle les lumieres du bureau avec la luminosité à 50% (Too complex... We should think about removing that)
-          - "(<allume>|<regle>) [toutes] [<le>][<lumieres>] [<de>] [<le>]{area} [avec la luminosité|avec la lumière] [à] {brightness}<pourcent>"
+          - "(<allume>|<regle>) [<tous>] [<le>][<lumieres>] [<de>] [<le>]{area} [avec la luminosité|avec la lumière] [à] {brightness}<pourcent>"
         response: brightness
         slots:
           name: all
@@ -77,9 +77,9 @@ intents:
           # Règle la couleur du salon en vert
           - "<regle> la couleur [<de>] [<le>]{area} [en] {color}"
           # Règle la couleur des lumières du salon en vert
-          - "<regle> la couleur <de> [toutes] [<le>](<lumiere>|<lumieres>) [<dans>] [<le>]{area} [en] {color}"
+          - "<regle> la couleur <de> [<tous>] [<le>](<lumiere>|<lumieres>) [<dans>] [<le>]{area} [en] {color}"
           # Allume les lumières du salon en rouge
-          - "(<regle>|<allume>) [toutes] [<le>](<lumiere>|<lumieres>) [<de>] [<le>]{area} [avec la couleur | de couleur | en] {color}"
+          - "(<regle>|<allume>) [<tous>] [<le>](<lumiere>|<lumieres>) [<de>] [<le>]{area} [avec la couleur | de couleur | en] {color}"
           # Allume le salon en rouge
           - "(<regle>|<allume>) [<le>]{area} [avec la couleur | de couleur | en] {color}"
         slots:

--- a/sentences/fr/light_HassLightSet.yaml
+++ b/sentences/fr/light_HassLightSet.yaml
@@ -22,7 +22,7 @@ intents:
           - "[<le>]{area} luminosité {brightness}<pourcent>"
           - "[<le>]{area} {brightness}<pourcent> luminosité"
           - "(allume|augmente|baisse) [la] (luminosité|lumière) [<de>] [<le>]{area} [à] {brightness}<pourcent>"
-          - "<allume> [toutes] [<lumieres>] [<de>] [<le>]{area} [avec la luminosité|avec la lumière] [à] {brightness}<pourcent>"
+          - "<allume> [toutes] [<le>][<lumieres>] [<de>] [<le>]{area} [avec la luminosité|avec la lumière] [à] {brightness}<pourcent>"
         response: brightness
         slots:
           name: all
@@ -48,10 +48,10 @@ intents:
 
       # color (area)
       - sentences:
-          - "<regle> [la couleur] [<de>] [toutes] [<lumieres>] [<de>] [<le>]{area} [en] {color}"
-          - "<regle> [la couleur] [des] [<lumieres>] [<dans>] [<le>]{area} [en] {color}"
-          - "<regle> [toutes] [<lumieres>] [<de>] [<le>]{area} [avec la couleur | de couleur | en] {color}"
-          - "<allume> [toutes] [<lumieres>] [<de>] [<le>]{area} [avec la couleur | de couleur | en] {color}"
+          - "<regle> [la couleur] [<de>] [toutes] [<le>][<lumieres>] [<de>] [<le>]{area} [en] {color}"
+          - "<regle> [la couleur] [des] [<le>][<lumieres>] [<dans>] [<le>]{area} [en] {color}"
+          - "<regle> [toutes] [<le>][<lumieres>] [<de>] [<le>]{area} [avec la couleur | de couleur | en] {color}"
+          - "<allume> [toutes] [<le>][<lumieres>] [<de>] [<le>]{area} [avec la couleur | de couleur | en] {color}"
         slots:
           name: all
         response: color

--- a/sentences/fr/light_HassLightSet.yaml
+++ b/sentences/fr/light_HassLightSet.yaml
@@ -66,23 +66,30 @@ intents:
 
       # color (name)
       - sentences:
-          - "<regle> [la couleur] [<de>] [<le>]{name} [en] {color}"
-          - "<regle> [<le>]{name} [avec la couleur | de couleur | en] {color}"
-          - "<allume> [<le>]{name} [avec la couleur | de couleur | en] {color}"
+          # Règle la couleur du mirrior en vert
+          - "<regle> la couleur [<de>] [<le>]{name} [en] {color}"
+          # Règle le mirrior en vert
+          - "(<regle>|<allume>) [<le>]{name} [avec la couleur | de couleur | en] {color}"
         response: color
 
       # color (area)
       - sentences:
-          - "<regle> [la couleur] [<de>] [toutes] [<le>][<lumieres>] [<de>] [<le>]{area} [en] {color}"
-          - "<regle> [la couleur] [des] [<le>][<lumieres>] [<dans>] [<le>]{area} [en] {color}"
-          - "<regle> [toutes] [<le>][<lumieres>] [<de>] [<le>]{area} [avec la couleur | de couleur | en] {color}"
-          - "<allume> [toutes] [<le>][<lumieres>] [<de>] [<le>]{area} [avec la couleur | de couleur | en] {color}"
+          # Règle la couleur du salon en vert
+          - "<regle> la couleur [<de>] [<le>]{area} [en] {color}"
+          # Règle la couleur des lumières du salon en vert
+          - "<regle> la couleur <de> [toutes] [<le>](<lumiere>|<lumieres>) [<dans>] [<le>]{area} [en] {color}"
+          # Allume les lumières du salon en rouge
+          - "(<regle>|<allume>) [toutes] [<le>](<lumiere>|<lumieres>) [<de>] [<le>]{area} [avec la couleur | de couleur | en] {color}"
+          # Allume le salon en rouge
+          - "(<regle>|<allume>) [<le>]{area} [avec la couleur | de couleur | en] {color}"
         slots:
           name: all
         response: color
 
       # color (name + area)
       - sentences:
-          - <regle> [la couleur de] [<le>]{name} [<dans>] [<le>]{area} [avec la couleur |
-            de couleur | en] {color}
+          # Règle la couleur du sapin dans le salon en rouge
+          - "<regle> la couleur [<de>] [<le>]{name} [<dans>] [<le>]{area} [en] {color}"
+          # Allume le sapin de l'exterieur en vert
+          - (<regle>|<allume>) [<le>]{name} [<dans>] [<le>]{area} [avec la couleur | de couleur | en] {color}
         response: color

--- a/sentences/fr/light_HassLightSet.yaml
+++ b/sentences/fr/light_HassLightSet.yaml
@@ -4,39 +4,64 @@ intents:
     data:
       # brightness (name)
       - sentences:
-          - "<regle> [la] luminosité [<de>] [<le>]{name} [à] {brightness}<pourcent>"
-          - "<regle> [<le>]{name} [à] {brightness}<pourcent> [de] luminosité"
-          - "<allume> [<le>]{name} [à] {brightness}<pourcent>"
+          # Règle la luminosité de la statue aà 50%
+          - "(<regle>|<augmente>|<diminue>) [la] luminosité [<de>] [<le>]{name} [à] {brightness}<pourcent>"
+          # Allume la lumière du mirroir à 70%
+          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>](<lumiere>|<lumieres>) [<de>] [<le>]{name} [à] {brightness}<pourcent>"
+          # Règle le mirrior à 50% de luminosité
+          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]{name} [à] {brightness}<pourcent> [de] luminosité"
+          # Allume le sapin à 50%
+          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]{name} [à] {brightness}<pourcent>"
+          # Luminosité statue 40%
           - "luminosité [<de>] [<le>]{name} [à] {brightness}<pourcent>"
-          - "[<le>]{name} {brightness}<pourcent>"
-          - "[<le>]{name} {brightness}<pourcent> luminosité"
-          - "[<le>]{name} luminosité {brightness}<pourcent>"
-          - "(augmente|baisse) [la] (luminosité|lumière) [<de>] [<le>]{name} [à] {brightness}<pourcent>"
+          # Sapin à 50%
+          - "[<le>]{name} [à] {brightness}<pourcent>"
+          # Mirroir à 20% de luminosité
+          - "[<le>]{name} [à] {brightness}<pourcent> [de] luminosité"
+          # Sapin luminosité 30%
+          - "[<le>]{name} luminosité [à] {brightness}<pourcent>"
         response: brightness
 
       # brightness (area)
       - sentences:
-          - "<regle> [la] luminosité [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
-          - "<regle> [<le>]{area} [à] {brightness}<pourcent> [de] luminosité"
+          # Baisse la luminosité du bureau à 40%
+          - "(<regle>|<augmente>|<diminue>) [la] luminosité [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
+          # Allume la lumière du bureau à 70%
+          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>](<lumiere>|<lumieres>)  [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
+          # Règle le bureau à 50% de luminosité
+          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]{area} [à] {brightness}<pourcent> [de] luminosité"
+          # Monte le bureau a 100%
+          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]{area} [à] {brightness}<pourcent>"
+          # Luminosité dans bureau à 50%
           - "luminosité [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
-          - "[<le>]{area} luminosité {brightness}<pourcent>"
-          - "[<le>]{area} {brightness}<pourcent> luminosité"
-          - "(allume|augmente|baisse) [la] (luminosité|lumière) [<de>] [<le>]{area} [à] {brightness}<pourcent>"
-          - "<allume> [toutes] [<le>][<lumieres>] [<de>] [<le>]{area} [avec la luminosité|avec la lumière] [à] {brightness}<pourcent>"
+          # Bureau luminosité 50%
+          - "[<le>]{area} luminosité [à] {brightness}<pourcent>"
+          # Bureau à 50 de luminosité
+          - "[<le>]{area} [à] {brightness}<pourcent> [de] luminosité"
+          # Règle les lumieres du bureau avec la luminosité à 50% (Too complex... We should think about removing that)
+          - "(<allume>|<regle>) [toutes] [<le>][<lumieres>] [<de>] [<le>]{area} [avec la luminosité|avec la lumière] [à] {brightness}<pourcent>"
         response: brightness
         slots:
           name: all
 
       # brightness (name + area)
       - sentences:
-          - "<regle> [la] luminosité [<de>] [<le>]{name} [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
-          - "<regle> [<le>]{name} [<dans>] [<le>]{area} [à] {brightness}<pourcent> [de] luminosité"
-          - "<allume> [<le>]{name} [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
+          # Baisse la luminosité du mirrior de la salle de bain à 20%
+          - "(<regle>|<augmente>|<diminue>) [la] luminosité [<de>] [<le>]{name} [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
+          # Allume la lumière de la statue du jardin à 60%
+          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>](<lumiere>|<lumieres>)  [<de>] [<le>]{name} [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
+          # Règle les spots du salon à 60% de luminosité
+          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]{name} [<dans>] [<le>]{area} [à] {brightness}<pourcent> [de] luminosité"
+          # Allume les spots du salon à 80%
+          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]{name} [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
+          # Luminosité du mirrior de la salle de bain à 40%
           - "luminosité [<de>] [<le>]{name} [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
+          # Mirrior de la salle de bain à 40%
           - "[<le>]{name} [<dans>] [<le>]{area} {brightness}<pourcent>"
-          - "[<le>]{name} [<dans>] [<le>]{area} {brightness}<pourcent> luminosité"
+          # Mirrior de la salle de bain à 40% de luminosité
+          - "[<le>]{name} [<dans>] [<le>]{area} {brightness}<pourcent> [de] luminosité"
+          # Mirroir salle de bain luminosité 40%
           - "[<le>]{name} [<dans>] [<le>]{area} luminosité {brightness}<pourcent>"
-          - "(augmente|baisse) [la] (luminosité|lumière) [<de>] [<le>]{name} [dans] [<le>]{area} [à] {brightness}<pourcent>"
         response: brightness
 
       # color (name)

--- a/sentences/fr/light_HassTurnOff.yaml
+++ b/sentences/fr/light_HassTurnOff.yaml
@@ -8,7 +8,7 @@ intents:
       # area
       - sentences:
           # Éteindre les lumieres du bureau
-          - "<eteins> [<tous>] [<le>](<lumiere>|<lumieres>) <dans> [<le>]{area}"
+          - "<eteins> [<tous>] [<le>](<lumiere>|<lumieres>) [<dans>] [<le>]{area}"
           # Éteint le salon
           - "<eteins> [<le>]{area}"
         slots:
@@ -21,7 +21,6 @@ intents:
           - "<eteins> [<tous>] [<le>](<lumiere>|<lumieres>) <ici>"
           # Éteindre les lumieres
           - "<eteins> [<le>](<lumiere>|<lumieres>)"
-
         expansion_rules:
           ici: "(dans la pièce)|(dans cette pièce)|(ici)"
         response: lights

--- a/sentences/fr/light_HassTurnOff.yaml
+++ b/sentences/fr/light_HassTurnOff.yaml
@@ -2,25 +2,44 @@ language: fr
 intents:
   HassTurnOff:
     data:
+      # name
+      # See intents/sentences/fr/homeassistant_HassTurnOff.yaml
+
+      # area
       - sentences:
-          - "<eteins> [toutes] [<le>](<lumiere>|<lumieres>) <dans> [<le>]{area}"
+          # Éteindre les lumieres du bureau
+          - "<eteins> [<tous>] [<le>](<lumiere>|<lumieres>) <dans> [<le>]{area}"
+          # Éteint le salon
+          - "<eteins> [<le>]{area}"
         slots:
           domain: light
         response: lights
 
+      # area + context awareness
       - sentences:
-          - <eteins> [<le>](<lumiere>|<lumieres>) partout
+          # Éteindre toutes les lumieres ici
+          - "<eteins> [<tous>] [<le>](<lumiere>|<lumieres>) <ici>"
+          # Éteindre les lumieres
+          - "<eteins> [<le>](<lumiere>|<lumieres>)"
+
+        expansion_rules:
+          ici: "(dans la pièce)|(dans cette pièce)|(ici)"
+        response: lights
+        slots:
+          domain: light
+        requires_context:
+          area: null
+
+      # name + area
+      # See intents/sentences/fr/homeassistant_HassTurnOff.yaml
+
+      # all
+      - sentences:
+          # Éteindre les lumieres de partout
+          - <eteins> [<le>](<lumiere>|<lumieres>) [de] partout
+          # Éteindre toutes lumieres de partout
           - <eteins> <tous> [<le>]<lumieres>
         slots:
           domain: light
+          name: all
         response: lights
-
-      # Turn off all lights in the same area as a satellite device
-      - sentences:
-          - "<eteins>[ (les|la) lumière[s]][( dans la pièce| ici)]"
-          - "<eteins> <tous>[ (les|la) lumière[s]]( dans la pièce| ici)"
-        response: "lights"
-        slots:
-          domain: "light"
-        requires_context:
-          area: null

--- a/sentences/fr/light_HassTurnOff.yaml
+++ b/sentences/fr/light_HassTurnOff.yaml
@@ -3,14 +3,14 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "<eteins> [toutes] (<lumiere> | <lumieres>) <dans> [<le>]{area}"
+          - "<eteins> [toutes] [<le>](<lumiere>|<lumieres>) <dans> [<le>]{area}"
         slots:
           domain: light
         response: lights
 
       - sentences:
-          - <eteins> (<lumiere> | <lumieres>) partout
-          - <eteins> <tous> <lumieres>
+          - <eteins> [<le>](<lumiere>|<lumieres>) partout
+          - <eteins> <tous> [<le>]<lumieres>
         slots:
           domain: light
         response: lights

--- a/sentences/fr/light_HassTurnOn.yaml
+++ b/sentences/fr/light_HassTurnOn.yaml
@@ -3,7 +3,7 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - <allume> [<tous>] (<lumiere> | <lumieres>) [<dans>] [<le>]{area}
+          - <allume> [<tous>] [<le>](<lumiere>|<lumieres>) [<dans>] [<le>]{area}
           - (lumières|lumière) [<dans>] [<le>]{area}
           - <eclaire> [<le>]{area}
         slots:
@@ -11,8 +11,8 @@ intents:
         response: lights
 
       - sentences:
-          - <allume> (<lumiere> | <lumieres>) partout
-          - <allume> <tous> <lumieres>
+          - <allume> [<le>](<lumiere>|<lumieres>) partout
+          - <allume> <tous> [<le>]<lumieres>
         slots:
           domain: light
           area: all

--- a/sentences/fr/light_HassTurnOn.yaml
+++ b/sentences/fr/light_HassTurnOn.yaml
@@ -36,7 +36,7 @@ intents:
 
       # all
       - sentences:
-          - <allume> [<le>](<lumiere>|<lumieres>) partout
+          - <allume> [<le>](<lumiere>|<lumieres>) [de] partout
           - <allume> <tous> [<le>]<lumieres>
         slots:
           domain: light

--- a/sentences/fr/light_HassTurnOn.yaml
+++ b/sentences/fr/light_HassTurnOn.yaml
@@ -2,14 +2,39 @@ language: fr
 intents:
   HassTurnOn:
     data:
+      # name
+      # See intents/sentences/fr/homeassistant_HassTurnOn.yaml
+
+      # area
       - sentences:
-          - <allume> [<tous>] [<le>](<lumiere>|<lumieres>) [<dans>] [<le>]{area}
-          - (lumières|lumière) [<dans>] [<le>]{area}
-          - <eclaire> [<le>]{area}
+          # Allume la lumiere du bureau
+          - "<allume> [<tous>] [<le>](<lumiere>|<lumieres>) [<dans>] [<le>]{area}"
+          # Allume le bureau
+          - "(<allume>|<eclaire>) [<le>]{area}"
+          # Lumière dans le bureau
+          - "(<lumiere>|<lumieres>) [<dans>] [<le>]{area}"
         slots:
           domain: light
         response: lights
 
+      # area + context awareness
+      - sentences:
+          # Allume toutes les lumieres ici
+          - "<allume> [<tous>] [<le>](<lumiere>|<lumieres>) <ici>"
+          # Allume les lumieres
+          - "<allume> [<le>](<lumiere>|<lumieres>)"
+        expansion_rules:
+          ici: "(dans la pièce)|(dans cette pièce)|(ici)"
+        response: lights
+        slots:
+          domain: light
+        requires_context:
+          area: null
+
+      # name + area
+      # See intents/sentences/fr/homeassistant_HassTurnOff.yaml
+
+      # all
       - sentences:
           - <allume> [<le>](<lumiere>|<lumieres>) partout
           - <allume> <tous> [<le>]<lumieres>
@@ -17,13 +42,3 @@ intents:
           domain: light
           area: all
         response: lights
-
-      # Turn off all lights in the same area as a satellite device
-      - sentences:
-          - "<allume>[ (les|la) lumière[s]][( dans la pièce| ici)]"
-          - "<allume> <tous>[ (les|la) lumière[s]]( dans la pièce| ici)"
-        response: "lights"
-        slots:
-          domain: "light"
-        requires_context:
-          area: null

--- a/tests/fr/light_HassLightSet.yaml
+++ b/tests/fr/light_HassLightSet.yaml
@@ -13,6 +13,9 @@ tests:
       - "lampe de chevet 50% luminosité"
       - "lampe de chevet luminosité 50%"
       - "Baisse la lumière de lampe de chevet à 50%"
+      - "Monte la lampe de chevet à 50%"
+      - "Baisse la lampe de chevet à 50 %"
+
     intent:
       name: HassLightSet
       slots:
@@ -32,6 +35,9 @@ tests:
       - "cuisine 50% luminosité"
       - "cuisine luminosité 50%"
       - "Augmente la lumière de la cuisine à 50%"
+      - "Monter la cuisine à 50 %"
+      - "Baisser la cuisine à 50 %"
+
     intent:
       name: HassLightSet
       slots:
@@ -53,6 +59,7 @@ tests:
       - "lampe de chevet chambre 50% luminosité"
       - "lampe de chevet chambre luminosité 50%"
       - "Augmente la luminosité de la lampe de chevet dans la chambre à 50%"
+      - "Allume la lampe de chevet de la chambre à 50 %"
     intent:
       name: HassLightSet
       slots:

--- a/tests/fr/light_HassTurnOff.yaml
+++ b/tests/fr/light_HassTurnOff.yaml
@@ -22,13 +22,14 @@ tests:
       name: HassTurnOff
       slots:
         domain: light
+        name: all
     response: Lumières éteintes
 
   - sentences:
-      - "Eteins toutes les lumières"
-      - "Eteins"
-      - "Eteins dans la pièce"
-      - "Eteins ici"
+      - "Eteins toutes les lumières ici"
+      - "Eteins les lumières"
+      - "Eteins la lumière dans cette pièce"
+      - "Eteindre la lumière ici"
     intent:
       name: HassTurnOff
       context:

--- a/tests/fr/light_HassTurnOff.yaml
+++ b/tests/fr/light_HassTurnOff.yaml
@@ -6,6 +6,9 @@ tests:
       - Éteins les lumières dans la cuisine
       - Éteins toutes les lumières dans la cuisine
       - Désactiver la lumière de la cuisine
+      - Éteins la cuisine
+      - Éteins toutes les lumières de la cuisine
+
     intent:
       name: HassTurnOff
       slots:
@@ -16,6 +19,7 @@ tests:
   - sentences:
       - Éteins toutes les lumières
       - Éteins les lumières partout
+      - Éteins les lumières de partout
       - Éteindre la lumière partout
       - Désactiver toutes les lumières
     intent:

--- a/tests/fr/light_HassTurnOn.yaml
+++ b/tests/fr/light_HassTurnOn.yaml
@@ -32,9 +32,9 @@ tests:
 
   - sentences:
       - "Allume toutes les lumières ici"
-      - "Allume"
-      - "Allume ici"
-      - "Allume la lumière"
+      - "Allume les lumières"
+      - "Allume la lumière dans cette pièce"
+      - "Allumer la lumière ici"
     intent:
       name: HassTurnOn
       context:

--- a/tests/fr/light_HassTurnOn.yaml
+++ b/tests/fr/light_HassTurnOn.yaml
@@ -10,6 +10,8 @@ tests:
       - Lumière dans la cuisine
       - Lumière cuisine
       - Éclaire la cuisine
+      - Allume la cuisine
+      - Allume toutes les lumières de la cuisine
       - Tu peux allumer les lumières de la cuisine
     intent:
       name: HassTurnOn
@@ -21,6 +23,7 @@ tests:
   - sentences:
       - Allume toutes les lumières
       - Allume les lumières partout
+      - Allume les lumières de partout
       - Allumer la lumière partout
       - Activer toutes les lumières
     intent:


### PR DESCRIPTION
### General Improvement for readability and maintainability of our intents
- Removed `le`, `la`, etc from expansion rules `lumiere` and `lumieres`. We have an expansion rule `le` for that
- All intents use expansion rules for verbs. So that we are sure the infinitive and imperative forms work
  - _Baisse la luminosité ...._
  - _Baisser la luminosité ...._
- Added a comment in front of all sentences to help the reader and contributor understand at least one match

### New sentences
New sentences to turn on, off, and set brightness of all areas.
A few examples
- _Allume le bureau_
- _Éteins le bureau_
- _Baisse le bureau à 20%_
- _Monte le salon à 100%_
  
### Bug fixes
- `<ouvre> [<le>]{name}` was defined without context. You were able to "open" lights, or vacuums
  - Added cover context
  - Moved to cover file
- Turning off all lights in the home with missing a slot (`name: all`)

### Breaking changes
We cannot survive with sentences such as "Éteins" or "Allume" to turn off and on lights in an area.
I added back the keyword "Lumière".
If tomorrow, we want to extend area awareness to other domains, we will be stuck.

Here are a few examples of sentences that are turning on lights in a room using area awareness
  - _"Allume toutes les lumières ici"_
  - _"Allume les lumières"_
  - "_Allume la lumière dans cette pièce"_
  - _"Allumer la lumière ici"_

What is not working anymore is 
- _~~Allume~~_
- _~~Allume ici~~_

JLo