### PR TITLE
[CS] Add sentence for turning on/off lights in the satelite area. Added expansion rule for lights in plural/singular

### DIFF
--- a/responses/cs/HassTurnOn.yaml
+++ b/responses/cs/HassTurnOn.yaml
@@ -4,6 +4,7 @@ responses:
     HassTurnOn:
       default: "Zapnuto"
       lights_area: "Světla rozsvícena"
+      light_all: "Všechna světla byla rozsvícena"
       fans_area: "Větráky zapnuty"
       fan: "Větrák zapnut"
       light: "Rozsvíceno"

--- a/sentences/cs/_common.yaml
+++ b/sentences/cs/_common.yaml
@@ -308,6 +308,7 @@ expansion_rules:
   vypnout: "(vypni|vypnout|zastavit|zastav)"
   rozsvitit: "(rozsviť|rozsvítit|rožn(i|out))" #some dialect to be served for users :)
   zhasnout: "(zhasni|zhasnout)"
+  svetla: "(světlo|[všechna ]světla)"
   nastavit: "(nastav|nastavit)"
   zmenit: "(změň|změnit)"
   ztlumit: "(ztlu(m|it)|snížit|sniž)"

--- a/sentences/cs/light_HassTurnOff.yaml
+++ b/sentences/cs/light_HassTurnOff.yaml
@@ -29,6 +29,4 @@ intents:
         response: "light_all"
         slots:
           domain: "light"
-        requires_context:
-          area:
-            slot: true
+          name: "all"

--- a/sentences/cs/light_HassTurnOff.yaml
+++ b/sentences/cs/light_HassTurnOff.yaml
@@ -3,26 +3,32 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "(<vypnout>|<zhasnout>) [světlo] {name}"
-          - "{name} (<vypnout>|<zhasnout>) [světlo]"
+          - "<vypnout> světlo {name}"
+          - "<zhasnout>[ světlo] {name}"
+          - "{name} <vypnout> světlo"
+          - "{name} <zhasnout>[ světlo]"
         requires_context:
           domain: light
         slots:
           domain: light
         response: light
       - sentences:
-          - "<vypnout> [všechna] světla <area>"
+          - "(<vypnout>|<zhasnout>)[ všechna] světla <area>"
           - "<vypnout> světlo <area>"
-          - "<zhasnout> [všechna] [světla] <area>"
-          - "<zhasnout> světlo <area>"
-          - "<area> (<vypnout>|<zhasnout>) [všechna] světla"
-          - "<area> (<vypnout>|<zhasnout>) světlo"
+          - "<zhasnout>[ světlo] <area>"
+          - "<area> (<vypnout>|<zhasnout>)[ všechna] světla"
+          - "<area> <vypnout> světlo"
+          - "<area> <zhasnout>[ světlo]"
         slots:
           domain: light
         response: lights_area
       - sentences:
-          - "(<vypnout>|<zhasnout>) [úplně] všechna světla"
+          - "(<vypnout>|<zhasnout>)[ úplně][ všechna] světla"
+          - "<vypnout> světlo"
+          - "<zhasnout>[ světlo]"
         response: "light_all"
         slots:
           domain: "light"
-          name: "all"
+        requires_context:
+          area:
+            slot: true

--- a/sentences/cs/light_HassTurnOff.yaml
+++ b/sentences/cs/light_HassTurnOff.yaml
@@ -13,12 +13,10 @@ intents:
           domain: light
         response: light
       - sentences:
-          - "(<vypnout>|<zhasnout>)[ všechna] světla <area>"
-          - "<vypnout> světlo <area>"
-          - "<zhasnout>[ světlo] <area>"
-          - "<area> (<vypnout>|<zhasnout>)[ všechna] světla"
-          - "<area> <vypnout> světlo"
-          - "<area> <zhasnout>[ světlo]"
+          - "<vypnout> <svetla> <area>"
+          - "<zhasnout>[ <svetla>] <area>"
+          - "<area> <vypnout> <svetla>"
+          - "<area> <zhasnout>[ <svetla>]"
         slots:
           domain: light
         response: lights_area

--- a/sentences/cs/light_HassTurnOn.yaml
+++ b/sentences/cs/light_HassTurnOn.yaml
@@ -13,12 +13,10 @@ intents:
           domain: light
         response: light
       - sentences:
-          - "(<zapnout>|<rozsvitit>)[ všechna] světla <area>"
-          - "<zapnout> světlo <area>"
-          - "<rozsvitit>[ světlo] <area>"
-          - "<area> (<zapnout>|<rozsvitit>)[ všechna] světla"
-          - "<area> <zapnout> světlo"
-          - "<area> <rozsvitit>[ světlo]"
+          - "<zapnout> <svetla> <area>"
+          - "<rozsvitit>[ <svetla>] <area>"
+          - "<area> <zapnout> <svetla>"
+          - "<area> <rozsvitit>[ <svetla>]"
         slots:
           domain: light
         response: lights_area

--- a/sentences/cs/light_HassTurnOn.yaml
+++ b/sentences/cs/light_HassTurnOn.yaml
@@ -23,12 +23,10 @@ intents:
           domain: light
         response: lights_area
       - sentences:
-          - "(<zapnout>|<rozsvitit>)[ všechna] světla"
+          - "(<zapnout>|<rozsvitit>)[ úplně][ všechna] světla"
           - "<zapnout> světlo"
           - "<rozsvitit>[ světlo]"
         response: "light_all"
         slots:
           domain: "light"
-        requires_context:
-          area:
-            slot: true
+          name: "all"

--- a/sentences/cs/light_HassTurnOn.yaml
+++ b/sentences/cs/light_HassTurnOn.yaml
@@ -3,20 +3,32 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "(<zapnout>|<rozsvitit>) [světlo] {name}"
-          - "{name} (<zapnout>|<rozsvitit>) [světlo]"
+          - "<zapnout> světlo {name}"
+          - "<rozsvitit>[ světlo] {name}"
+          - "{name} <zapnout> světlo"
+          - "{name} <rozsvitit>[ světlo]"
         requires_context:
           domain: light
         slots:
           domain: light
         response: light
       - sentences:
-          - "<zapnout> [všechna] světla <area>"
+          - "(<zapnout>|<rozsvitit>)[ všechna] světla <area>"
           - "<zapnout> světlo <area>"
-          - "<rozsvitit> [všechna] [světla] <area>"
-          - "<rozsvitit> světlo <area>"
-          - "<area> (<zapnout>|<rozsvitit>) [všechna] světla"
-          - "<area> (<zapnout>|<rozsvitit>) světlo"
+          - "<rozsvitit>[ světlo] <area>"
+          - "<area> (<zapnout>|<rozsvitit>)[ všechna] světla"
+          - "<area> <zapnout> světlo"
+          - "<area> <rozsvitit>[ světlo]"
         slots:
           domain: light
         response: lights_area
+      - sentences:
+          - "(<zapnout>|<rozsvitit>)[ všechna] světla"
+          - "<zapnout> světlo"
+          - "<rozsvitit>[ světlo]"
+        response: "light_all"
+        slots:
+          domain: "light"
+        requires_context:
+          area:
+            slot: true

--- a/tests/cs/light_HassTurnOff.yaml
+++ b/tests/cs/light_HassTurnOff.yaml
@@ -20,6 +20,7 @@ tests:
 
   - sentences:
       - "zhasni světlo lampička v ložnici"
+      - "zhasni lampičku v ložnici"
       - "lampičku v ložnici zhasnout"
     intent:
       name: HassTurnOff
@@ -40,6 +41,8 @@ tests:
   - sentences:
       - "vypni všechna světla"
       - "vypni úplně všechna světla"
+      - "zhasni světla"
+      - "zhasni"
     intent:
       name: HassTurnOff
       slots:

--- a/tests/cs/light_HassTurnOn.yaml
+++ b/tests/cs/light_HassTurnOn.yaml
@@ -16,10 +16,9 @@ tests:
     response: "Rozsvíceno"
 
   - sentences:
-      - "zapni předsíň"
+      - "zapni světlo předsíň"
       - "předsíň rozsviť"
       - "rozsviť předsíň"
-      - "zapni světlo předsíň"
     intent:
       name: HassTurnOn
       slots:
@@ -45,3 +44,15 @@ tests:
           - obýváku
     response:
       - "Světla rozsvícena"
+  - sentences:
+      - "zapni všechna světla"
+      - "zapni úplně všechna světla"
+      - "rozsviť světla"
+      - "rozsviť"
+    intent:
+      name: HassTurnOn
+      slots:
+        domain: light
+        name: all
+    response:
+      - "Všechna světla byla rozsvícena"

--- a/tests/cs/light_HassTurnOn.yaml
+++ b/tests/cs/light_HassTurnOn.yaml
@@ -4,7 +4,6 @@ tests:
       - "rozsviť světlo lampička v obývacím pokoji"
       - "rozsviť lampičku v obývacím pokoji"
       - "zapni světlo lampička v obývacím pokoji"
-      - "zapni lampičku v obývacím pokoji"
     intent:
       name: HassTurnOn
       slots:
@@ -17,7 +16,8 @@ tests:
 
   - sentences:
       - "zapni světlo předsíň"
-      - "předsíň rozsviť"
+      - "předsíň rozsvítit"
+      - "rozsviť světlo předsíň"
       - "rozsviť předsíň"
     intent:
       name: HassTurnOn


### PR DESCRIPTION
Added sentence for turning on all lights in the same area as the same are as the satelite device.
Also added an expansion rule for lights, accepting both plural an dsingular (as suggested in #1983)

Whilst doing that, I made the sentences consistent so they make sense in the CZ:
rozsvitit means turn on the light, zhasnout means turn off the light. So when using these two words, I made the word svetlo (light) optional - you can say rozsvit or rozsvit svetlo, both is correct. But when using more generic zapni/vypni (turn on/turn off), the word light should not be optional, to make it clear we are switching the light, as there might be other devices in the room with the same name. This is consistent with EN.
I made an expansion for lights (<svetla>). But I only use it in the area. The device is always singular, and for all the lights, the wold "uplne" (completely) only makes sense for plural.