### PR TITLE
Delete expansion rule for temp in Italian

### DIFF
--- a/sentences/it/_common.yaml
+++ b/sentences/it/_common.yaml
@@ -311,7 +311,6 @@ expansion_rules:
   open: "(apr(i|ire) | alz(a|are))"
   close: "(chiud(i|ere) | abbass(a|are))"
   set: "(impost(a|are) | cambi(a|are) | mett(i|ere) | modific(a|are))"
-  temp: "[la] (temperatura)"
   temperature: "{temperature}[°| gradi] [{temperature_unit}]"
   cover: "(tend(a|e)[ da sole]|serrand(a|e)|tapparell(a|e)|persian(a|e)|port(a|e)|saracinesc(a|he)|venezian(a|e)|cancell(o|i)|finestr(a|e))"
   climate: "(clima|climatizzator(e|i)|condizionator(e|i)|aria condizionata)"

--- a/sentences/it/climate_HassClimateGetTemperature.yaml
+++ b/sentences/it/climate_HassClimateGetTemperature.yaml
@@ -3,6 +3,6 @@ intents:
   HassClimateGetTemperature:
     data:
       - sentences:
-          - "[<what_is>] <temp> [c'è] [(<in> | <of> | <the>)] [<area>]"
+          - "[<what_is>] [la] temperatura [c'è] [(<in> | <of> | <the>)] [<area>]"
           - "[quanto] [(è | c'è | fa)] (caldo | freddo) [(<in> | <the>)] [<area>]"
           - "quanto (caldo | freddo) [(è | c'è | fa)] [(<in>|<the>) <area>]"

--- a/sentences/it/climate_HassClimateSetTemperature.yaml
+++ b/sentences/it/climate_HassClimateSetTemperature.yaml
@@ -3,8 +3,8 @@ intents:
   HassClimateSetTemperature:
     data:
       - sentences:
-          - "<set> <temp> a <temperature>"
-          - "<set> [<temp>] [<in>] <area> [a] <temperature>"
-          - "<set> [<temp>] [di] <temperature> [<in>] <area>"
-          - "<set> [<in>] <area> [<temp>] [di] <temperature>"
-          - "<set> <temp> <area> [a] <temperature>"
+          - "<set> [la] temperatura a <temperature>"
+          - "<set> [[la] temperatura] [<in>] <area> [a] <temperature>"
+          - "<set> [[la] temperatura] [di] <temperature> [<in>] <area>"
+          - "<set> [<in>] <area> [[la] temperatura] [di] <temperature>"
+          - "<set> [la] temperatura <area> [a] <temperature>"


### PR DESCRIPTION
Expansion rule for temp is useful in english where it can be expressed as temp or temperature, but not in italian where it is called only temperatura. I deleted the expansion rule and substituted with [la] temperatura like other languages already do