### PR TITLE
[FI] Don't exclude script from the generic HassTurnOn

### DIFF
--- a/sentences/fi/homeassistant_HassTurnOn.yaml
+++ b/sentences/fi/homeassistant_HassTurnOn.yaml
@@ -15,6 +15,5 @@ intents:
             - cover
             - lock
             - scene
-            - script
             - sensor
             - valve


### PR DESCRIPTION
There doesn't seem to be any way currently to start scripts via voice, and "käynnistä" is a very natural Finnish language word to use to start a script.