### PR TITLE
Correct error in the italian expansion rule for <in>

### DIFF
--- a/sentences/it/_common.yaml
+++ b/sentences/it/_common.yaml
@@ -299,7 +299,7 @@ lists:
 
 expansion_rules:
   the: "(l(o|a|e) | i[l] | gli | l'| in | nel[(lo|la|le|l'|gli)] | a[(l|llo|lla|lle|gli)])"
-  in: "(in | ne[i|gli|l[lo|la|le]])"
+  in: "(in | ne(i|gli|l[l'|lo|la|le]))"
   of: "(de[i|gli|l[lo|la|le]]|di)"
   to: "a[l[lo|la|le] | gli]"
   name: "{name}"


### PR DESCRIPTION
The previous version allowed ne and it didn't allowed nell'