### PR TITLE
[FR] Quick Fix on HassSetVolume: Use expansion rule instead of hardcoded `de`

### DIFF
--- a/sentences/fr/media_player_HassSetVolume.yaml
+++ b/sentences/fr/media_player_HassSetVolume.yaml
@@ -3,7 +3,9 @@ intents:
   HassSetVolume:
     data:
       - sentences:
-          # Règle le volume de la TV sur 50%
-          - "<regle> [le volume de] [<le>]{name} [à|sur] {volume:volume_level}<pourcent>"
+          # Règle la TV à 50%
+          - "<regle> [<le>]{name} [à|sur] {volume:volume_level}<pourcent>"
+          # Règle le volume des enceintes sur 50%
+          - "<regle> le volume [<de>] [<le>]{name} [à|sur] {volume:volume_level}<pourcent>"
         requires_context:
           domain: media_player

--- a/tests/fr/_fixtures.yaml
+++ b/tests/fr/_fixtures.yaml
@@ -766,6 +766,12 @@ entities:
     attributes:
       volume_level: "50"
 
+  - name: "Enceintes"
+    id: "media_player.speakers"
+    state: "idle"
+    attributes:
+      volume_level: "70"
+
   - name: "Nestor"
     id: "vacuum.nestor"
     state: "idle"

--- a/tests/fr/media_player_HassSetVolume.yaml
+++ b/tests/fr/media_player_HassSetVolume.yaml
@@ -3,9 +3,21 @@ tests:
   - sentences:
       - "Ajuste le volume de la TV à 50 pourcent"
       - "Mettre le volume de la TV sur 50%"
+      - "Règle la TV à 50%"
     intent:
       name: HassSetVolume
       slots:
         name: "TV"
         volume_level: 50
+    response: "Volume réglé"
+
+  - sentences:
+      - "Ajuste le volume des enceintes à 70 pourcent"
+      - "Mettre le volume des enceintes sur 70%"
+      - "Règle les enceintes à 70%"
+    intent:
+      name: HassSetVolume
+      slots:
+        name: "Enceintes"
+        volume_level: 70
     response: "Volume réglé"


### PR DESCRIPTION
## Problem
This sentence does not work:
- `Règle le volume des enceintes sur 50%`

But this one does:
- `Règle le volume de les enceintes sur 50%`

![CleanShot 2024-03-14 at 14 31 38](https://github.com/home-assistant/intents/assets/5878296/effda6f3-5ab1-4403-8e46-2e537d951b25)



## Solution
Just like we do for brightness, colors, and cover position, I am now using the expansion rule `<de>` instead of a hardcoded `de` here:

```yaml
- "<regle> le volume [<de>] [<le>]{name} [à|sur] {volume:volume_level}<pourcent>"
```

This allows users to say more natural sentences for media players that are plural:
- `Règle le volume des enceintes sur 50%`

NOTE: I added tests with a plural example to make sure we think about these in the future.
