### PR TITLE
[Fr] Add "pour cent" in the expansion rule <pourcent>

### DIFF
--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -511,7 +511,7 @@ lists:
 
 expansion_rules:
   #Common rules
-  pourcent: "(%| %| pourcent)"
+  pourcent: "(%| %| pourcent| pour cent)"
   degres: "(°| °| degré| degrés)"
   le: (le |la |les |l')
   dans: "(dans|du|de|des|à|au|aux|sur)"


### PR DESCRIPTION
this PR is related to https://github.com/home-assistant/intents/issues/2064

In French, Whisper is sometimes returning "pourcent" in two words. --> "pour cent" added in the related expansion rule