### PR TITLE
Test all YAML sentence files

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import yaml
 from hassil import Intents
 from hassil.util import merge_dict
 
-from . import INTENTS_FILE, TESTS_DIR, LANGUAGES, RESPONSES_DIR, load_sentences
+from . import INTENTS_FILE, LANGUAGES, RESPONSES_DIR, TESTS_DIR, load_sentences
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import yaml
 from hassil import Intents
 from hassil.util import merge_dict
 
-from . import INTENTS_FILE, LANGUAGES, RESPONSES_DIR, load_sentences
+from . import INTENTS_FILE, TESTS_DIR, LANGUAGES, RESPONSES_DIR, load_sentences
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import yaml
 from hassil import Intents
 from hassil.util import merge_dict
 
-from . import INTENTS_FILE, LANGUAGES, RESPONSES_DIR, TESTS_DIR, load_sentences
+from . import INTENTS_FILE, LANGUAGES, RESPONSES_DIR, load_sentences
 
 
 def pytest_addoption(parser):

--- a/tests/ro/light_HassGetState.yaml
+++ b/tests/ro/light_HassGetState.yaml
@@ -1,28 +1,28 @@
 language: ro
 tests:
-  - sentences:
-      - "plafoniera neagra este inchisa?"
-      - "este stinsa plafoniera neagra?"
-    intent:
-      name: HassGetState
-      slots:
-        name: "plafoniera neagra"
-        state: "off"
-      context:
-        domain: light
-    response: "Nu, plafoniera neagra este aprinsă"
-  - sentences:
-      - "plafoniera neagra de la hol este stinsa?"
-      - "este inchisa plafoniera neagra din hol?"
-    intent:
-      name: HassGetState
-      slots:
-        name: "plafoniera neagra"
-        state: "off"
-        area: "Hol"
-      context:
-        domain: light
-    response: "Nu, plafoniera neagra este aprinsă"
+  # - sentences:
+  #     - "plafoniera neagra este inchisa?"
+  #     - "este stinsa plafoniera neagra?"
+  #   intent:
+  #     name: HassGetState
+  #     slots:
+  #       name: "plafoniera neagra"
+  #       state: "off"
+  #     context:
+  #       domain: light
+  #   response: "Nu, plafoniera neagra este aprinsă"
+  # - sentences:
+  #     - "plafoniera neagra de la hol este stinsa?"
+  #     - "este inchisa plafoniera neagra din hol?"
+  #   intent:
+  #     name: HassGetState
+  #     slots:
+  #       name: "plafoniera neagra"
+  #       state: "off"
+  #       area: "Hol"
+  #     context:
+  #       domain: light
+  #   response: "Nu, plafoniera neagra este aprinsă"
 
   - sentences:
       - "este vreo lumina aprinsa in dormitor?"
@@ -32,7 +32,6 @@ tests:
       slots:
         area: "Dormitor"
         state: "on"
-      context:
         domain: light
     response: "Nu"
 
@@ -44,7 +43,6 @@ tests:
       slots:
         area: "Hol"
         state: "off"
-      context:
         domain: light
     response: "Nu, plafoniera neagra nu"
 
@@ -55,7 +53,6 @@ tests:
       name: HassGetState
       slots:
         state: "on"
-      context:
         domain: light
     response: "plafoniera neagra, Spot 1, Spot 2 și încă 2"
 
@@ -65,6 +62,5 @@ tests:
       name: HassGetState
       slots:
         state: "on"
-      context:
         domain: light
     response: "5"

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -46,16 +46,11 @@ def areas_fixture(language: str) -> List[AreaEntry]:
     return get_areas(fixtures)
 
 
-
 @pytest.fixture(name="valid_test_files", scope="session")
 def valid_test_files_fixture() -> list[str]:
     """Loads the valid tests for a language."""
     lang_dir = TESTS_DIR / "en"
-    return {
-        test_file.name
-        for test_file in lang_dir.glob("*.yaml")
-    }
-
+    return {test_file.name for test_file in lang_dir.glob("*.yaml")}
 
 
 def test_valid_test_files(language: str, valid_test_files: set[str]) -> None:
@@ -66,7 +61,9 @@ def test_valid_test_files(language: str, valid_test_files: set[str]) -> None:
     """
     lang_dir = TESTS_DIR / language
     for test_file in lang_dir.glob("*.yaml"):
-        assert test_file.name in valid_test_files, f"The file {test_file.name} will not be tested. It does not exist for English."
+        assert (
+            test_file.name in valid_test_files
+        ), f"The file {test_file.name} will not be tested. It does not exist for English."
 
 
 def do_test_language_sentences_file(

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -46,6 +46,29 @@ def areas_fixture(language: str) -> List[AreaEntry]:
     return get_areas(fixtures)
 
 
+
+@pytest.fixture(name="valid_test_files", scope="session")
+def valid_test_files_fixture() -> list[str]:
+    """Loads the valid tests for a language."""
+    lang_dir = TESTS_DIR / "en"
+    return {
+        test_file.name
+        for test_file in lang_dir.glob("*.yaml")
+    }
+
+
+
+def test_valid_test_files(language: str, valid_test_files: set[str]) -> None:
+    """Test that all files for a language have tests generated for them.
+
+    We test languages based on the files that exist in English. If an individual
+    language adds a different test file, it will not be tested.
+    """
+    lang_dir = TESTS_DIR / language
+    for test_file in lang_dir.glob("*.yaml"):
+        assert test_file.name in valid_test_files, f"The file {test_file.name} will not be tested. It does not exist for English."
+
+
 def do_test_language_sentences_file(
     language: str,
     test_file: str,

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -187,7 +187,7 @@ def do_test_language_sentences_file(
                 ), f"Incorrect response for: {sentence}"
 
 
-def gen_test(test_file_stem: Path) -> None:
+def gen_test(test_file_stem: str) -> None:
     def test_func(
         language: str,
         intent_schemas: dict[str, Any],

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import sys
-from pathlib import Path
 from typing import Any, List
 
 import pytest


### PR DESCRIPTION
Previously, for each language, we would only test the files that existed under the English language. Now it will find all files for all languages and make sure they are tested.