### PR TITLE
[NL] Remove C or F from weather response

### DIFF
--- a/responses/nl/HassGetWeather.yaml
+++ b/responses/nl/HassGetWeather.yaml
@@ -21,4 +21,4 @@ responses:
           'windy': 'met wind',
           'windy-variant': 'met wind en bewolking'
         } %}
-        {{ state.attributes.get('temperature') }} {{ state.attributes.get('temperature_unit') }} {{ weather_condition.get((state.state | string).lower(), "") }}
+        {{ state.attributes.get('temperature') }} graden {{ weather_condition.get((state.state | string).lower(), "") }}

--- a/tests/nl/weather_HassGetWeather.yaml
+++ b/tests/nl/weather_HassGetWeather.yaml
@@ -6,7 +6,7 @@ tests:
       - "hoe is het weer"
     intent:
       name: HassGetWeather
-    response: 20 °C en zonnig
+    response: 20 graden en zonnig
 
   - sentences:
       - "hoe is de weersvoorspelling voor Amsterdam"
@@ -16,4 +16,4 @@ tests:
       name: HassGetWeather
       slots:
         name: Amsterdam
-    response: 12 °C met regen
+    response: 12 graden met regen


### PR DESCRIPTION
The user will know which kind of degrees he/she/they is using (Celcsius or Fahrenheit or maybe even Kelvin).
So it seems redundant to add it to the response.