### PR TITLE
[ES] Improve success response for turning on a light

### DIFF
--- a/responses/es/HassTurnOn.yaml
+++ b/responses/es/HassTurnOn.yaml
@@ -3,6 +3,7 @@ responses:
   intents:
     HassTurnOn:
       default: "{{ slots.name }} se ha activado"
+      light: "{{ slots.name }} se ha encendido"
       lights_area: "Luces encendidas"
       fan: "{{ slots.name }} se ha encendido"
       fans_area: "Ventiladores encendidos"


### PR DESCRIPTION
Before this change, turning on a light used the default response (e.g. "Luz de la cocina de ha activado"), but that sounds quite awkward to me.

Lights are "encendidas", not "activadas".
Now voice assistant will say: "Luz de la cocina se ha encendido".

I did consider being even more succint: "Luz de la cocina encendida". In fact I like it a bit better but I'll ask for your opinion, since other sentences seem to prefer the more verbose approach.