### PR TITLE
[CA] Update sentences for opening the lights

### DIFF
--- a/sentences/ca/light_HassTurnOn.yaml
+++ b/sentences/ca/light_HassTurnOn.yaml
@@ -3,9 +3,9 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "<engega> tots els llums [<area>]"
-          - "<engega> totes les llums [<area>]"
-          - "<engega> [els|les] llums [<area>]"
+          - "(<engega>|<obre>) tots els llums [<area>]"
+          - "(<engega>|<obre>) totes les llums [<area>]"
+          - "(<engega>|<obre>) [els|les] llums [<area>]"
         slots:
           domain: light
           name: all

--- a/tests/ca/light_HassTurnOn.yaml
+++ b/tests/ca/light_HassTurnOn.yaml
@@ -1,25 +1,17 @@
 language: ca
 tests:
-  # - sentences:
-  #     - encén la llum del menjador
-  #   intent:
-  #     name: HassTurnOn
-  #     slots:
-  #       domain: light
-  #       area: living_room
-  # - sentences:
-  #     - posa la llum de la cuina
-  #   intent:
-  #     name: HassTurnOn
-  #     slots:
-  #       domain: light
-  #       area: kitchen
   - sentences:
       - encén tots els llums de la cuina
       - encén totes les llums de la cuina
       - encén les llums de la cuina
       - encendre les llums de la cuina
+      - engega les llums de la cuina
       - engegar les llums de la cuina
+      - posa les llums de la cuina
+      - activa les llums de la cuina
+      - activar les llums de la cuina
+      - obre les llums de la cuina
+      - obrir les llums de la cuina
     intent:
       name: HassTurnOn
       slots:
@@ -27,7 +19,16 @@ tests:
         name: all
         area: Cuina
   - sentences:
-      - activar la llum del menjador
+      - encén el llum del menjador
+      - encén la llum del menjador
+      - encendre el llum del menjador
+      - engega el llum del menjador
+      - engegar el llum del menjador
+      - posa el llum del menjador
+      - activa el llum del menjador
+      - activar el llum del menjador
+      - obre el llum del menjador
+      - obrir el llum del menjador
     intent:
       name: HassTurnOn
       slots:


### PR DESCRIPTION
The same way that you can light on or open a light, in Catalan you can 'encendre' or 'obrir' the lights.

It was set like this for singular, but not for plural. This was making me be able to close all the lights but just be able to close one light, not all of them. (In some regions we just say 'obrir' not 'encendre')

The singular was added later in https://github.com/home-assistant/intents/pull/804 that is why this was missed.