### PR TITLE
Migliorati messaggi di errore

### DIFF
--- a/sentences/it/_common.yaml
+++ b/sentences/it/_common.yaml
@@ -1,12 +1,36 @@
 language: it
 responses:
   errors:
-    no_intent: "Mi dispiace, non ho capito"
-    no_area: "Non esiste nessuna area chiamata {{ area }}"
-    no_domain_in_area: "{{ area }} non contiene {{ domain }}"
     no_device_class_in_area: "{{ area }} non contiene {{ device_class }}"
     no_entity: "Non esiste nessun dispositivo o entità chiamato {{ entity }}"
+
+responses:
+  errors:
+    # Errori generici
+    no_intent: "Mi dispiace, non ho capito"
     handle_error: "Si è verificato un errore inatteso durante l'elaborazione"
+
+    # Errori per quando un utente non ha effettuato l'accesso
+    no_area: "Non conosco nessuna area chiamata {{ area }}"
+    no_domain: "Mi dispiace, non conosco nessun dispositivo appartenente al dominio {{ domain }}"
+    no_domain_in_area: "Mi dispiace, nell'area {{ area }} non conosco nessun dispositivo appartenente al dominio {{ domain }}"
+    no_device_class: "Mi dispiace, non conosco nessun dispositivo appartenente alla classe {{ device_class }}"
+    no_device_class_in_area: "Mi dispiace, nell'area {{ area }} non conosco nessun dispositivo appartenente alla classe {{ device_class }}"
+    no_entity: "Mi dispiace, non sconosco nessun dispositivo chiamato {{ entity }}"
+    no_entity_in_area: "Mi dispiace, nell'area {{ area }} non sconosco nessun dispositivo chiamato {{ entity }}"
+
+    # Errori per quando un utente ha effettuato l'accesso ed è quindi possibile dare più informazioni
+    no_entity_exposed: "Mi dispiace, il dispositivo {{ entity }} non è stato esposto"
+    no_entity_in_area_exposed: "Mi dispiace, il dispositivo {{ entity }} nell'area {{ area }} non è stato esposto"
+    no_domain_exposed: "Mi dispiace, il dominio {{ domain }} non è stato esposto"
+    no_domain_in_area_exposed: "Mi dispiace, nell'area {{ area }} il dominio {{ domain }} non è stato esposto"
+    no_device_class_exposed: "Mi dispiace, nessun dispositivo appartenente alla classe {{ device_class }} è stato esposto"
+    no_device_class_in_area_exposed: "Mi dispiace, nell'area {{ area }} nessun dispositivo appartenente alla classe {{ device_class }} è stato esposto"
+
+    # Errori quando più di un dispositivo esposto ha lo stesso nome
+    duplicate_entities: "Mi dispiace, esistono più dispositivi chiamati {{ entity }}"
+    duplicate_entities_in_area: "Mi dispiace, nell'area {{ area }} esistono più dispositivi chiamati {{ entity }}"
+  
 lists:
   color:
     values:


### PR DESCRIPTION
Aggiunti e migliorati messaggi di errore (basandomi sulla versione inglese). Dato che, a differenza dell'inglese, il genere di un nome si riflette sulle parole che si riferiscono a quel nome era impossibile usare frasi del tipo:
* Non conosco nessun {{domain}} in {{ area }} perchè sarebbe andato bene per il dominio sensore ma non per il dominio luce

Per ovviare a questo ho usato dispositivo, area e classe per riferirmi a entity, area e device class.