### PR TITLE
[FR] Remove name all slot for french intents

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -24,6 +24,8 @@ HassTurnOn:
       - "name"
     area_only:
       - "area"
+    domain_only:
+      - "domain"
     area_name:
       - "name"
       - "area"
@@ -54,6 +56,25 @@ HassTurnOff:
     device_class:
       description: "Device class of devices/entities in an area"
       required: false
+  slot_combinations:
+    name_only:
+      - "name"
+    area_only:
+      - "area"
+    domain_only:
+      - "domain"
+    area_name:
+      - "name"
+      - "area"
+    area_domain:
+      - "area"
+      - "domain"
+    area_device_class:
+      - "area"
+      - "device_class"
+    domain_device_class:
+      - "domain"
+      - "device_class"
 
 HassGetState:
   supported: true

--- a/sentences/fr/cover_HassTurnOff.yaml
+++ b/sentences/fr/cover_HassTurnOff.yaml
@@ -21,7 +21,6 @@ intents:
           - <ferme> tous (<volets>|<volet>)
         response: cover_device_class
         slots:
-          name: all
           device_class:
             - blind
             - curtain

--- a/sentences/fr/cover_HassTurnOn.yaml
+++ b/sentences/fr/cover_HassTurnOn.yaml
@@ -32,7 +32,6 @@ intents:
           - <ouvre> tous [les] (<volets>|<volet>)
         response: cover_device_class
         slots:
-          name: all
           device_class:
             - blind
             - curtain

--- a/sentences/fr/fan_HassTurnOff.yaml
+++ b/sentences/fr/fan_HassTurnOff.yaml
@@ -6,7 +6,6 @@ intents:
           - "<eteins> [tous] <ventilateurs> <dans> [[<le>]{area}]"
         slots:
           domain: fan
-          name: all
         response: fans
       - sentences:
           - "<eteins> <ventilateur> [<dans>] [[<le>]{area}]"

--- a/sentences/fr/fan_HassTurnOn.yaml
+++ b/sentences/fr/fan_HassTurnOn.yaml
@@ -6,7 +6,6 @@ intents:
           - "<allume> [tous] (<ventilateur> | <ventilateurs>) <dans> [[<le>]{area}]"
         slots:
           domain: fan
-          name: all
         response: fans
       - sentences:
           - "<allume> (<ventilateur> | <ventilateurs>) [<dans>] [[<le>]{area}]"

--- a/sentences/fr/light_HassLightSet.yaml
+++ b/sentences/fr/light_HassLightSet.yaml
@@ -41,8 +41,6 @@ intents:
           # Règle les lumieres du bureau avec la luminosité à 50% (Too complex... We should think about removing that)
           - "(<allume>|<regle>) [<tous>] [<le>][<lumieres>] [<de>] [<le>]{area} [avec la luminosité|avec la lumière] [à] {brightness}<pourcent>"
         response: brightness
-        slots:
-          name: all
 
       # brightness (name + area)
       - sentences:
@@ -82,8 +80,6 @@ intents:
           - "(<regle>|<allume>) [<tous>] [<le>](<lumiere>|<lumieres>) [<de>] [<le>]{area} [avec la couleur | de couleur | en] {color}"
           # Allume le salon en rouge
           - "(<regle>|<allume>) [<le>]{area} [avec la couleur | de couleur | en] {color}"
-        slots:
-          name: all
         response: color
 
       # color (name + area)

--- a/sentences/fr/light_HassTurnOff.yaml
+++ b/sentences/fr/light_HassTurnOff.yaml
@@ -41,5 +41,4 @@ intents:
           - <eteins> <tous> [<le>]<lumieres>
         slots:
           domain: light
-          name: all
         response: lights

--- a/sentences/fr/light_HassTurnOn.yaml
+++ b/sentences/fr/light_HassTurnOn.yaml
@@ -41,5 +41,4 @@ intents:
           - <allume> <tous> [<le>]<lumieres>
         slots:
           domain: light
-          area: all
         response: lights

--- a/sentences/fr/lock_HassTurnOff.yaml
+++ b/sentences/fr/lock_HassTurnOff.yaml
@@ -12,5 +12,4 @@ intents:
           - "déverrouille[(z|r)] [<tous>] [(la|le[s])] [(porte[s]|serrure[s]|verrou[s])] [<dans>] [<le>]{area}"
         slots:
           domain: "lock"
-          name: "all"
         response: lock

--- a/sentences/fr/lock_HassTurnOn.yaml
+++ b/sentences/fr/lock_HassTurnOn.yaml
@@ -13,5 +13,4 @@ intents:
           - "verrouille[(z|r)] [<tous>] (la|le[s]) (porte[s]|serrure[s]|verrou[s]) [<dans> [<le>]{area}]"
         slots:
           domain: "lock"
-          name: "all"
         response: lock

--- a/tests/fr/cover_HassTurnOff.yaml
+++ b/tests/fr/cover_HassTurnOff.yaml
@@ -37,7 +37,6 @@ tests:
     intent:
       name: HassTurnOff
       slots:
-        name: all
         device_class:
           - blind
           - curtain

--- a/tests/fr/cover_HassTurnOn.yaml
+++ b/tests/fr/cover_HassTurnOn.yaml
@@ -37,7 +37,6 @@ tests:
     intent:
       name: HassTurnOn
       slots:
-        name: all
         device_class:
           - blind
           - curtain

--- a/tests/fr/fan_HassTurnOff.yaml
+++ b/tests/fr/fan_HassTurnOff.yaml
@@ -12,5 +12,4 @@ tests:
       slots:
         area: salon
         domain: fan
-        name: all
     response: "Ventilateurs éteints"

--- a/tests/fr/fan_HassTurnOn.yaml
+++ b/tests/fr/fan_HassTurnOn.yaml
@@ -10,5 +10,4 @@ tests:
       slots:
         area: salon
         domain: fan
-        name: all
     response: "Ventilateurs allumés"

--- a/tests/fr/homeassistant_HassTurnOff.yaml
+++ b/tests/fr/homeassistant_HassTurnOff.yaml
@@ -81,4 +81,3 @@ tests:
           - blind
           - curtain
           - shutter
-        name: all

--- a/tests/fr/homeassistant_HassTurnOn.yaml
+++ b/tests/fr/homeassistant_HassTurnOn.yaml
@@ -83,4 +83,3 @@ tests:
           - blind
           - curtain
           - shutter
-        name: all

--- a/tests/fr/light_HassLightSet.yaml
+++ b/tests/fr/light_HassLightSet.yaml
@@ -43,7 +43,6 @@ tests:
       slots:
         brightness: 50
         area: cuisine
-        name: all
     response: Luminosité réglée
 
   # brightness (name + area)
@@ -93,7 +92,6 @@ tests:
       slots:
         color: red
         area: cuisine
-        name: all
     response: Couleur réglée
 
   # color (name + area)
@@ -137,5 +135,4 @@ tests:
       slots:
         area: chambre
         color: red
-        name: all
     response: Couleur réglée

--- a/tests/fr/light_HassTurnOff.yaml
+++ b/tests/fr/light_HassTurnOff.yaml
@@ -26,7 +26,6 @@ tests:
       name: HassTurnOff
       slots:
         domain: light
-        name: all
     response: Lumières éteintes
 
   - sentences:

--- a/tests/fr/light_HassTurnOn.yaml
+++ b/tests/fr/light_HassTurnOn.yaml
@@ -30,7 +30,6 @@ tests:
       name: HassTurnOn
       slots:
         domain: light
-        area: all
     response: Lumières allumées
 
   - sentences:

--- a/tests/fr/lock_HassTurnOff.yaml
+++ b/tests/fr/lock_HassTurnOff.yaml
@@ -19,7 +19,6 @@ tests:
       slots:
         area: garage
         domain: lock
-        name: all
     response: "Ouvert"
 
   - sentences:
@@ -29,5 +28,4 @@ tests:
       slots:
         area: entrée
         domain: lock
-        name: all
     response: "Ouvert"

--- a/tests/fr/lock_HassTurnOn.yaml
+++ b/tests/fr/lock_HassTurnOn.yaml
@@ -19,7 +19,6 @@ tests:
       slots:
         area: garage
         domain: lock
-        name: all
     response: "Fermé"
 
   - sentences:
@@ -29,5 +28,4 @@ tests:
       slots:
         area: entrée
         domain: lock
-        name: all
     response: "Fermé"


### PR DESCRIPTION
Allow targeting all entities from a domain without setting `name: all` (e.g. turning on/off all lights of the house) by adding `domain_only` slot combination.

@synesthesiam Not sure if a core update is required for that so I put this PR in draft 🙂
I also noticed that slot combinations were missing for `HassTurnOff`.