### PR TITLE
[DE] Add more variants to Nevermind

### DIFF
--- a/sentences/de/homeassistant_HassNevermind.yaml
+++ b/sentences/de/homeassistant_HassNevermind.yaml
@@ -7,4 +7,4 @@ intents:
           - "egal"
           - "abbrechen"
           - "Abbruch"
-          - "[doch] (nicht[s]|nix)"
+          - "[doch ](nicht[s]|nix)"

--- a/sentences/de/homeassistant_HassNevermind.yaml
+++ b/sentences/de/homeassistant_HassNevermind.yaml
@@ -7,4 +7,4 @@ intents:
           - "egal"
           - "abbrechen"
           - "Abbruch"
-          - "nichts"
+          - "[doch] (nicht[s]|nix)"

--- a/tests/de/homeassistant_HassNevermind.yaml
+++ b/tests/de/homeassistant_HassNevermind.yaml
@@ -6,5 +6,9 @@ tests:
       - "abbrechen"
       - "Abbruch"
       - "nichts"
+      - "nix"
+      - "doch nichts"
+      - "doch nicht"
+      - "doch nix"
     intent:
       name: HassNevermind


### PR DESCRIPTION
This adds "doch" and "doch nicht" to the "nichts" option, and adds "nix", if the TTS should ever detect that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced recognition for the `HassNevermind` intent by updating phrases to include variations like "nix," "doch nichts," "doch nicht," and "doch nix."

- **Tests**
  - Added new test phrases to ensure improved recognition for the `HassNevermind` intent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->