### PR TITLE
[FR] New translation update 

### DIFF
--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -1,10 +1,14 @@
 language: fr
 responses:
   errors:
+    # General errors
     no_intent: "Désolé, je n'ai pas compris"
+    handle_error: "Une erreur est intervenue pendant le traitement"
+
+    # Errors for when user is not logged in
     no_area: "Désolé, je ne connais pas la pièce {{ area }}"
-    no_domain_in_area: |
-      {% set translations_domains_with_article = {
+    no_domain: |
+      {% set translations = {
         "button": "de boutons",
         "camera": "de caméras",
         "input_button": "de boutons",
@@ -27,13 +31,42 @@ responses:
         "lawn_mower": "de tondeuses à gazon",
         "valve": "de vannes"
         } %}
-      {% if domain in translations_domains_with_article %}
-        Désolé, je n'ai pas trouvé {{ translations_domains_with_article[domain] }} dans {{ area }}
-      {% else %}
-        Désolé, je n'ai rien trouvé de correspondant  dans {{ area }}
-      {% endif %}
-    no_device_class_in_area: |
-      {% set translations_cover_device_classes_with_article = {
+      {% if domain in translations -%}
+        Désolé, je n'ai pas trouvé {{ translations[domain] }}
+      {%- else -%}
+        Désolé, je n'ai rien trouvé de correspondant
+      {%- endif %}
+    no_domain_in_area: |
+      {% set translations = {
+        "button": "de boutons",
+        "camera": "de caméras",
+        "input_button": "de boutons",
+        "alarm_control_panel": "d'alarmes",
+        "automation": "d'automatisations",
+        "fan": "de ventilateurs",
+        "climate": "de thermostats",
+        "humidifier": "d'humidificateurs",
+        "input_boolean": "de commutateurs",
+        "siren": "de sirènes",
+        "water_heater": "de ballon d'eau chaude",
+        "light": "de lumières",
+        "switch": "de commutateurs",
+        "script": "de scripts",
+        "remote": "de télécommandes",
+        "lock": "de verrous",
+        "vacuum": "d'aspirateurs",
+        "scene": "de scènes",
+        "media_player": "de lecteurs multimédia",
+        "lawn_mower": "de tondeuses à gazon",
+        "valve": "de vannes"
+        } %}
+      {% if domain in translations -%}
+        Désolé, je n'ai pas trouvé {{ translations[domain] }} dans cette pièce
+      {%- else -%}
+        Désolé, je n'ai rien trouvé de correspondant dans cette pièce
+      {%- endif %}
+    no_device_class: |
+      {% set translations = {
         "awning": "d'auvents",
         "blind": "de stores",
         "curtain": "de rideaux",
@@ -44,13 +77,131 @@ responses:
         "shutter": "de volets",
         "window": "de fenêtres"
         } %}
-      {% if device_class in translations_cover_device_classes_with_article %}
-        Désolé, je n'ai pas trouvé {{ translations_cover_device_classes_with_article[device_class] }} dans {{ area }}
-      {% else %}
-        Désolé, je n'ai rien trouvé de correspondant  dans {{ area }}
-      {% endif %}
-    no_entity: "Désolé, je ne connais pas l'appareil {{ entity }}"
-    handle_error: "Une erreur est intervenue pendant le traitement"
+      {% if device_class in translations -%}
+        Désolé, je n'ai pas trouvé {{ translations[device_class] }}
+      {%- else -%}
+        Désolé, je n'ai rien trouvé de correspondant
+      {%- endif %}
+    no_device_class_in_area: |
+      {% set translations = {
+        "awning": "d'auvents",
+        "blind": "de stores",
+        "curtain": "de rideaux",
+        "door": "de portes",
+        "garage": "de portes de garage",
+        "gate": "de portes",
+        "shade": "de stores",
+        "shutter": "de volets",
+        "window": "de fenêtres"
+        } %}
+      {% if device_class in translations -%}
+        Désolé, je n'ai pas trouvé {{ translations[device_class] }} dans cette pièce
+      {%- else -%}
+        Désolé, je n'ai rien trouvé de correspondant dans cette pièce
+      {%- endif %}
+    no_device: "Désolé, je ne connais pas l'appareil {{ device }}"
+    no_device_in_area: "Désolé, je ne connais pas l'appareil {{ device }}"
+
+    # Errors for when user is logged in and we can give more information
+    no_device_exposed: "Désolé, l'appareil {{ device }} n'est pas exposé"
+    no_device_in_area_exposed: "Désolé, l'appareil {{ device }} n'est pas exposé"
+    no_domain_exposed: |
+      {% set translations = {
+        "button": "aucun bouton n'est exposé",
+        "camera": "aucune caméra n'est exposée",
+        "input_button": "aucun bouton n'est exposé",
+        "alarm_control_panel": "aucune alarme n'est exposée",
+        "automation": "aucune automatisation n'est exposée",
+        "fan": "aucun ventilateur n'est exposé",
+        "climate": "aucun thermostat n'est exposé",
+        "humidifier": "aucun humidificateur n'est exposé",
+        "input_boolean": "aucun commutateur n'est exposé",
+        "siren": "aucune sirène n'est exposée",
+        "water_heater": "aucun ballon d'eau chaude n'est exposé",
+        "light": "aucune lumière n'est exposée",
+        "switch": "aucun commutateur n'est exposé",
+        "script": "aucun script n'est exposé",
+        "remote": "aucune télécommande n'est exposée",
+        "lock": "aucun verrou n'est exposé",
+        "vacuum": "aucun aspirateur n'est exposé",
+        "scene": "aucune scène n'est exposée",
+        "media_player": "aucun lecteur multimédia n'est exposé",
+        "lawn_mower": "aucune tondeuse à gazon n'est exposée",
+        "valve": "aucune vanne n'est exposée"
+        } %}
+      {% if domain in translations -%}
+        Désolé, {{ translations[domain] }}
+      {%- else -%}
+        Désolé, aucun appareil de ce type n'est exposé
+      {%- endif %}
+    no_domain_in_area_exposed: |
+      {% set translations = {
+        "button": "aucun bouton de cette pièce n'est exposé",
+        "camera": "aucune caméra de cette pièce n'est exposée",
+        "input_button": "aucun bouton de cette pièce n'est exposé",
+        "alarm_control_panel": "aucune alarme de cette pièce n'est exposée",
+        "automation": "aucune automatisation de cette pièce n'est exposée",
+        "fan": "aucun ventilateur de cette pièce n'est exposé",
+        "climate": "aucun thermostat de cette pièce n'est exposé",
+        "humidifier": "aucun humidificateur de cette pièce n'est exposé",
+        "input_boolean": "aucun commutateur de cette pièce n'est exposé",
+        "siren": "aucune sirène de cette pièce n'est exposée",
+        "water_heater": "aucun ballon d'eau chaude de cette pièce n'est exposé",
+        "light": "aucune lumière de cette pièce n'est exposée",
+        "switch": "aucun commutateur de cette pièce n'est exposé",
+        "script": "aucun script de cette pièce n'est exposé",
+        "remote": "aucune télécommande de cette pièce n'est exposée",
+        "lock": "aucun verrou de cette pièce n'est exposé",
+        "vacuum": "aucun aspirateur de cette pièce n'est exposé",
+        "scene": "aucune scène de cette pièce n'est exposée",
+        "media_player": "aucun lecteur multimédia de cette pièce n'est exposé",
+        "lawn_mower": "aucune tondeuse à gazon de cette pièce n'est exposée",
+        "valve": "aucune vanne de cette pièce n'est exposée"
+        } %}
+      {% if domain in translations -%}
+        Désolé, {{ translations[domain] }}
+      {%- else -%}
+        Désolé, aucun appareil de ce type n'est exposé
+      {%- endif %}
+    no_device_class_exposed: |
+      {% set translations = {
+        "awning": "aucun auvent n'est exposé",
+        "blind": "aucun store n'est exposé",
+        "curtain": "aucun rideau n'est exposé",
+        "door": "aucune porte n'est exposée",
+        "garage": "aucune porte de garage n'est exposée",
+        "gate": "aucune porte n'est exposée",
+        "shade": "aucun store n'est exposé",
+        "shutter": "aucun volet n'est exposé",
+        "window": "aucune fenêtre n'est exposeé"
+        } %}
+      {% if device_class in translations -%}
+        Désolé, {{ translations[device_class] }}
+      {%- else -%}
+        Désolé, aucun appareil de ce type n'est exposé
+      {%- endif %}
+    no_device_class_in_area_exposed: |
+      {% set translations = {
+        "awning": "aucun auvent de cette pièce n'est exposé",
+        "blind": "aucun store de cette pièce n'est exposé",
+        "curtain": "aucun rideau de cette pièce n'est exposé",
+        "door": "aucune porte de cette pièce n'est exposée",
+        "garage": "aucune porte de garage de cette pièce n'est exposée",
+        "gate": "aucune porte de cette pièce n'est exposée",
+        "shade": "aucun store de cette pièce n'est exposé",
+        "shutter": "aucun volet de cette pièce n'est exposé",
+        "window": "aucune fenêtre de cette pièce n'est exposeé"
+        } %}
+      {% if device_class in translations -%}
+        Désolé, {{ translations[device_class] }}
+      {%- else -%}
+        Désolé, aucun appareil de ce type n'est exposé
+      {%- endif %}
+
+    # Used when multiple (exposed) devices have the same name
+    duplicate_devices: "Désolé, plusieurs appareils sont nommés {{device}}"
+    duplicate_devices_in_area: "Désolé, plusieurs appareils de cette pièce sont nommés {{device}}"
+
 lists:
   color:
     values:

--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -99,12 +99,12 @@ responses:
       {%- else -%}
         Désolé, je n'ai rien trouvé de correspondant dans cette pièce
       {%- endif %}
-    no_device: "Désolé, je ne connais pas l'appareil {{ device }}"
-    no_device_in_area: "Désolé, je ne connais pas l'appareil {{ device }}"
+    no_entity: "Désolé, je ne connais pas l'appareil {{ entity }}"
+    no_entity_in_area: "Désolé, je ne connais pas l'appareil {{ entity }}"
 
     # Errors for when user is logged in and we can give more information
-    no_device_exposed: "Désolé, l'appareil {{ device }} n'est pas exposé"
-    no_device_in_area_exposed: "Désolé, l'appareil {{ device }} n'est pas exposé"
+    no_entity_exposed: "Désolé, l'appareil {{ entity }} n'est pas exposé"
+    no_entity_in_area_exposed: "Désolé, l'appareil {{ entity }} n'est pas exposé"
     no_domain_exposed: |
       {% set translations = {
         "button": "aucun bouton n'est exposé",

--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -199,8 +199,8 @@ responses:
       {%- endif %}
 
     # Used when multiple (exposed) devices have the same name
-    duplicate_devices: "Désolé, plusieurs appareils sont nommés {{device}}"
-    duplicate_devices_in_area: "Désolé, plusieurs appareils de cette pièce sont nommés {{device}}"
+    duplicate_entities: "Désolé, plusieurs appareils sont nommés {{entity}}"
+    duplicate_entities_in_area: "Désolé, plusieurs appareils de cette pièce sont nommés {{entity}}"
 
 lists:
   color:


### PR DESCRIPTION
To be merged after https://github.com/home-assistant/intents/pull/1906

New translation for French errors.

On top of "just" translating the errors in French, we took one decision:

Only one variable will be returned in an error
  - If "living room" is not a known area: 
    - "Open the curtains in the living room" will return "Sorry, `living room` is not a known area"
  - If "living room" is a  known area: 
    - "Open the curtains in the living room" will return "Sorry, no `curtains` in this area"
    
We also decided to translate `no_device` and `no_device_in_area` the same way because we do not know if the device is not known in the context of the area, or just not known overall.