### PR TITLE
Create lock_HassTurnOff and lock_HassTurnOnfor lang fr-CA

### DIFF
--- a/sentences/fr-CA/lock_HassTurnOff.yaml
+++ b/sentences/fr-CA/lock_HassTurnOff.yaml
@@ -1,0 +1,15 @@
+language: fr
+intents:
+  HassTurnOff:
+    data:
+      - sentences:
+          - "débarre[(z|r)] [<le>]{name} [<dans> [<le>]{area}]"
+        requires_context:
+          domain: lock
+        response: lock
+
+      - sentences:
+          - "débarre[(z|r)] [<tous>] [(la|le[s])] [(porte[s]|serrure[s]|verrou[s])] [<dans>] [<le>]{area}"
+        slots:
+          domain: "lock"
+        response: lock

--- a/sentences/fr-CA/lock_HassTurnOff.yaml
+++ b/sentences/fr-CA/lock_HassTurnOff.yaml
@@ -4,12 +4,14 @@ intents:
     data:
       - sentences:
           - "débarre[(z|r)] [<le>]{name} [<dans> [<le>]{area}]"
+          - "déverrouille[(z|r)] [<le>]{name} [<dans> [<le>]{area}]"
         requires_context:
           domain: lock
         response: lock
 
       - sentences:
           - "débarre[(z|r)] [<tous>] [(la|le[s])] [(porte[s]|serrure[s]|verrou[s])] [<dans>] [<le>]{area}"
+          - "déverrouille[(z|r)] [<tous>] [(la|le[s])] [(porte[s]|serrure[s]|verrou[s])] [<dans>] [<le>]{area}"
         slots:
           domain: "lock"
         response: lock

--- a/sentences/fr-CA/lock_HassTurnOn.yaml
+++ b/sentences/fr-CA/lock_HassTurnOn.yaml
@@ -1,0 +1,16 @@
+language: fr-CA
+intents:
+  HassTurnOn:
+    data:
+      - sentences:
+          - "barre[(z|r)] [<le>]{name} [<dans> [<le>]{area}]"
+        requires_context:
+          domain: lock
+        response: lock
+
+      - sentences:
+          - "barre[(z|r)] [<tous>] [(la|le[s])] [(porte[s]|serrure[s]|verrou[s])] [<dans>] [<le>]{area}"
+          - "barre[(z|r)] [<tous>] (la|le[s]) (porte[s]|serrure[s]|verrou[s]) [<dans> [<le>]{area}]"
+        slots:
+          domain: "lock"
+        response: lock

--- a/sentences/fr-CA/lock_HassTurnOn.yaml
+++ b/sentences/fr-CA/lock_HassTurnOn.yaml
@@ -4,6 +4,7 @@ intents:
     data:
       - sentences:
           - "barre[(z|r)] [<le>]{name} [<dans> [<le>]{area}]"
+          - "verrouille[(z|r)] [<le>]{name} [<dans> [<le>]{area}]"
         requires_context:
           domain: lock
         response: lock
@@ -11,6 +12,8 @@ intents:
       - sentences:
           - "barre[(z|r)] [<tous>] [(la|le[s])] [(porte[s]|serrure[s]|verrou[s])] [<dans>] [<le>]{area}"
           - "barre[(z|r)] [<tous>] (la|le[s]) (porte[s]|serrure[s]|verrou[s]) [<dans> [<le>]{area}]"
+          - "verrouille[(z|r)] [<tous>] [(la|le[s])] [(porte[s]|serrure[s]|verrou[s])] [<dans>] [<le>]{area}"
+          - "verrouille[(z|r)] [<tous>] (la|le[s]) (porte[s]|serrure[s]|verrou[s]) [<dans> [<le>]{area}]"
         slots:
           domain: "lock"
         response: lock


### PR DESCRIPTION
Here's two addition to the fr-CA language that should help people from Quebec unlocking door using the most common local word "barrer" and "débarrer" .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced French language support for locking and unlocking commands with the `HassTurnOff` and `HassTurnOn` intents.
	- Added flexible sentence structures for users to issue commands related to specific locks or multiple locks in a designated area.

These enhancements improve user interaction by allowing commands in French, increasing accessibility for French-speaking users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->