### PR TITLE
Fix Hebrew response for HassClimateGetTemperature

### DIFF
--- a/responses/he/HassClimateGetTemperature.yaml
+++ b/responses/he/HassClimateGetTemperature.yaml
@@ -2,4 +2,10 @@ language: he
 responses:
   intents:
     HassClimateGetTemperature:
-      default: "ב{{ slots.area }} {{ state_attr(state.entity_id, 'current_temperature') }} מעלות"
+      default: >
+        {% set temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% if slots.area: %}
+        ב{{ slots.area }} {{ state_attr(state.entity_id, 'current_temperature') }} מעלות
+        {% else: %}
+        הטמפרטורה היא {{ state_attr(state.entity_id, 'current_temperature') }} מעלות
+        {% endif %}

--- a/responses/he/HassClimateGetTemperature.yaml
+++ b/responses/he/HassClimateGetTemperature.yaml
@@ -2,4 +2,4 @@ language: he
 responses:
   intents:
     HassClimateGetTemperature:
-      default: "{{ state.state }} מעלות"
+      default: "ב{{ slots.area }} {{ state_attr(state.entity_id, 'current_temperature') }} מעלות"

--- a/tests/he/_fixtures.yaml
+++ b/tests/he/_fixtures.yaml
@@ -83,6 +83,6 @@ entities:
   - name: "Thermostat"
     id: "climate.thermostat"
     area: "living_room"
-    state: "68"
+    state: "heat"
     attributes:
-      unit_of_measurement: "°F"
+      current_temperature: 68

--- a/tests/he/climate_HassClimateGetTemperature.yaml
+++ b/tests/he/climate_HassClimateGetTemperature.yaml
@@ -4,15 +4,20 @@ tests:
       - ?מה הטמפרטורה
     intent:
       name: HassClimateGetTemperature
+    response: "הטמפרטורה היא 68 מעלות"
+
   - sentences:
       - מה הטמפרטורה בסלון?
     intent:
       name: HassClimateGetTemperature
       slots:
         area: סלון
+    response: "בסלון 68 מעלות"
+
   - sentences:
       - כמה חם בסלון?
     intent:
       name: HassClimateGetTemperature
       slots:
         area: סלון
+    response: "בסלון 68 מעלות"


### PR DESCRIPTION
The Hebrew response for `HassClimateGetTemperature` returned the climate's state, rather than the current temp.

Also, when a sentence in Hebrew starts with a number, or an english letter, it jumbles it.

Fixed the value and added the name of the area to the beginning of the sentence to avoid it getting jumbled.

The new sentence translates to  "In {area} {temperature} degrees" (no need for ["it is"] between area and temperature in Hebrew)