### PR TITLE
[NL] Avoid HassGetState getting triggered on only name

### DIFF
--- a/sentences/nl/homeassistant_HassGetState.yaml
+++ b/sentences/nl/homeassistant_HassGetState.yaml
@@ -4,8 +4,8 @@ intents:
     data:
       - sentences:
           - Wat is [<in> <area>] [[de] [huidige] <staat> [van]] [<area>][ ]<name>[ ][<type>][ ][<staat>] [<in> <area>]
-          - "[<in> <area>] [de] [huidige] <staat> [van] [<area>][ ]<name>[ ][<type>]  [<in> <area>]"
-          - "[<in> <area>][ ]<name>[ ][<type>][ ][<staat>]  [<in> <area>]"
+          - "[<in> <area>] [de] [huidige] <staat> [van] [<area>][ ]<name>[ ][<type>] [<in> <area>]"
+          - "[<in> <area>][ ]<name>[ ][<type>][ ]<staat> [<in> <area>]"
         response: one
 
       - sentences:


### PR DESCRIPTION
HassGetState was getting triggerend when only the name/alias of an entity was used as input. This was uninted, and fixed with this PR.