### PR TITLE
[FR] TODO improvements  20240101

### DIFF
--- a/sentences/fr/todo_HassListAddItem.yaml
+++ b/sentences/fr/todo_HassListAddItem.yaml
@@ -3,8 +3,6 @@ intents:
   HassListAddItem:
     data:
       - sentences:
-          #- (ajoute|met)[s] <item> (dans|à) [la liste] [de] {name}
-
           # Ajoute du pain à la liste des courses
           - <ajoute> [<de_le>]<item> <a_le>{name}
 

--- a/sentences/fr/todo_HassListAddItem.yaml
+++ b/sentences/fr/todo_HassListAddItem.yaml
@@ -3,9 +3,30 @@ intents:
   HassListAddItem:
     data:
       - sentences:
-          - (ajoute|met)[s] <item> (dans|à) [la liste] [de] {name}
+          #- (ajoute|met)[s] <item> (dans|à) [la liste] [de] {name}
+
+          # Ajoute du pain à la liste des courses
+          - <ajoute> [<de_le>] <item> <a_le> {name}
+
+          # Met des oeufs dans la liste des courses
+          - <ajoute> [<de_le>] <item> dans [<le>] {name}
+
+          # Rajoute du lait sur la liste des courses
+          - <ajoute> [<de_le>] <item> sur [<le>] {name}
+
+          # Ajouter pain à la liste des courses
+          - <ajoute> [<de_le>] <item> à la liste [<de>] {name}
+
+          # Rajoute pain dans liste des courses
+          - <ajoute> [<de_le>] <item> dans [la] liste [<de>] {name}
+
+          # Mettre du lait sur la liste des courses
+          - <ajoute> [<de_le>] <item> sur [la] liste [<de>] {name}
         response: item_added
         requires_context:
           domain: todo
         expansion_rules:
           item: "{shopping_list_item:item}"
+          de_le: (de la |du |des | de l')
+          ajoute: (ajoute|ajouter|mets|met|mettre|rajoute|rajouter)
+          a_le: (a la|à la|au|aux)

--- a/sentences/fr/todo_HassListAddItem.yaml
+++ b/sentences/fr/todo_HassListAddItem.yaml
@@ -6,27 +6,27 @@ intents:
           #- (ajoute|met)[s] <item> (dans|à) [la liste] [de] {name}
 
           # Ajoute du pain à la liste des courses
-          - <ajoute> [<de_le>] <item> <a_le> {name}
+          - <ajoute> [<de_le>]<item> <a_le>{name}
 
           # Met des oeufs dans la liste des courses
-          - <ajoute> [<de_le>] <item> dans [<le>] {name}
+          - <ajoute> [<de_le>]<item> dans [<le>]{name}
 
           # Rajoute du lait sur la liste des courses
-          - <ajoute> [<de_le>] <item> sur [<le>] {name}
+          - <ajoute> [<de_le>]<item> sur [<le>]{name}
 
           # Ajouter pain à la liste des courses
-          - <ajoute> [<de_le>] <item> à la liste [<de>] {name}
+          - <ajoute> [<de_le>]<item> à la liste [<de>] {name}
 
           # Rajoute pain dans liste des courses
-          - <ajoute> [<de_le>] <item> dans [la] liste [<de>] {name}
+          - <ajoute> [<de_le>]<item> dans [la] liste [<de>] {name}
 
           # Mettre du lait sur la liste des courses
-          - <ajoute> [<de_le>] <item> sur [la] liste [<de>] {name}
+          - <ajoute> [<de_le>]<item> sur [la] liste [<de>] {name}
         response: item_added
         requires_context:
           domain: todo
         expansion_rules:
           item: "{shopping_list_item:item}"
-          de_le: (de la |du |des | de l')
+          de_le: (de la |du |des |de l')
           ajoute: (ajoute|ajouter|mets|met|mettre|rajoute|rajouter)
-          a_le: (a la|à la|au|aux)
+          a_le: (a la |à la |a l'|a l'|au |aux )

--- a/tests/fr/_fixtures.yaml
+++ b/tests/fr/_fixtures.yaml
@@ -752,3 +752,6 @@ entities:
   - name: "tâches"
     id: "todo.taches"
     state: ""
+  - name: "liste des courses"
+    id: "todo.liste_des_courses"
+    state: ""

--- a/tests/fr/todo_HassListAddItem.yaml
+++ b/tests/fr/todo_HassListAddItem.yaml
@@ -1,11 +1,32 @@
 language: fr
 tests:
   - sentences:
-      - ajoute réparer le volet à tâches
-      - mets réparer le volet dans la liste de tâches
+      - ajoute réparer le volet aux tâches
+      - ajouter réparer le volet dans les tâches
+      - Rajoute réparer le volet sur la liste des tâches
     intent:
       name: HassListAddItem
       slots:
         item: "réparer le volet "
         name: "tâches"
     response: réparer le volet ajouté
+  - sentences:
+      - ajoute des bières dans la liste des courses
+      - Mettre des bières dans la liste des courses
+      - ajoute bières dans liste des courses
+    intent:
+      name: HassListAddItem
+      slots:
+        item: "bières "
+        name: "liste des courses"
+    response: bières ajouté
+  - sentences:
+      - ajoute du lait à la liste des courses
+      - mets du lait sur la liste des courses
+      - rajouter du lait dans la liste des courses
+    intent:
+      name: HassListAddItem
+      slots:
+        item: "lait "
+        name: "liste des courses"
+    response: lait ajouté


### PR DESCRIPTION
### Added new sentences to add items on a todo list in a natural way. 
Sentences include:
- _Ajoute du pain à la liste des courses_
- _Met des oeufs dans la liste des courses_
- _Rajoute du lait sur la liste des courses_
- _ajoute réparer le volet aux tâches_
- _ajoute réparer le volet à la liste des tâches_

Features
- Infinitive and Imperatif forms for the action verbs _(Ajoute, Ajouter)_
- Singular and Plural, masculine, feminine for the item _(Ajoute du pain, de la bière, des craquottes, de l'eau, etc)_
- Singular and Plural, masculine, feminine for the list _(À la liste de courses, aux taches, au livre des dolenances, etc)_

### Added tests for all that.

### Note
What do we do with `HassShoppingListAddItem` ?
Now that all shopping lists are also todo entities, I think we could safely remove this intent completely from our intent collection.
For now, I did not touch it.