### PR TITLE
[FR] Floor basic support for lights TurnOn and TurnOff

### DIFF
--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -101,7 +101,7 @@ responses:
       {%- endif %}
     no_entity: "Désolé, je ne connais pas l'appareil {{ entity }}"
     no_entity_in_area: "Désolé, je ne connais pas l'appareil {{ entity }}"
-    no_floor: "Désolé, je ne connais pas l'étage {{ area }}"
+    no_floor: "Désolé, je ne connais pas l'étage {{ floor }}"
     no_domain_in_floor: |
       {% set translations = {
         "button": "de boutons",

--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -625,7 +625,7 @@ expansion_rules:
   demarre: "(démarre|démarrer|lance|lancer)"
   diminue: "(diminue|diminuer|baisse|baisser)"
   eclaire: "(éclaire|éclairer|illumine|illuminer)"
-  eteins: "(éteint|eteint|éteins|eteins|éteindre|eteindre|désactive|désactiver|stoppe|stopper|arrête|arrêter|coupe|couper)"
+  eteins: "(éteint|eteint|éteins|eteins|éteindre|eteindre|désactive|désactiver|stoppe|stopper|arrête|arrêter|coupe|couper|<eteins_dirty>)"
   ferme: "(ferme|fermer|baisse|baisser)"
   lis: "(lis|lire|lecture)"
   mets: "(mets|mettre|passe|passer)"
@@ -633,6 +633,8 @@ expansion_rules:
   regle: "(règle|régler|met|mets|mettre|ajuste|ajuster|change|changer)"
   renvoie: "(renvoie|renvoyer|arrête|arrêter|stop[pe]|stopper)"
   reprends: "(reprends|reprendre|reprise)"
+  # We have some heavy STT limitations today. "Éteins" is often misunderstood as a different word. Because it's such a commun action, we're willing to support this hack for now. Ideally this should be removed once we have a better STT engine. Hence the fact that we decided to put it on a different expansion rules. The goal of this expansion rule is to be removed in the future.
+  eteins_dirty: "(étant|étends|étend|étendre|état|et tant|et teins|et teint|et teints|et t'as|été|étais|était)"
 
   # Domains and Things
   lumiere: "(lumière|lampe|ampoule)"

--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -101,7 +101,54 @@ responses:
       {%- endif %}
     no_entity: "Désolé, je ne connais pas l'appareil {{ entity }}"
     no_entity_in_area: "Désolé, je ne connais pas l'appareil {{ entity }}"
-
+    no_floor: "Désolé, je ne connais pas l'étage {{ area }}"
+    no_domain_in_floor: |
+      {% set translations = {
+        "button": "de boutons",
+        "camera": "de caméras",
+        "input_button": "de boutons",
+        "alarm_control_panel": "d'alarmes",
+        "automation": "d'automatisations",
+        "fan": "de ventilateurs",
+        "climate": "de thermostats",
+        "humidifier": "d'humidificateurs",
+        "input_boolean": "de commutateurs",
+        "siren": "de sirènes",
+        "water_heater": "de ballon d'eau chaude",
+        "light": "de lumières",
+        "switch": "de commutateurs",
+        "script": "de scripts",
+        "remote": "de télécommandes",
+        "lock": "de verrous",
+        "vacuum": "d'aspirateurs",
+        "scene": "de scènes",
+        "media_player": "de lecteurs multimédia",
+        "lawn_mower": "de tondeuses à gazon",
+        "valve": "de vannes"
+        } %}
+      {% if domain in translations -%}
+        Désolé, je n'ai pas trouvé {{ translations[domain] }} dans cet étage
+      {%- else -%}
+        Désolé, je n'ai rien trouvé de correspondant dans cet étage
+      {%- endif %}
+    no_device_class_in_floor: |
+      {% set translations = {
+        "awning": "d'auvents",
+        "blind": "de stores",
+        "curtain": "de rideaux",
+        "door": "de portes",
+        "garage": "de portes de garage",
+        "gate": "de portes",
+        "shade": "de stores",
+        "shutter": "de volets",
+        "window": "de fenêtres"
+        } %}
+      {% if device_class in translations -%}
+        Désolé, je n'ai pas trouvé {{ translations[device_class] }} dans cet étage
+      {%- else -%}
+        Désolé, je n'ai rien trouvé de correspondant dans cet étage
+      {%- endif %}
+    no_entity_in_floor: "Désolé, je ne connais pas l'appareil {{ entity }}"
     # Errors for when user is logged in and we can give more information
     no_entity_exposed: "Désolé, l'appareil {{ entity }} n'est pas exposé"
     no_entity_in_area_exposed: "Désolé, l'appareil {{ entity }} n'est pas exposé"
@@ -197,10 +244,58 @@ responses:
       {%- else -%}
         Désolé, aucun appareil de ce type n'est exposé
       {%- endif %}
+    no_entity_in_floor_exposed: "Désolé, l'appareil {{ entity }} n'est pas exposé"
+    no_domain_in_floor_exposed: |
+      {% set translations = {
+        "button": "aucun bouton de cet étage n'est exposé",
+        "camera": "aucune caméra de cet étage n'est exposée",
+        "input_button": "aucun bouton de cet étage n'est exposé",
+        "alarm_control_panel": "aucune alarme de cet étage n'est exposée",
+        "automation": "aucune automatisation de cet étage n'est exposée",
+        "fan": "aucun ventilateur de cet étage n'est exposé",
+        "climate": "aucun thermostat de cet étage n'est exposé",
+        "humidifier": "aucun humidificateur de cet étage n'est exposé",
+        "input_boolean": "aucun commutateur de cet étage n'est exposé",
+        "siren": "aucune sirène de cet étage n'est exposée",
+        "water_heater": "aucun ballon d'eau chaude de cet étage n'est exposé",
+        "light": "aucune lumière de cet étage n'est exposée",
+        "switch": "aucun commutateur de cet étage n'est exposé",
+        "script": "aucun script de cet étage n'est exposé",
+        "remote": "aucune télécommande de cet étage n'est exposée",
+        "lock": "aucun verrou de cet étage n'est exposé",
+        "vacuum": "aucun aspirateur de cet étage n'est exposé",
+        "scene": "aucune scène de cet étage n'est exposée",
+        "media_player": "aucun lecteur multimédia de cet étage n'est exposé",
+        "lawn_mower": "aucune tondeuse à gazon de cet étage n'est exposée",
+        "valve": "aucune vanne de cet étage n'est exposée"
+        } %}
+      {% if domain in translations -%}
+        Désolé, {{ translations[domain] }}
+      {%- else -%}
+        Désolé, aucun appareil de ce type n'est exposé
+      {%- endif %}
+    no_device_class_in_floor_exposed: |
+      {% set translations = {
+        "awning": "aucun auvent de cet étage n'est exposé",
+        "blind": "aucun store de cet étage n'est exposé",
+        "curtain": "aucun rideau de cet étage n'est exposé",
+        "door": "aucune porte de cet étage n'est exposée",
+        "garage": "aucune porte de garage de cet étage n'est exposée",
+        "gate": "aucune porte de cet étage n'est exposée",
+        "shade": "aucun store de cet étage n'est exposé",
+        "shutter": "aucun volet de cet étage n'est exposé",
+        "window": "aucune fenêtre de cet étage n'est exposeé"
+        } %}
+      {% if device_class in translations -%}
+        Désolé, {{ translations[device_class] }}
+      {%- else -%}
+        Désolé, aucun appareil de ce type n'est exposé
+      {%- endif %}
 
     # Used when multiple (exposed) devices have the same name
     duplicate_entities: "Désolé, plusieurs appareils sont nommés {{entity}}"
     duplicate_entities_in_area: "Désolé, plusieurs appareils de cette pièce sont nommés {{entity}}"
+    duplicate_entities_in_floor: "Désolé, plusieurs appareils de cet étage sont nommés {{entity}}"
 
 lists:
   color:

--- a/sentences/fr/cover_HassSetPosition.yaml
+++ b/sentences/fr/cover_HassSetPosition.yaml
@@ -67,7 +67,7 @@ intents:
             slot: true
 
       # name and floor
-      # To be done
+      # To be done when it's supported in the slot_combinations
 
       # device_class and floor
-      # To be done
+      # To be done when it's supported in the slot_combinations

--- a/sentences/fr/cover_HassSetPosition.yaml
+++ b/sentences/fr/cover_HassSetPosition.yaml
@@ -65,3 +65,9 @@ intents:
         requires_context:
           area:
             slot: true
+
+      # name and floor
+      # To be done
+
+      # device_class and floor
+      # To be done

--- a/sentences/fr/cover_HassTurnOff.yaml
+++ b/sentences/fr/cover_HassTurnOff.yaml
@@ -50,7 +50,7 @@ intents:
         response: cover
 
       # name and floor
-      # To be done
+      # To be done when it's supported in the slot_combinations
 
       # device_class and floor
-      # To be done
+      # To be done when it's supported in the slot_combinations

--- a/sentences/fr/cover_HassTurnOff.yaml
+++ b/sentences/fr/cover_HassTurnOff.yaml
@@ -48,3 +48,9 @@ intents:
           area:
             slot: true
         response: cover
+
+      # name and floor
+      # To be done
+
+      # device_class and floor
+      # To be done

--- a/sentences/fr/cover_HassTurnOn.yaml
+++ b/sentences/fr/cover_HassTurnOn.yaml
@@ -50,7 +50,7 @@ intents:
         response: cover
 
       # name and floor
-      # To be done
+      # To be done when it's supported in the slot_combinations
 
       # device_class and floor
-      # To be done
+      # To be done when it's supported in the slot_combinations

--- a/sentences/fr/cover_HassTurnOn.yaml
+++ b/sentences/fr/cover_HassTurnOn.yaml
@@ -48,3 +48,9 @@ intents:
           area:
             slot: true
         response: cover
+
+      # name and floor
+      # To be done
+
+      # device_class and floor
+      # To be done

--- a/sentences/fr/light_HassLightSet.yaml
+++ b/sentences/fr/light_HassLightSet.yaml
@@ -84,10 +84,10 @@ intents:
         response: brightness
 
       # brightness (name + floor)
-      # To be done
+      # To be done when it's supported in the slot_combinations
 
       # brightness (floor)
-      # To be done
+      # To be done when it's supported in the slot_combinations
 
       # color (name)
       - sentences:
@@ -135,7 +135,7 @@ intents:
         response: color
 
       # color (name + floor)
-      # To be done
+      # To be done when it's supported in the slot_combinations
 
       # color (floor)
-      # To be done
+      # To be done when it's supported in the slot_combinations

--- a/sentences/fr/light_HassLightSet.yaml
+++ b/sentences/fr/light_HassLightSet.yaml
@@ -83,6 +83,12 @@ intents:
           domain: light
         response: brightness
 
+      # brightness (name + floor)
+      # To be done
+
+      # brightness (floor)
+      # To be done
+
       # color (name)
       - sentences:
           # Règle la couleur du mirrior en vert
@@ -127,3 +133,9 @@ intents:
         requires_context:
           domain: light
         response: color
+
+      # color (name + floor)
+      # To be done
+
+      # color (floor)
+      # To be done

--- a/sentences/fr/light_HassTurnOff.yaml
+++ b/sentences/fr/light_HassTurnOff.yaml
@@ -41,7 +41,13 @@ intents:
           domain: light
 
       # name + floor
-      # To be done
+      # To be done when it's supported in the slot_combinations
 
       # floor
-      # To be done
+      - sentences:
+          # Éteindre les lumieres du premiere étage
+          - "<eteins> [<tous>] [<le>](<lumiere>|<lumieres>) [<dans>] [<le>]{floor}"
+          # Éteint le rez-de-chaussée
+          - "<eteins> [<le>]{floor}"
+        slots:
+          domain: light

--- a/sentences/fr/light_HassTurnOff.yaml
+++ b/sentences/fr/light_HassTurnOff.yaml
@@ -39,3 +39,9 @@ intents:
           - <eteins> <tous> [<le>]<lumieres>
         slots:
           domain: light
+
+      # name + floor
+      # To be done
+
+      # floor
+      # To be done

--- a/sentences/fr/light_HassTurnOn.yaml
+++ b/sentences/fr/light_HassTurnOn.yaml
@@ -39,3 +39,9 @@ intents:
           - <allume> <tous> [<le>]<lumieres>
         slots:
           domain: light
+
+      # name + floor
+      # To be done
+
+      # floor
+      # To be done

--- a/sentences/fr/light_HassTurnOn.yaml
+++ b/sentences/fr/light_HassTurnOn.yaml
@@ -41,7 +41,15 @@ intents:
           domain: light
 
       # name + floor
-      # To be done
+      # To be done when it's supported in the slot_combinations
 
       # floor
-      # To be done
+      - sentences:
+          # Allume la lumiere du premier étage
+          - "<allume> [<tous>] [<le>](<lumiere>|<lumieres>) [<dans>] [<le>]{floor}"
+          # Allume le rez-de-chaussée
+          - "(<allume>|<eclaire>) [<le>]{floor}"
+          # Lumière au premier étage
+          - "(<lumiere>|<lumieres>) [<dans>] [<le>]{floor}"
+        slots:
+          domain: light

--- a/tests/fr/_fixtures.yaml
+++ b/tests/fr/_fixtures.yaml
@@ -2,14 +2,24 @@ language: fr
 areas:
   - name: "cuisine"
     id: "kitchen"
+    floor: "Rez-De-Chaussée"
+
   - name: "salon"
     id: "living_room"
+    floor: "Rez-De-Chaussée"
+
   - name: "chambre"
     id: "bedroom"
+    floor: "Premier Étage"
+
   - name: "garage"
     id: "garage"
+    floor: "Rez-De-Chaussée"
+
   - name: "entrée"
     id: "hall"
+    floor: "Rez-De-Chaussée"
+
 entities:
   - name: "lumière du plafond"
     id: "light.bedroom_lamp"

--- a/tests/fr/light_HassTurnOff.yaml
+++ b/tests/fr/light_HassTurnOff.yaml
@@ -43,3 +43,14 @@ tests:
         domain: light
         area: Living Room
     response: "Éteint"
+
+  - sentences:
+      - "Éteindre la lumière du rez-de-chaussée"
+      - "Éteins la lumière au rez-de-chaussée"
+      - "Éteindre le rez-de-chaussée"
+    intent:
+      name: HassTurnOff
+      slots:
+        domain: light
+        floor: Rez-De-Chaussée
+    response: "Éteint"

--- a/tests/fr/light_HassTurnOn.yaml
+++ b/tests/fr/light_HassTurnOn.yaml
@@ -47,3 +47,15 @@ tests:
         domain: light
         area: Living Room
     response: "Allumé"
+
+  - sentences:
+      - "Allume la lumière du premier étage"
+      - "Allume la lumière au premier étage"
+      - "Allumer le premier étage"
+      - "Lumière au premier étage"
+    intent:
+      name: HassTurnOn
+      slots:
+        domain: light
+        floor: Premier Étage
+    response: "Allumé"


### PR DESCRIPTION
## Floor supports
Floors are now supported in French. (A basic support for now)

Please note that, as of today, the only intent supported by `floor` is `HassTurnOn` and `HassTurnOff`.
The only slot combination is `domain` + `floor`
This restricts what is possible.

This PR adds support for floors to lights.
- Turning on all lights on a floor
- Turning off all lights on a floor 

This is it for now. 
Once more intents, and slot combinations are supported, more sentences will come.

## Dirty hack support for the word "éteins" 
I am personally not a fan of introducing dirty hacks in our sentences, but this one is big, and is starting to get attention (https://github.com/home-assistant/intents/issues/2112).

The word "éteins" (Which means "Turn off") is often misunderstood as other words (étant among others)
I decided to create a "dirty" expansion rule and append it to the clean one.

I, on purpose, decided not to add the misunderstood words on the clean expansion rule because I want this gone in the future, once we find a better STT engine, or can perform some sort of fuzzy matching of words.

As of today, these words are now understood as a turn off action on top of the "Clean" verbs
```yaml
eteins_dirty: "(étant|étends|étend|étendre|état|et tant|et teins|et teint|et teints|et t'as|été|étais|était)"
```
