### PR TITLE
[FR] Error message improvements

### DIFF
--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -2,10 +2,54 @@ language: fr
 responses:
   errors:
     no_intent: "Désolé, je n'ai pas compris"
-    no_area: "Aucune zone appelée {{ area }}"
-    no_domain: "{{ area }} ne contient pas de {{ domain }}"
-    no_device_class: "{{ area }} ne contient pas de {{ device_class }}"
-    no_entity: "Aucun appareil ou entité appelé {{ entity }}"
+    no_area: "Désolé, je ne connais pas la pièce {{ area }}"
+    no_domain: |
+      {% set translations_domains_with_article = {
+        "button": "de boutons",
+        "camera": "de caméras",
+        "input_button": "de boutons",
+        "alarm_control_panel": "d'alarmes",
+        "automation": "d'automatisations",
+        "fan": "de ventilateurs",
+        "climate": "de thermostats",
+        "humidifier": "d'humidificateurs",
+        "input_boolean": "de commutateurs",
+        "siren": "de sirènes",
+        "water_heater": "de ballon d'eau chaude",
+        "light": "de lumières",
+        "switch": "de commutateurs",
+        "script": "de scripts",
+        "remote": "de télécommandes",
+        "lock": "de verrous",
+        "vacuum": "d'aspirateurs",
+        "scene": "de scènes",
+        "media_player": "de lecteurs multimédia",
+        "lawn_mower": "de tondeuses à gazon",
+        "valve": "de vannes"
+        } %}
+      {% if domain in translations_domains_with_article %}
+        Désolé, je n'ai pas trouvé {{ translations_domains_with_article[domain] }} dans {{ area }}
+      {% else %}
+        Désolé, je n'ai rien trouvé de correspondant  dans {{ area }}
+      {% endif %}
+    no_device_class: |
+      {% set translations_cover_device_classes_with_article = {
+        "awning": "d'auvents",
+        "blind": "de stores vénitiens",
+        "curtain": "de rideaux",
+        "door": "de porte",
+        "garage": "de portes de garage",
+        "gate": "de portes",
+        "shade": "de stores",
+        "shutter": "de volets",
+        "window": "de fenêtres"
+        } %}
+      {% if device_class in translations_cover_device_classes_with_article %}
+        Désolé, je n'ai pas trouvé {{ translations_cover_device_classes_with_article[device_class] }} dans {{ area }}
+      {% else %}
+        Désolé, je n'ai rien trouvé de correspondant  dans {{ area }}
+      {% endif %}
+    no_entity: "Désolé, je ne connais pas l'appareil {{ entity }}"
     handle_error: "Une erreur est intervenue pendant le traitement"
 lists:
   color:

--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -37,7 +37,7 @@ responses:
         "awning": "d'auvents",
         "blind": "de stores",
         "curtain": "de rideaux",
-        "door": "de porte",
+        "door": "de portes",
         "garage": "de portes de garage",
         "gate": "de portes",
         "shade": "de stores",

--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -35,7 +35,7 @@ responses:
     no_device_class: |
       {% set translations_cover_device_classes_with_article = {
         "awning": "d'auvents",
-        "blind": "de stores vénitiens",
+        "blind": "de stores",
         "curtain": "de rideaux",
         "door": "de porte",
         "garage": "de portes de garage",
@@ -118,13 +118,10 @@ lists:
         out: "closing"
   cover_classes:
     values:
-      - in: "store[s]"
+      - in: "store[s] [vénitien[s]]"
         out:
-          - "awning"
           - "blind"
           - "shade"
-      - in: "store[s] vénitien[s]"
-        out: "blind"
       - in: "(banne[s])|(auvent[s])|(store[s] banne[s])"
         out: "awning"
       - in: "rideau[x]"

--- a/tests/fr/cover_HassTurnOn.yaml
+++ b/tests/fr/cover_HassTurnOn.yaml
@@ -23,7 +23,6 @@ tests:
       slots:
         area: cuisine
         device_class:
-          - "awning"
           - "blind"
           - "shade"
         domain: cover


### PR DESCRIPTION
## New error message improvements 🎉 

We renamed `area` to `pièce` instead of `zone`.
`zone` is already used for `zone` (An external concept like your kid's school or your work place)

We felt the wording `Aucun appareil ou entité appelé ...` was a bit heavy for a voice interface so we simplified it to `je ne connais pas l'appareil ...`

The biggest change is that we now translate `domains` and `device_classes` for some errors.

Here are a few examples of interactions you will get from this PR:

- `Ouvre les rideaux du jardin`
  - Before:  `Jardin ne continent pas de curtain`
  - Now ✨: `Désolé, je n'ai pas trouvé de rideaux dans jardin`
- Allume les lumières du jardin
  - Before:  `Jardin ne continent pas de light`
  - Now ✨: `Désolé, je n'ai pas trouvé de lumières dans jardin`

## What's "not perfect"
`{area}` cannot be prefaced with the correct article. 

We cannot say:

  - `Dans le jardin`
  -  `Dans la cuisine`
  -  `Dans l'entrée`

 ... because we simply do not know 


For `Cover_HassTurnOn` and `Cover_HassTurnOff`, we have a hybrid mapping of a single word: "Store" matching 3 device classes: 
```yaml
lists:
  ...
  cover_classes:
    values:
      - in: "store[s]"
        out:
          - "shade"
          - "blind"
          - "awning"
      - ....
 ```
 When we say `Ouvre les stores dans {area}` ... If `area` does not contain any of these device classes, then unfortunately, the response will only return the first one alphabetically (awning) .... 
As such 
![image](https://github.com/home-assistant/intents/assets/5878296/5a56361c-54c4-4d3b-a795-67286714b3e4)

Note: I tried to move the order so that `shade` would be the first because `shade` is translated as "Store" .. but I think HASIL is re-ordering them alphabetically...

Note 2: Our hybrid mapping **does work** in case you are wondering, we are really targeting all 3 device classes as shown here (And also on the tests of this repo)
```yaml
intent:
  name: HassTurnOn
slots:
  device_class:
    - shade
    - blind
    - awning
  area: jardin
  domain: cover
details:
  device_class:
    name: device_class
    value:
      - shade
      - blind
      - awning
    text: stores
  area:
    name: area
    value: jardin
    text: jardin
  domain:
    name: domain
    value: cover
    text: ''
targets: {}
match: true
sentence_template: <ouvre> [<tous>] [<le>]{cover_classes:device_class} [<dans>] [<le>]{area}
unmatched_slots: {}
```
This only issue is how the response is constructed, and this is not something we can control here unfortunately 

**_EDIT_**
After talking to @piitaya , we are simplifying our cover device classes mapping
```yaml
      - in: "store[s] [vénitien[s]]"
        out:
          - "blind"
          - "shade"
```
"Store" targets both type of "Store" and both device classes are now translated as "store" (and not "Store vénitien")

JLo