### PR TITLE
Fix context awareness

### DIFF
--- a/sentences/fr/light_HassTurnOff.yaml
+++ b/sentences/fr/light_HassTurnOff.yaml
@@ -27,7 +27,8 @@ intents:
         slots:
           domain: light
         requires_context:
-          area: null
+          area:
+            slot: true
 
       # name + area
       # See intents/sentences/fr/homeassistant_HassTurnOff.yaml

--- a/sentences/fr/light_HassTurnOn.yaml
+++ b/sentences/fr/light_HassTurnOn.yaml
@@ -29,7 +29,8 @@ intents:
         slots:
           domain: light
         requires_context:
-          area: null
+          area:
+            slot: true
 
       # name + area
       # See intents/sentences/fr/homeassistant_HassTurnOff.yaml

--- a/sentences/nl/light_HassTurnOff.yaml
+++ b/sentences/nl/light_HassTurnOff.yaml
@@ -32,7 +32,8 @@ intents:
         slots:
           domain: "light"
         requires_context:
-          area: null
+          area:
+            slot: true
 
       - sentences:
           - "[<doe>] ((overal|<alle>) <lamp>|<lamp> overal) uit"

--- a/sentences/nl/light_HassTurnOn.yaml
+++ b/sentences/nl/light_HassTurnOn.yaml
@@ -34,4 +34,5 @@ intents:
         slots:
           domain: "light"
         requires_context:
-          area: null
+          area:
+            slot: true

--- a/tests/fr/light_HassTurnOff.yaml
+++ b/tests/fr/light_HassTurnOff.yaml
@@ -40,4 +40,5 @@ tests:
         area: Living Room
       slots:
         domain: light
+        area: Living Room
     response: "Lumières éteintes"

--- a/tests/fr/light_HassTurnOn.yaml
+++ b/tests/fr/light_HassTurnOn.yaml
@@ -44,4 +44,5 @@ tests:
         area: Living Room
       slots:
         domain: light
+        area: Living Room
     response: "Lumières allumées"

--- a/tests/nl/light_HassTurnOff.yaml
+++ b/tests/nl/light_HassTurnOff.yaml
@@ -44,6 +44,7 @@ tests:
       context:
         area: Woonkamer
       slots:
+        area: Woonkamer
         domain: light
     response: "Verlichting uitgezet"
 

--- a/tests/nl/light_HassTurnOn.yaml
+++ b/tests/nl/light_HassTurnOn.yaml
@@ -47,5 +47,6 @@ tests:
       context:
         area: Woonkamer
       slots:
+        area: Woonkamer
         domain: light
     response: "Verlichting aangezet"


### PR DESCRIPTION
The way context awareness is processed changed recently (See commit for EN sentences here https://github.com/home-assistant/intents/commit/eda5cba86371a7145124b1aa4d5c19e2351f9d6f) 

I mentioned that FR and NL were still using the old syntax to @synesthesiam and we agreed that we will try to fix this before tomorrow's release.

We now need to explicitly tell in the sentence to add the area in a slot as such:
```yaml
  requires_context:
    area:
      slot: true
```
_This is what changed in the sentences._

The tests have been updated to accommodate the additional slot passed to the intent.