### PR TITLE
[RU] Fix negative temperature pronouncing

### DIFF
--- a/responses/ru/HassGetWeather.yaml
+++ b/responses/ru/HassGetWeather.yaml
@@ -21,4 +21,13 @@ responses:
           'windy': ', ветренно',
           'windy-variant': ', ветренно и облачно'
         } %}
-        {{ state.attributes.get('temperature') }} {{ state.attributes.get('temperature_unit') }}{{ weather_condition.get((state.state | string).lower(), "") }}
+
+
+
+        {% set temperature = state.attributes.get('temperature') | float %}
+        {% if temperature < 0 %}
+          {% set temperature_string = 'минус ' ~ (temperature * -1) | string | replace('.', ',') %}
+        {% else %}
+          {% set temperature_string = temperature | string | replace('.', ',') %}
+        {% endif %}
+        {{ temperature_string }} {{ state.attributes.get('temperature_unit') }}{{ weather_condition.get((state.state | string).lower(), state.state | string) }}

--- a/tests/ru/_fixtures.yaml
+++ b/tests/ru/_fixtures.yaml
@@ -680,6 +680,13 @@ entities:
       temperature: "24"
       temperature_unit: "°C"
 
+  - name: "Зеленоград[е]"
+    id: "weather.zelenograd"
+    state: "sunny"
+    attributes:
+      temperature: "-5.5"
+      temperature_unit: "°C"
+
   - name: "Воронеж[е]"
     id: "weather.voronezh"
     state: "clear"

--- a/tests/ru/weather_HassGetWeather.yaml
+++ b/tests/ru/weather_HassGetWeather.yaml
@@ -5,7 +5,7 @@ tests:
       - "погода"
     intent:
       name: HassGetWeather
-    response: 24 °C, облачно
+    response: 24,0 °C, облачно
 
   - sentences:
       - "Какая погода в Москве?"
@@ -14,7 +14,15 @@ tests:
       name: HassGetWeather
       slots:
         name: Москве
-    response: 24 °C, облачно
+    response: 24,0 °C, облачно
+
+  - sentences:
+      - "Какая погода в Зеленограде?"
+    intent:
+      name: HassGetWeather
+      slots:
+        name: Зеленограде
+    response: минус 5,5 °C, солнечно
 
   - sentences:
       - "погода в Воронеже"
@@ -22,4 +30,4 @@ tests:
       name: HassGetWeather
       slots:
         name: Воронеже
-    response: 13 °C, ясно
+    response: 13,0 °C, ясно


### PR DESCRIPTION
In russian language TTS doesn't handle negative values correctly and thus does not pronounce word "minus".

In order to fix this problem, temperature value is checked before response and if it's negative, word “minus” is added at the response begining.

This fix addressing #1683 and has been ported from #2038.