### PR TITLE
[FR] Add context light to sentence targeting `{name}`

### DIFF
--- a/sentences/fr/light_HassLightSet.yaml
+++ b/sentences/fr/light_HassLightSet.yaml
@@ -20,6 +20,8 @@ intents:
           - "[<le>]{name} [à] {brightness}<pourcent> [de] luminosité"
           # Sapin luminosité 30%
           - "[<le>]{name} luminosité [à] {brightness}<pourcent>"
+        requires_context:
+          domain: light
         response: brightness
 
       # brightness (area)
@@ -60,6 +62,8 @@ intents:
           - "[<le>]{name} [<dans>] [<le>]{area} {brightness}<pourcent> [de] luminosité"
           # Mirroir salle de bain luminosité 40%
           - "[<le>]{name} [<dans>] [<le>]{area} luminosité {brightness}<pourcent>"
+        requires_context:
+          domain: light
         response: brightness
 
       # color (name)
@@ -68,6 +72,8 @@ intents:
           - "<regle> la couleur [<de>] [<le>]{name} [en] {color}"
           # Règle le mirrior en vert
           - "(<regle>|<allume>) [<le>]{name} [avec la couleur | de couleur | en] {color}"
+        requires_context:
+          domain: light
         response: color
 
       # color (area)
@@ -88,4 +94,6 @@ intents:
           - "<regle> la couleur [<de>] [<le>]{name} [<dans>] [<le>]{area} [en] {color}"
           # Allume le sapin de l'exterieur en vert
           - (<regle>|<allume>) [<le>]{name} [<dans>] [<le>]{area} [avec la couleur | de couleur | en] {color}
+        requires_context:
+          domain: light
         response: color


### PR DESCRIPTION
@piitaya very strange PR, that requires a few explanations

So we have a bug on our French intents today on the intent `light_HassLightSet`.

As you can see here, the intent can be targeted by any entity, of any domain:
<img width="362" alt="Screenshot 2024-01-06 at 16 37 35" src="https://github.com/home-assistant/intents/assets/5878296/4d75be53-ba50-40c2-b490-e7066228677d">

So my initial plan was to add 
```yaml
        requires_context:
          domain: light
``` 
on any sentences targeting a `{name}`

and add
```yaml
        slots:
          domain: light
```
on any sentences targeting an `{area}`

The thing is, the test engine fails if I add a `slot` on the `sentence` file with this:
```
FAILED tests/test_language_intents.py::test_light_HassLightSet[fr] - AssertionError: File light_HassLightSet.yaml should only have sentences without a domain slot
```

My gues is that, if you target an area, the `domain` `light` is already targeted on the intent itself and you do not need to add it.

I checked in English, it's the same behavior... a `requires_context` in any sentences targeting a `{name}`, nothing in any sentences targeting an `{area}`

The second peculiar thing: Nothing has to be added on the test, I tried adding a `domain: light` as `context`, but the test engine fails too with
```
FAILED tests/test_language_sentences.py::test_light_HassLightSet[fr] - AssertionError: File light_HassLightSet: tests should not have a domain slot
```

So the context is not added for `light_HassLightSet` .. in comparison of `homeassistant_HassTurnOn` for example where we had to add the `domain` as `context` for all tests. 
Very strange inconsistency, I guess it is coming from the fact that the intent already targets a domain by design.

So the only thing needed is to require a context on the sentence.
I tested it and indeed, this addition makes the intent parser fails for `Allume less volets en rouge`, which is a good thing.