### PR TITLE
[EN] Better error messages

### DIFF
--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -2,10 +2,10 @@ language: "en"
 responses:
   errors:
     no_intent: "Sorry, I couldn't understand that"
-    no_area: "No area named {{ area }}"
-    no_domain: "{{ area }} does not contain a {{ domain }}"
-    no_device_class: "{{ area }} does not contain a {{ device_class }}"
-    no_entity: "No device or entity named {{ entity }}"
+    no_area: "Sorry, I am not aware of any area called {{ area }}"
+    no_domain: "Sorry, I am not aware of any {{ domain }} in the {{ area }} area"
+    no_device_class: "Sorry, I am not aware of any {{ device_class }} in the {{ area }} area"
+    no_entity: "Sorry, I am not aware of any device or entity called {{ entity }}"
     handle_error: "An unexpected error occurred while handling the intent"
 lists:
   color:


### PR DESCRIPTION
Friendlier error messages in the context of https://github.com/home-assistant/core/pull/107151

I picked "called" instead of "named" to hint that aliases are included as well, as opposed to just names.

I picked "I am not aware" instead of "I couldn't find" as I think that, traditionally, inability to find something hints to its non-existence, whereas the issue here might be a lack of exposure which can be fixed by exposing an entity to Assist.

I used `in the {{area}} area` instead of `in {{area}}` because of prepositionless area names like `Outside` or other area names that might require different prepositions, like `[on the] Lawn`, `[on the] Porch` etc.