### PR TITLE
[EN] Fix scene sentences

### DIFF
--- a/sentences/en/scene_HassTurnOn.yaml
+++ b/sentences/en/scene_HassTurnOn.yaml
@@ -3,18 +3,25 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "[activate|<turn>] <name> [scene] [on]"
-          - "(change|transition) to <name> [scene]"
+          - "[activate] <name> [scene]"
+          - "<name> on"
+          - "<turn> (<name> [scene];on)"
+          - "(change|transition) to (<name> [scene]|scene <name>)"
         requires_context:
           domain: scene
         slots:
           domain: scene
         response: scene
       - sentences:
-          - "[activate|<turn>] <area> <name> [scene] [on]"
-          - "[activate|<turn>] <name> [scene] <in> <area>"
+          - "[activate] <area> <name> [scene]"
+          - "<area> <name> on"
+          - "<turn> (<area> <name> [scene];on)"
+          - "[activate] <name> [scene] <in> <area>"
+          - "<turn> (<name> [scene] <in> <area>;on)"
           - "(change|transition) ([to] <area> <name>|<area> to <name>) [scene]"
           - "(change|transition) to <name> [scene] <in> <area>"
+        requires_context:
+          domain: scene
         slots:
           domain: scene
         response: scene

--- a/tests/en/scene_HassTurnOn.yaml
+++ b/tests/en/scene_HassTurnOn.yaml
@@ -18,6 +18,7 @@ tests:
       - "activate party mode in the kitchen"
       - "activate party mode at the Kitchen"
       - "kitchen party mode on"
+      - "turn on party mode in the kitchen"
       - "change kitchen to the party mode scene"
       - "transition to the kitchen party mode"
       - "change to party mode at the kitchen"


### PR DESCRIPTION
Too many optional components in sentences for `scene` activation

Also, one set of sentences lacked the `requires_context: { domain: "scene" }` clause, making it match against other unintended custom sentences. [Details here](https://discord.com/channels/330944238910963714/646814454063038466/1199845994439905320).