### PR TITLE
[NL] Add support for the word dim to set brightness

### DIFF
--- a/sentences/nl/light_HassLightSet.yaml
+++ b/sentences/nl/light_HassLightSet.yaml
@@ -4,13 +4,13 @@ intents:
     data:
       # Brightness value
       - sentences:
-          - "[<doe>|<zou>] <name>[ ][<lamp>][ ][<helderheid>] [<naar>] <brightness> [[willen|kunnen] <doe>]"
-          - "[<doe>|<zou>] <helderheid> [van] <name>[ ][<lamp>] [<naar>] <brightness> [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>|dim] <name>[ ][<lamp>][ ][<helderheid>] [<naar>] <brightness> [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>] <helderheid> [van] <name>[ ][<lamp>] [<naar>] <brightness> [[willen|kunnen] (<doe>|dimmen)]"
         response: "brightness"
 
       - sentences:
-          - "[<doe>|<zou>] [<helderheid>] <in> <area>[[ ]<lamp>] [<naar>] <brightness> [[willen|kunnen] <doe>]"
-          - "[<doe>|<zou>] <area>[ ][<helderheid>|lamp] [<naar>] <brightness> [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>|dim] [<helderheid>] <in> <area>[[ ]<lamp>] [<naar>] <brightness> [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>] <area>[ ][<helderheid>|lamp] [<naar>] <brightness> [[willen|kunnen] (<doe>|dimmen)]"
         slots:
           name: "all"
         response: "brightness"

--- a/sentences/nl/light_HassLightSet.yaml
+++ b/sentences/nl/light_HassLightSet.yaml
@@ -5,12 +5,14 @@ intents:
       # Brightness value
       - sentences:
           - "[<doe>|<zou>|dim] <name>[ ][<lamp>][ ][<helderheid>] [<naar>] <brightness> [[willen|kunnen] <doe>]"
-          - "[<doe>|<zou>] <helderheid> [van] <name>[ ][<lamp>] [<naar>] <brightness> [[willen|kunnen] (<doe>|dimmen)]"
+          - "[<doe>|<zou>] <helderheid> [van] <name>[ ][<lamp>] [<naar>] <brightness> [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>] [<helderheid>] [van] <name>[ ][<lamp>] [<naar>] <brightness> [[willen|kunnen] dimmen]"
         response: "brightness"
 
       - sentences:
           - "[<doe>|<zou>|dim] [<helderheid>] <in> <area>[[ ]<lamp>] [<naar>] <brightness> [[willen|kunnen] <doe>]"
-          - "[<doe>|<zou>] <area>[ ][<helderheid>|lamp] [<naar>] <brightness> [[willen|kunnen] (<doe>|dimmen)]"
+          - "[<doe>|<zou>] <area>[ ][<helderheid>|lamp] [<naar>] <brightness> [[willen|kunnen] <doe>]"
+          - "[<doe>|<zou>] <area>[ ][<helderheid>|lamp] [<naar>] <brightness> [[willen|kunnen] dimmen]"
         slots:
           name: "all"
         response: "brightness"

--- a/tests/nl/light_HassLightSet.yaml
+++ b/tests/nl/light_HassLightSet.yaml
@@ -7,7 +7,9 @@ tests:
       - Verander de helderheid van het slaapkamerlampje naar 50 procent
       - Intensiteit slaapkamerlampje 50%
       - Slaapkamerlampje helderheid 50%
-      - Zal je het slaapkamerlampje op 50% willen zetten?
+      - Zou je het slaapkamerlampje op 50% willen zetten?
+      - Dim slaapkamerlampje naar 50%"
+      - Slaapkamerlampje naar 50% dimmen" 
     intent:
       name: HassLightSet
       slots:
@@ -36,6 +38,8 @@ tests:
       - Doe slaapkamerverlichting naar 75%
       - Slaapkamerhelderheid 75%
       - Zal je de helderheid in de slaapkamer op 75% willen zetten?
+      - Dim slaapkamer lampen naar 75%
+      - Slaapkamer naar 75% dimmen
     intent:
       name: HassLightSet
       slots:

--- a/tests/nl/light_HassLightSet.yaml
+++ b/tests/nl/light_HassLightSet.yaml
@@ -8,8 +8,9 @@ tests:
       - Intensiteit slaapkamerlampje 50%
       - Slaapkamerlampje helderheid 50%
       - Zou je het slaapkamerlampje op 50% willen zetten?
-      - Dim slaapkamerlampje naar 50%"
-      - Slaapkamerlampje naar 50% dimmen" 
+      - Dim slaapkamerlampje naar 50%
+      - Slaapkamerlampje naar 50% dimmen
+      - Slaapkamerlampje 50%
     intent:
       name: HassLightSet
       slots:


### PR DESCRIPTION
Sentences like the examples below were not allowed. These have been added now:
* `dim <name> naar 50%`
* `<name> naar 50% dimmen`
* `dim <area> naar 50%`
* `<area> naar 50% dimmen`

(`naar` is optional in these sentences)