### PR TITLE
[FI] new try on fixing lists

### DIFF
--- a/responses/fi/HassListAddItem.yaml
+++ b/responses/fi/HassListAddItem.yaml
@@ -1,0 +1,5 @@
+language: "fi"
+responses:
+  intents:
+    HassListAddItem:
+      item_added: "{{ slots.item }} lisätty"

--- a/sentences/fi/todo_HassListAddItem.yaml
+++ b/sentences/fi/todo_HassListAddItem.yaml
@@ -1,11 +1,13 @@
 language: "fi"
 intents:
-  HassShoppingListAddItem:
+  HassListAddItem:
     data:
       - sentences:
           - (lisää|laita) <item> <my_list>
           - (lisää|laita) <my_list> <item>
         response: item_added
+        requires_context:
+          domain: todo
         expansion_rules:
-          my_list: "[minun|mun|miun|meidän] ostoslista[lle|lleni|llemme]"
+          my_list: "[minun|mun|miun|meidän] lista(lle|lleni|llemme) {name}"
           item: "{shopping_list_item:item}"

--- a/tests/fi/_fixtures.yaml
+++ b/tests/fi/_fixtures.yaml
@@ -391,3 +391,7 @@ entities:
     attributes:
       temperature: "-30"
       temperature_unit: "°C"
+
+  - name: "Rautakauppa"
+    id: "todo.rautakauppa"
+    state: ""

--- a/tests/fi/shopping_list_HassShoppingListAddItem.yaml
+++ b/tests/fi/shopping_list_HassShoppingListAddItem.yaml
@@ -1,8 +1,8 @@
-language: fi
+language: "fi"
 tests:
   - sentences:
-      - laita omena minun ostoslistalleni
-      - laita omena listalle
+      - laita omena mun ostoslistalle
+      - laita omena ostoslistalle
       - lisää omena ostoslistalle
 
     intent:
@@ -15,6 +15,7 @@ tests:
   - sentences:
       - lisää mun ostoslistalle omena
       - laita miun ostoslistalle omena
+      - lisää ostoslistalle omena
 
     intent:
       name: HassShoppingListAddItem

--- a/tests/fi/todo_HassListAddItem.yaml
+++ b/tests/fi/todo_HassListAddItem.yaml
@@ -1,0 +1,22 @@
+language: "fi"
+tests:
+  - sentences:
+      - laita vasara listalle rautakauppa
+      - lisää vasara listalle rautakauppa
+    intent:
+      name: HassListAddItem
+      slots:
+        item: "vasara "
+        name: "Rautakauppa"
+    response: "vasara lisätty"
+
+  # Below sentences only work when the item is given without the whitespace in the end.
+  - sentences:
+      - lisää meidän listalle rautakauppa vasara
+      - laita listalle rautakauppa vasara
+    intent:
+      name: HassListAddItem
+      slots:
+        item: "vasara"
+        name: "Rautakauppa"
+    response: "vasara lisätty"


### PR DESCRIPTION
- must say "ostoslistalle" instead of only "listalle" (tralates to "on shopping list" instead of "on list") to differentiate shopping list from todo
- added todo lists