### PR TITLE
[ES] Add new sentence to set a light to a specific brightness

### DIFF
--- a/sentences/es/_common.yaml
+++ b/sentences/es/_common.yaml
@@ -353,7 +353,7 @@ expansion_rules:
   ejecuta: "(<enciende>|ejecut(a|e|ar|á)|inici(a|e|ar|á))"
   establece: "(pon[ga|er|é]|estable[z]c(a|e|er|é)|ajust(a|e|ar|á)|configur(a|e|ar|á)|cambi(a[r]|á|e))"
   establece_abre_cierra: "(<establece>|<abre>|<cierra>)"
-  establece_sube_baja: "(<establece>|sub(a|e|ir|í)|baj(a|e|ar|á))"
+  establece_sube_baja: "(<establece>|<enciende>|sub(a|e|ir|í)|baj(a|e|ar|á))"
   mide: "[que] ([es|está] (mid(e|ie)|medi|indica|marca)[ndo|d(a|o)]|tiene|hay) [por|en]"
   name: "[el|la|los|las] {name}"
   pausa: "(paus(a|ar|e|á)|par(a|ar|e|á))|det(én|ener|enga|ené)"


### PR DESCRIPTION
I just started controlling my home with my voice using an Onju Home a couple days ago and I noticed one sentence that I used with alexa ALL THE TIME that wasn't recognized.

The ability to say "Enciende la luz de la cocina al 30%", as 'Enciende' was not recognized as a way of triggering setting a light to a specific brightness, but I think it's a very natural phase, specially when the lights are off.