### PR TITLE
Add initial support for floors

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -13,6 +13,9 @@ HassTurnOn:
     area:
       description: "Name of an area"
       required: false
+    floor:
+      description: "Name of a floor"
+      required: false
     domain:
       description: "Domain of devices/entities in an area"
       required: false
@@ -23,6 +26,8 @@ HassTurnOn:
     name_only:
       - "name"
     area_only:
+      - "area"
+    floor_only:
       - "area"
     domain_only:
       - "domain"
@@ -50,6 +55,9 @@ HassTurnOff:
     area:
       description: "Name of an area"
       required: false
+    floor:
+      description: "Name of a floor"
+      required: false
     domain:
       description: "Domain of devices/entities in an area"
       required: false
@@ -60,6 +68,8 @@ HassTurnOff:
     name_only:
       - "name"
     area_only:
+      - "area"
+    floor_only:
       - "area"
     domain_only:
       - "domain"

--- a/responses/en/HassTurnOff.yaml
+++ b/responses/en/HassTurnOff.yaml
@@ -4,6 +4,7 @@ responses:
     HassTurnOff:
       default: "Turned off the {{ state.domain }}"
       lights_area: "Turned off the lights"
+      lights_floor: "Turned off the lights"
       fans_area: "Turned off the fans"
       cover: "Closed"
       light_all: "Turned off all of the lights"

--- a/responses/en/HassTurnOn.yaml
+++ b/responses/en/HassTurnOn.yaml
@@ -4,6 +4,7 @@ responses:
     HassTurnOn:
       default: "Turned on the {{ state.domain }}"
       lights_area: "Turned on the lights"
+      lights_floor: "Turned on the lights"
       light_all: "Turned on all of the lights"
       fans_area: "Turned on the fans"
       cover: "Opened"

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -112,20 +112,28 @@ INTENT_ERRORS = {
     "no_intent",
     "handle_error",
     "no_area",
+    "no_floor",
     "no_domain",
     "no_domain_in_area",
+    "no_domain_in_floor",
     "no_device_class",
     "no_device_class_in_area",
+    "no_device_class_in_floor",
     "no_entity",
     "no_entity_in_area",
+    "no_entity_in_floor",
     "no_entity_exposed",
     "no_entity_in_area_exposed",
+    "no_entity_in_floor_exposed",
     "no_domain_exposed",
     "no_domain_in_area_exposed",
+    "no_domain_in_floor_exposed",
     "no_device_class_exposed",
     "no_device_class_in_area_exposed",
+    "no_device_class_in_floor_exposed",
     "duplicate_entities",
     "duplicate_entities_in_area",
+    "duplicate_entities_in_floor",
 }
 
 SENTENCE_MATCHER = vol.All(
@@ -224,6 +232,7 @@ TESTS_FIXTURES = vol.Schema(
             {
                 vol.Required("name"): str,
                 vol.Required("id"): str,
+                vol.Optional("floor"): str,
             }
         ],
         vol.Optional("entities"): [

--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -333,7 +333,7 @@ lists:
 expansion_rules:
   name: "[the] {name}"
   area: "[the] {area}"
-  floor: "[the] {floor}"
+  floor: "[the] {floor}[ floor]"
   what_is: "(what's|whats|what is)"
   where_is: "(where's|wheres|where is)"
   brightness: "{brightness}[[ ]%| percent]"

--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -7,24 +7,32 @@ responses:
 
     # Errors for when user is not logged in
     no_area: "Sorry, I am not aware of any area called {{ area }}"
+    no_floor: "Sorry, I am not aware of any floor called {{ floor }}"
     no_domain: "Sorry, I am not aware of any {{ domain }}"
     no_domain_in_area: "Sorry, I am not aware of any {{ domain }} in the {{ area }} area"
+    no_domain_in_floor: "Sorry, I am not aware of any {{ domain }} on the {{ floor }} floor"
     no_device_class: "Sorry, I am not aware of any {{ device_class }}"
     no_device_class_in_area: "Sorry, I am not aware of any {{ device_class }} in the {{ area }} area"
+    no_device_class_in_floor: "Sorry, I am not aware of any {{ device_class }} in the {{ floor }} floor"
     no_entity: "Sorry, I am not aware of any device called {{ entity }}"
     no_entity_in_area: "Sorry, I am not aware of any device called {{ entity }} in the {{ area }} area"
+    no_entity_in_floor: "Sorry, I am not aware of any device called {{ entity }} in the {{ floor }} floor"
 
     # Errors for when user is logged in and we can give more information
     no_entity_exposed: "Sorry, {{ entity }} is not exposed"
     no_entity_in_area_exposed: "Sorry, {{ entity }} in the {{ area }} area is not exposed"
+    no_entity_in_floor_exposed: "Sorry, {{ entity }} in the {{ floor }} floor is not exposed"
     no_domain_exposed: "Sorry, no {{ domain }} is exposed"
     no_domain_in_area_exposed: "Sorry, no {{ domain }} in the {{ area }} area is exposed"
+    no_domain_in_floor_exposed: "Sorry, no {{ domain }} in the {{ floor }} floor is exposed"
     no_device_class_exposed: "Sorry, no {{ device_class }} is exposed"
     no_device_class_in_area_exposed: "Sorry, no {{ device_class }} in the {{ area }} area is exposed"
+    no_device_class_in_floor_exposed: "Sorry, no {{ device_class }} in the {{ floor }} floor is exposed"
 
     # Used when multiple (exposed) devices have the same name
     duplicate_entities: "Sorry, there are multiple devices called {{ entity }}"
     duplicate_entities_in_area: "Sorry, there are multiple devices called {{ entity }} in the {{ area }} area"
+    duplicate_entities_in_floor: "Sorry, there are multiple devices called {{ entity }} in the {{ floor }} floor"
 lists:
   color:
     values:
@@ -325,6 +333,7 @@ lists:
 expansion_rules:
   name: "[the] {name}"
   area: "[the] {area}"
+  floor: "[the] {floor}"
   what_is: "(what's|whats|what is)"
   where_is: "(where's|wheres|where is)"
   brightness: "{brightness}[[ ]%| percent]"

--- a/sentences/en/light_HassTurnOff.yaml
+++ b/sentences/en/light_HassTurnOff.yaml
@@ -59,6 +59,7 @@ intents:
       # Turn off all lights on a floor
       - sentences:
           - "<turn> off <all> <light> (on|in) <floor>"
+          - "<turn> off <all> <light> <floor>"
           - "<turn> off <all> <floor> <light>"
           - "<turn> <floor> <light> off"
           - "<floor> <light> off"

--- a/sentences/en/light_HassTurnOff.yaml
+++ b/sentences/en/light_HassTurnOff.yaml
@@ -55,3 +55,15 @@ intents:
         requires_context:
           area:
             slot: true
+
+      # Turn off all lights on a floor
+      - sentences:
+          - "<turn> off <all> <light> (on|in) <floor>"
+          - "<turn> off <all> <floor> <light>"
+          - "<turn> <floor> <light> off"
+          - "<floor> <light> off"
+          - "deactivate <all> <floor> <light>"
+          - "deactivate <all> <light> (on|in) <floor>"
+        response: "lights_floor"
+        slots:
+          domain: "light"

--- a/sentences/en/light_HassTurnOn.yaml
+++ b/sentences/en/light_HassTurnOn.yaml
@@ -59,6 +59,7 @@ intents:
       # Turn on all lights on a floor
       - sentences:
           - "<turn> on <all> <light> (on|in) <floor>"
+          - "<turn> on <all> <light> <floor>"
           - "<turn> on <all> <floor> <light>"
           - "<turn> <floor> <light> on"
           - "<floor> <light> on"

--- a/sentences/en/light_HassTurnOn.yaml
+++ b/sentences/en/light_HassTurnOn.yaml
@@ -55,3 +55,15 @@ intents:
         requires_context:
           area:
             slot: true
+
+      # Turn on all lights on a floor
+      - sentences:
+          - "<turn> on <all> <light> (on|in) <floor>"
+          - "<turn> on <all> <floor> <light>"
+          - "<turn> <floor> <light> on"
+          - "<floor> <light> on"
+          - "activate <all> <floor> <light>"
+          - "activate <all> <light> (on|in) <floor>"
+        response: "lights_floor"
+        slots:
+          domain: "light"

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -204,8 +204,9 @@ def get_slot_lists(fixtures: dict[str, Any]) -> dict[str, SlotList]:
     # Load test areas and entities for language
     slot_lists: dict[str, SlotList] = {}
 
-    # Generate names from templates
+    # area/floor
     area_names: List[str] = []
+    floor_names: List[str] = []
     for area in fixtures["areas"]:
         area_name = area["name"]
         if is_template(area_name):
@@ -216,8 +217,22 @@ def get_slot_lists(fixtures: dict[str, Any]) -> dict[str, SlotList]:
         else:
             area_names.append(area_name.strip())
 
-    slot_lists["area"] = TextSlotList.from_strings(area_names)
+        floor_name = area.get("floor")
+        if not floor_name:
+            continue
 
+        if is_template(floor_name):
+            floor_names.extend(
+                floor_name.strip()
+                for floor_name in sample_expression(parse_sentence(floor_name))
+            )
+        else:
+            floor_names.append(floor_name.strip())
+
+    slot_lists["area"] = TextSlotList.from_strings(area_names)
+    slot_lists["floor"] = TextSlotList.from_strings(floor_names)
+
+    # name
     entity_tuples: List[Tuple[str, str, Dict[str, Any]]] = []
     for entity in fixtures["entities"]:
         context = _entity_context(entity)

--- a/tests/en/_fixtures.yaml
+++ b/tests/en/_fixtures.yaml
@@ -2,21 +2,27 @@ language: "en"
 areas:
   - name: "Kitchen"
     id: "kitchen"
+    floor: "First Floor"
 
   - name: "Living Room"
     id: "living_room"
+    floor: "First Floor"
 
   - name: "Bedroom"
     id: "bedroom"
+    floor: "Second Floor"
 
   - name: "Garage"
     id: "garage"
+    floor: "First Floor"
 
   - name: "Entrance"
     id: "entrance"
+    floor: "First Floor"
 
   - name: "Office"
     id: "office"
+    floor: "Basement"
 entities:
   - name: "Bedroom Lamp"
     id: "light.bedroom_lamp"

--- a/tests/en/light_HassTurnOff.yaml
+++ b/tests/en/light_HassTurnOff.yaml
@@ -1,5 +1,6 @@
 language: en
 tests:
+  # Turn off all lights in an area
   - sentences:
       - "turn off all the lights in the kitchen"
       - "turn off all the lights in kitchen"
@@ -29,7 +30,7 @@ tests:
         domain: light
     response: "Turned off the lights"
 
-    # Turn off all lights in the home
+  # Turn off all lights in the home
   - sentences:
       - Turn all lights off in the appartment
       - Switch off every light in the home
@@ -49,7 +50,7 @@ tests:
       slots:
         domain: light
 
-    # Turn off lights in the same area as a satellite device
+  # Turn off lights in the same area as a satellite device
   - sentences:
       - Turn every light off in this room
       - Turn the lights off here
@@ -69,4 +70,19 @@ tests:
       slots:
         domain: light
         area: Living Room
+    response: "Turned off the lights"
+
+  # Turn off all lights on a floor
+  - sentences:
+      - Turn off all the lights on the first floor
+      - Switch off all first floor lights
+      - Turn first floor lights off
+      - First floor lights off
+      - Deactivate all first floor lights
+      - Deactivate all lights on the first floor
+    intent:
+      name: HassTurnOff
+      slots:
+        domain: light
+        floor: First Floor
     response: "Turned off the lights"

--- a/tests/en/light_HassTurnOff.yaml
+++ b/tests/en/light_HassTurnOff.yaml
@@ -75,6 +75,7 @@ tests:
   # Turn off all lights on a floor
   - sentences:
       - Turn off all the lights on the first floor
+      - Turn off all the lights first floor
       - Switch off all first floor lights
       - Turn first floor lights off
       - First floor lights off

--- a/tests/en/light_HassTurnOn.yaml
+++ b/tests/en/light_HassTurnOn.yaml
@@ -77,6 +77,7 @@ tests:
   # Turn on all lights on a floor
   - sentences:
       - Turn on all the lights on the first floor
+      - Turn on all the lights first floor
       - Switch on all first floor lights
       - Turn first floor lights on
       - First floor lights on

--- a/tests/en/light_HassTurnOn.yaml
+++ b/tests/en/light_HassTurnOn.yaml
@@ -1,5 +1,6 @@
 language: en
 tests:
+  # Turn on all lights in an area
   - sentences:
       - "turn on all the lights in the living room"
       - "turn on all the lights in living room"
@@ -51,7 +52,7 @@ tests:
       slots:
         domain: light
 
-    # Turn on lights in the same area as a satellite device
+  # Turn on lights in the same area as a satellite device
   - sentences:
       - Turn every light on in this room
       - Turn the lights on here
@@ -71,4 +72,19 @@ tests:
       slots:
         domain: light
         area: Living Room
+    response: "Turned on the lights"
+
+  # Turn on all lights on a floor
+  - sentences:
+      - Turn on all the lights on the first floor
+      - Switch on all first floor lights
+      - Turn first floor lights on
+      - First floor lights on
+      - Activate all first floor lights
+      - Activate all lights on the first floor
+    intent:
+      name: HassTurnOn
+      slots:
+        domain: light
+        floor: First Floor
     response: "Turned on the lights"

--- a/tests/test_language_intents.py
+++ b/tests/test_language_intents.py
@@ -71,6 +71,7 @@ def do_test_language_sentences(
     # Add placeholder slots that HA will generate
     language_sentences.slot_lists["area"] = TextSlotList(values=[])
     language_sentences.slot_lists["name"] = TextSlotList(values=[])
+    language_sentences.slot_lists["floor"] = TextSlotList(values=[])
 
     # Lint sentences
     for intent_name, intent in language_sentences.intents.items():


### PR DESCRIPTION
The Home Assistant 2024.4 beta includes support for [floors](https://rc.home-assistant.io/blog/2024/03/27/release-20244/#floors-of-your-home), which group areas.

This PR adds initial support for a `{floor}` slot list to lights for `HassTurnOn` and `HassTurnOff`. At the moment, only sentences for turning on/off lights on a floor are present.

Additionally, new error messages have been added that mirror areas.