### PR TITLE
Remove area "all" slot for all languages

### DIFF
--- a/sentences/ar/fan_HassTurnOff.yaml
+++ b/sentences/ar/fan_HassTurnOff.yaml
@@ -14,5 +14,4 @@ intents:
         slots:
           domain: fan
           name: all
-          area: all
         response: fan_all

--- a/sentences/ar/light_HassLightSet.yaml
+++ b/sentences/ar/light_HassLightSet.yaml
@@ -26,7 +26,6 @@ intents:
           - "[<turn>] <intensity> <all> <light> [الى] <brightness>"
           - "[<turn>] <all> <light> [الى] <intensity> <brightness>"
         slots:
-          area: all
           name: all
         response: brightness
 
@@ -54,7 +53,6 @@ intents:
           - "[<turn>] <all> <light> [الى] <intensity> {brightness_level:brightness}"
         slots:
           name: all
-          area: all
         response: brightness
 
       # Color
@@ -81,6 +79,5 @@ intents:
           - "[<turn>] <color> <all> <light> [الى] <colors>"
           - "[<turn>] <all> <light> [الى] <color> <colors>"
         slots:
-          area: all
           name: all
         response: color

--- a/sentences/ar/light_HassTurnOff.yaml
+++ b/sentences/ar/light_HassTurnOff.yaml
@@ -13,6 +13,5 @@ intents:
           - "<turn_off> [<all>] <light>"
         slots:
           domain: light
-          area: all
           name: all
         response: light_all

--- a/sentences/es/fan_HassTurnOff.yaml
+++ b/sentences/es/fan_HassTurnOff.yaml
@@ -14,5 +14,4 @@ intents:
         response: "light_all"
         slots:
           domain: "fan"
-          area: "all"
           name: "all"

--- a/sentences/fr/light_HassTurnOn.yaml
+++ b/sentences/fr/light_HassTurnOn.yaml
@@ -41,5 +41,5 @@ intents:
           - <allume> <tous> [<le>]<lumieres>
         slots:
           domain: light
-          area: all
+          name: all
         response: lights

--- a/sentences/hr/fan_HassTurnOff.yaml
+++ b/sentences/hr/fan_HassTurnOff.yaml
@@ -15,5 +15,4 @@ intents:
         response: "fans_area"
         slots:
           domain: "fan"
-          area: "all"
           name: "all"

--- a/sentences/hr/fan_HassTurnOn.yaml
+++ b/sentences/hr/fan_HassTurnOn.yaml
@@ -15,5 +15,4 @@ intents:
         response: "fans_area"
         slots:
           domain: "fan"
-          area: "all"
           name: "all"

--- a/sentences/lv/cover_HassTurnOff.yaml
+++ b/sentences/lv/cover_HassTurnOff.yaml
@@ -7,7 +7,6 @@ intents:
         response: cover_device_class
         slots:
           device_class: garage
-          area: all
           name: all
           domain: cover
       - sentences:

--- a/sentences/lv/cover_HassTurnOn.yaml
+++ b/sentences/lv/cover_HassTurnOn.yaml
@@ -7,7 +7,6 @@ intents:
         response: cover_device_class
         slots:
           device_class: garage
-          area: all
           name: all
           domain: cover
       - sentences:

--- a/sentences/nb/fan_HassTurnOff.yaml
+++ b/sentences/nb/fan_HassTurnOff.yaml
@@ -22,6 +22,5 @@ intents:
           - "<skru_av> [<alle>] <vifte> <i_på> alle rom"
         slots:
           domain: "fan"
-          area: "all"
           name: "all"
         response: "fans_all"

--- a/sentences/nb/fan_HassTurnOn.yaml
+++ b/sentences/nb/fan_HassTurnOn.yaml
@@ -14,6 +14,5 @@ intents:
           - "<skru_på> [<alle>] <vifte> <i_på> alle rom"
         slots:
           domain: "fan"
-          area: "all"
           name: "all"
         response: "fans_all"

--- a/sentences/nb/light_HassTurnOff.yaml
+++ b/sentences/nb/light_HassTurnOff.yaml
@@ -14,6 +14,5 @@ intents:
           - "<skru_av> <alle> <lys>"
         slots:
           domain: "light"
-          area: "all"
           name: "all"
         response: "lights_all"

--- a/sentences/nb/light_HassTurnOn.yaml
+++ b/sentences/nb/light_HassTurnOn.yaml
@@ -14,6 +14,5 @@ intents:
           - "<skru_på> <alle> <lys>"
         slots:
           domain: "light"
-          area: "all"
           name: "all"
         response: "lights_all"

--- a/sentences/nl/fan_HassTurnOff.yaml
+++ b/sentences/nl/fan_HassTurnOff.yaml
@@ -24,5 +24,4 @@ intents:
         response: "fan_all"
         slots:
           domain: "fan"
-          area: "all"
           name: "all"

--- a/sentences/nl/light_HassTurnOff.yaml
+++ b/sentences/nl/light_HassTurnOff.yaml
@@ -43,5 +43,4 @@ intents:
         response: "light_all"
         slots:
           domain: "light"
-          area: "all"
           name: "all"

--- a/sentences/pl/fan_HassTurnOff.yaml
+++ b/sentences/pl/fan_HassTurnOff.yaml
@@ -23,5 +23,4 @@ intents:
         slots:
           domain: fan
           name: all
-          area: all
         response: fans_all

--- a/sentences/pl/fan_HassTurnOn.yaml
+++ b/sentences/pl/fan_HassTurnOn.yaml
@@ -23,5 +23,4 @@ intents:
         slots:
           domain: fan
           name: all
-          area: all
         response: fans_all

--- a/sentences/pl/light_HassTurnOff.yaml
+++ b/sentences/pl/light_HassTurnOff.yaml
@@ -13,6 +13,5 @@ intents:
           - "(<turn_off>|<turn_off_light>) [<all>] światła"
         slots:
           domain: "light"
-          area: "all"
           name: "all"
         response: "light_all"

--- a/sentences/pl/light_HassTurnOn.yaml
+++ b/sentences/pl/light_HassTurnOn.yaml
@@ -13,6 +13,5 @@ intents:
           - "(<turn_on>|<turn_on_light>) <all> światła"
         slots:
           domain: light
-          area: all
           name: all
         response: light_all

--- a/sentences/pt-br/light_HassTurnOff.yaml
+++ b/sentences/pt-br/light_HassTurnOff.yaml
@@ -11,6 +11,5 @@ intents:
           - "<desligar> [tod[a|o]s] [(o[s]| a[s])] (luz[es]| lâmpada[s]) [da casa]"
         slots:
           domain: "light"
-          area: "all"
           name: "all"
         response: "light_all"

--- a/sentences/pt-br/light_HassTurnOn.yaml
+++ b/sentences/pt-br/light_HassTurnOn.yaml
@@ -11,6 +11,5 @@ intents:
           - "<ligar> [tod[a|o]s] [(o[s]| a[s])] (luz[es]| lâmpada[s]) [da casa]"
         slots:
           domain: "light"
-          area: "all"
           name: "all"
         response: "light_all"

--- a/sentences/sl/fan_HassTurnOff.yaml
+++ b/sentences/sl/fan_HassTurnOff.yaml
@@ -15,5 +15,4 @@ intents:
         response: "fans_area"
         slots:
           domain: "fan"
-          area: "all"
           name: "all"

--- a/sentences/sl/fan_HassTurnOn.yaml
+++ b/sentences/sl/fan_HassTurnOn.yaml
@@ -7,7 +7,6 @@ intents:
           - "<vključi> [vse|vso] <area> (ventilator[je]|ventilacijo)"
         slots:
           domain: "fan"
-          area: "all"
         response: fans_area
 
       - sentences:
@@ -15,5 +14,4 @@ intents:
         response: "fans_area"
         slots:
           domain: "fan"
-          area: "all"
           name: "all"

--- a/sentences/zh-tw/fan_HassTurnOff.yaml
+++ b/sentences/zh-tw/fan_HassTurnOff.yaml
@@ -19,5 +19,4 @@ intents:
         response: "light_all"
         slots:
           domain: "fan"
-          area: "all"
           name: "all"

--- a/sentences/zh-tw/light_HassTurnOff.yaml
+++ b/sentences/zh-tw/light_HassTurnOff.yaml
@@ -19,5 +19,4 @@ intents:
         response: "light_all"
         slots:
           domain: "light"
-          area: "all"
           name: "all"

--- a/tests/ar/fan_HassTurnOff.yaml
+++ b/tests/ar/fan_HassTurnOff.yaml
@@ -17,7 +17,6 @@ tests:
     intent:
       name: HassTurnOff
       slots:
-        area: all
         domain: fan
         name: all
     response: "تم اطفاء جميع المراوح"

--- a/tests/ar/light_HassLightSet.yaml
+++ b/tests/ar/light_HassLightSet.yaml
@@ -36,7 +36,6 @@ tests:
       slots:
         name: all
         brightness: 50
-        area: all
     response:
       - "تم ضبط السطوع إلى 50"
 
@@ -103,7 +102,6 @@ tests:
       slots:
         name: all
         brightness: 1
-        area: all
     response:
       - "تم ضبط السطوع إلى منخفض"
 
@@ -116,7 +114,6 @@ tests:
       slots:
         name: all
         brightness: 100
-        area: all
     response:
       - "تم ضبط السطوع إلى قصوى"
 
@@ -156,6 +153,5 @@ tests:
       slots:
         name: all
         color: red
-        area: all
     response:
       - "تم ضبط اللون إلى احمر"

--- a/tests/ar/light_HassTurnOff.yaml
+++ b/tests/ar/light_HassTurnOff.yaml
@@ -23,6 +23,5 @@ tests:
       name: HassTurnOff
       slots:
         domain: light
-        area: all
         name: all
     response: "تم اطفاء جميع الاضواء"

--- a/tests/fr/light_HassTurnOn.yaml
+++ b/tests/fr/light_HassTurnOn.yaml
@@ -30,7 +30,7 @@ tests:
       name: HassTurnOn
       slots:
         domain: light
-        area: all
+        name: all
     response: Lumières allumées
 
   - sentences:

--- a/tests/hr/fan_HassTurnOff.yaml
+++ b/tests/hr/fan_HassTurnOff.yaml
@@ -36,6 +36,5 @@ tests:
       name: HassTurnOff
       slots:
         domain: fan
-        area: all
         name: all
     response: "Ventilatori su isključeni"

--- a/tests/hr/fan_HassTurnOn.yaml
+++ b/tests/hr/fan_HassTurnOn.yaml
@@ -34,6 +34,5 @@ tests:
       name: HassTurnOn
       slots:
         domain: fan
-        area: all
         name: all
     response: "Ventilatori su uključeni"

--- a/tests/lv/cover_HassTurnOff.yaml
+++ b/tests/lv/cover_HassTurnOff.yaml
@@ -6,7 +6,6 @@ tests:
       name: HassTurnOff
       slots:
         device_class: garage
-        area: all
         name: all
         domain: cover
     response: Closed garage

--- a/tests/lv/cover_HassTurnOn.yaml
+++ b/tests/lv/cover_HassTurnOn.yaml
@@ -6,7 +6,6 @@ tests:
       name: HassTurnOn
       slots:
         device_class: garage
-        area: all
         name: all
         domain: cover
     response: Opened garage

--- a/tests/lv/homeassistant_HassTurnOff.yaml
+++ b/tests/lv/homeassistant_HassTurnOff.yaml
@@ -58,7 +58,6 @@ tests:
       name: HassTurnOff
       slots:
         device_class: garage
-        area: all
         name: all
         domain: cover
   - sentences:

--- a/tests/lv/homeassistant_HassTurnOn.yaml
+++ b/tests/lv/homeassistant_HassTurnOn.yaml
@@ -58,7 +58,6 @@ tests:
       name: HassTurnOn
       slots:
         device_class: garage
-        area: all
         name: all
         domain: cover
   - sentences:

--- a/tests/nb/light_HassTurnOff.yaml
+++ b/tests/nb/light_HassTurnOff.yaml
@@ -77,6 +77,5 @@ tests:
       name: HassTurnOff
       slots:
         domain: light
-        area: all
         name: all
     response: "Slo av alle lys"

--- a/tests/nb/light_HassTurnOn.yaml
+++ b/tests/nb/light_HassTurnOn.yaml
@@ -77,6 +77,5 @@ tests:
       name: HassTurnOn
       slots:
         domain: light
-        area: all
         name: all
     response: "Slo på alle lys"

--- a/tests/nl/fan_HassTurnOff.yaml
+++ b/tests/nl/fan_HassTurnOff.yaml
@@ -41,5 +41,4 @@ tests:
       name: HassTurnOff
       slots:
         domain: fan
-        area: all
         name: all

--- a/tests/nl/light_HassTurnOff.yaml
+++ b/tests/nl/light_HassTurnOff.yaml
@@ -63,5 +63,4 @@ tests:
       name: HassTurnOff
       slots:
         domain: light
-        area: all
         name: all

--- a/tests/pl/fan_HassTurnOff.yaml
+++ b/tests/pl/fan_HassTurnOff.yaml
@@ -35,6 +35,5 @@ tests:
       name: HassTurnOff
       slots:
         domain: fan
-        area: all
         name: all
     response: Wyłączono wszystkie wentylatory

--- a/tests/pl/fan_HassTurnOn.yaml
+++ b/tests/pl/fan_HassTurnOn.yaml
@@ -35,6 +35,5 @@ tests:
       name: HassTurnOn
       slots:
         domain: fan
-        area: all
         name: all
     response: Włączono wszystkie wentylatory

--- a/tests/pl/light_HassTurnOff.yaml
+++ b/tests/pl/light_HassTurnOff.yaml
@@ -20,6 +20,5 @@ tests:
       name: HassTurnOff
       slots:
         name: all
-        area: all
         domain: light
     response: Wyłączono wszystkie światła

--- a/tests/pl/light_HassTurnOn.yaml
+++ b/tests/pl/light_HassTurnOn.yaml
@@ -19,7 +19,6 @@ tests:
     intent:
       name: HassTurnOn
       slots:
-        area: all
         name: all
         domain: light
     response: Włączono wszystkie światła

--- a/tests/sl/fan_HassTurnOff.yaml
+++ b/tests/sl/fan_HassTurnOff.yaml
@@ -31,6 +31,5 @@ tests:
       name: HassTurnOff
       slots:
         domain: fan
-        area: all
         name: all
     response: "Ventilator je izklopljen"

--- a/tests/sl/fan_HassTurnOn.yaml
+++ b/tests/sl/fan_HassTurnOn.yaml
@@ -22,6 +22,5 @@ tests:
       name: HassTurnOn
       slots:
         domain: fan
-        area: all
         name: all
     response: "Ventilator je vklopljen"

--- a/tests/zh-tw/fan_HassTurnOff.yaml
+++ b/tests/zh-tw/fan_HassTurnOff.yaml
@@ -24,5 +24,4 @@ tests:
       name: HassTurnOff
       slots:
         domain: fan
-        area: all
         name: all

--- a/tests/zh-tw/light_HassTurnOff.yaml
+++ b/tests/zh-tw/light_HassTurnOff.yaml
@@ -22,5 +22,4 @@ tests:
       name: HassTurnOff
       slots:
         domain: light
-        area: all
         name: all


### PR DESCRIPTION
Following https://github.com/home-assistant/intents/pull/1500
`area: all` doesn't target all areas but only the area called "all" so it should not be used.