### PR TITLE
Add timers for English

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -408,3 +408,184 @@ HassSetVolume:
     area_name:
       - "name"
       - "area"
+
+# -----------------------------------------------------------------------------
+# timers
+# -----------------------------------------------------------------------------
+
+HassStartTimer:
+  supported: true
+  domain: intent
+  description: "Starts a timer"
+  slots:
+    hours:
+      description: "Number of hours"
+      required: false
+    minutes:
+      description: "Number of minutes"
+      required: false
+    seconds:
+      description: "Number of seconds"
+      required: false
+    name:
+      description: "Name attached to the timer"
+      required: false
+  slot_groups:
+    duration:
+      - "hours"
+      - "minutes"
+      - "seconds"
+
+HassCancelTimer:
+  supported: true
+  domain: intent
+  description: "Cancels a timer"
+  slots:
+    start_hours:
+      description: "Hours the timer was started with"
+      required: false
+    start_minutes:
+      description: "Minutes the timer was started with"
+      required: false
+    start_seconds:
+      description: "Seconds the timer was started with"
+      required: false
+    name:
+      description: "Name attached to the timer"
+      required: false
+    area:
+      description: "Area of the device used to start the timer"
+      required: false
+
+HassIncreaseTimer:
+  supported: true
+  domain: intent
+  description: "Adds time to a timer"
+  slots:
+    hours:
+      description: "Number of hours"
+      required: false
+    minutes:
+      description: "Number of minutes"
+      required: false
+    seconds:
+      description: "Number of seconds"
+      required: false
+    start_hours:
+      description: "Hours the timer was started with"
+      required: false
+    start_minutes:
+      description: "Minutes the timer was started with"
+      required: false
+    start_seconds:
+      description: "Seconds the timer was started with"
+      required: false
+    name:
+      description: "Name attached to the timer"
+      required: false
+    area:
+      description: "Area of the device used to start the timer"
+      required: false
+  slot_groups:
+    duration:
+      - "hours"
+      - "minutes"
+      - "seconds"
+
+HassDecreaseTimer:
+  supported: true
+  domain: intent
+  description: "Adds time to a timer"
+  slots:
+    hours:
+      description: "Number of hours"
+      required: false
+    minutes:
+      description: "Number of minutes"
+      required: false
+    seconds:
+      description: "Number of seconds"
+      required: false
+    start_hours:
+      description: "Hours the timer was started with"
+      required: false
+    start_minutes:
+      description: "Minutes the timer was started with"
+      required: false
+    start_seconds:
+      description: "Seconds the timer was started with"
+      required: false
+    name:
+      description: "Name attached to the timer"
+      required: false
+    area:
+      description: "Area of the device used to start the timer"
+      required: false
+  slot_groups:
+    duration:
+      - "hours"
+      - "minutes"
+      - "seconds"
+
+HassPauseTimer:
+  supported: true
+  domain: intent
+  description: "Pauses a running timer"
+  slots:
+    start_hours:
+      description: "Hours the timer was started with"
+      required: false
+    start_minutes:
+      description: "Minutes the timer was started with"
+      required: false
+    start_seconds:
+      description: "Seconds the timer was started with"
+      required: false
+    name:
+      description: "Name attached to the timer"
+      required: false
+    area:
+      description: "Area of the device used to start the timer"
+      required: false
+
+HassUnpauseTimer:
+  supported: true
+  domain: intent
+  description: "Resumes a paused timer"
+  slots:
+    start_hours:
+      description: "Hours the timer was started with"
+      required: false
+    start_minutes:
+      description: "Minutes the timer was started with"
+      required: false
+    start_seconds:
+      description: "Seconds the timer was started with"
+      required: false
+    name:
+      description: "Name attached to the timer"
+      required: false
+    area:
+      description: "Area of the device used to start the timer"
+      required: false
+
+HassTimerStatus:
+  supported: true
+  domain: intent
+  description: "Reports status of one or more timers"
+  slots:
+    start_hours:
+      description: "Hours the timer was started with"
+      required: false
+    start_minutes:
+      description: "Minutes the timer was started with"
+      required: false
+    start_seconds:
+      description: "Seconds the timer was started with"
+      required: false
+    name:
+      description: "Name attached to the timer"
+      required: false
+    area:
+      description: "Area of the device used to start the timer"
+      required: false

--- a/responses/en/HassCancelTimer.yaml
+++ b/responses/en/HassCancelTimer.yaml
@@ -1,0 +1,6 @@
+---
+language: en
+responses:
+  intents:
+    HassCancelTimer:
+      default: "Timer cancelled"

--- a/responses/en/HassDecreaseTimer.yaml
+++ b/responses/en/HassDecreaseTimer.yaml
@@ -1,0 +1,6 @@
+---
+language: en
+responses:
+  intents:
+    HassDecreaseTimer:
+      default: "Removed time"

--- a/responses/en/HassDecreaseTimer.yaml
+++ b/responses/en/HassDecreaseTimer.yaml
@@ -3,4 +3,4 @@ language: en
 responses:
   intents:
     HassDecreaseTimer:
-      default: "Removed time"
+      default: "Timer updated"

--- a/responses/en/HassIncreaseTimer.yaml
+++ b/responses/en/HassIncreaseTimer.yaml
@@ -1,0 +1,6 @@
+---
+language: en
+responses:
+  intents:
+    HassIncreaseTimer:
+      default: "Added time"

--- a/responses/en/HassIncreaseTimer.yaml
+++ b/responses/en/HassIncreaseTimer.yaml
@@ -3,4 +3,4 @@ language: en
 responses:
   intents:
     HassIncreaseTimer:
-      default: "Added time"
+      default: "Timer updated"

--- a/responses/en/HassPauseTimer.yaml
+++ b/responses/en/HassPauseTimer.yaml
@@ -1,0 +1,6 @@
+---
+language: en
+responses:
+  intents:
+    HassPauseTimer:
+      default: "Timer paused"

--- a/responses/en/HassStartTimer.yaml
+++ b/responses/en/HassStartTimer.yaml
@@ -1,0 +1,6 @@
+---
+language: en
+responses:
+  intents:
+    HassStartTimer:
+      default: "Timer started"

--- a/responses/en/HassTimerStatus.yaml
+++ b/responses/en/HassTimerStatus.yaml
@@ -1,0 +1,64 @@
+---
+language: en
+responses:
+  intents:
+    HassTimerStatus:
+      default: |
+        {% set num_timers = slots.timers | length %}
+        {% set timer = None %}
+        {% if num_timers == 0: %}
+        No timers
+        {% elif num_timers == 1: %}
+        {% set timer = slots.timers[0] %}
+        {% else: %}
+        {% set sorted_timers = slots.timers | sort(attribute='total_seconds_left') %}
+        {% set timer = sorted_timers[0] %}
+        {{ num_timers }} timers running.
+        {% endif %}
+
+        {% if timer: %}
+        {% if (timer.rounded_hours_left == 1) and (timer.rounded_minutes_left > 0): %}
+        1 hour and {{ timer.rounded_minutes_left }} minutes
+        {% elif (timer.rounded_hours_left == 1): %}
+        1 hour
+        {% elif (timer.rounded_hours_left > 1) and (timer.rounded_minutes_left > 0): %}
+        {{ timer.rounded_hours_left }} hours and {{ timer.rounded_minutes_left }} minutes
+        {% elif (timer.rounded_hours_left > 1): %}
+        {{ timer.rounded_hours_left }} hours
+        {% elif (timer.rounded_minutes_left == 1) and (timer.rounded_seconds_left > 0): %}
+        1 minute and {{ timer.rounded_seconds_left }} seconds
+        {% elif (timer.rounded_minutes_left == 1): %}
+        1 minute
+        {% elif (timer.rounded_minutes_left > 1) and (timer.rounded_seconds_left > 0): %}
+        {{ timer.rounded_minutes_left }} minutes and {{ timer.rounded_seconds_left }} seconds
+        {% elif (timer.rounded_minutes_left > 1): %}
+        {{ timer.rounded_minutes_left }} minutes
+        {% elif (timer.rounded_seconds_left == 1): %}
+        1 second
+        {% elif (timer.rounded_seconds_left > 1): %}
+        {{ timer.rounded_seconds_left }} seconds
+        {% endif %}
+
+        {% if num_timers == 1: %}
+        left.
+        {% elif num_timers > 1: %}
+        left on
+        {% if (timer.start_hours > 0) and (timer.start_minutes > 0): %}
+        {{ timer.start_hours }} hour and {{ timer.start_minutes }} minute
+        {% elif (timer.start_hours > 0): %}
+        {{ timer.start_hours }} hour
+        {% elif (timer.start_minutes > 0) and (timer.start_seconds > 0): %}
+        {{ timer.start_minutes }} minute and {{ timer.start_seconds }} second
+        {% elif (timer.start_minutes > 0): %}
+        {{ timer.start_minutes }} minute
+        {% elif (timer.start_seconds > 0): %}
+        {{ timer.start_seconds }} second
+        {% endif %}
+
+        {% if timer.name: %}
+        {{ timer.name }}
+        {% endif %}
+
+        timer.
+        {% endif %}
+        {% endif %}

--- a/responses/en/HassTimerStatus.yaml
+++ b/responses/en/HassTimerStatus.yaml
@@ -5,60 +5,87 @@ responses:
     HassTimerStatus:
       default: |
         {% set num_timers = slots.timers | length %}
-        {% set timer = None %}
+        {% set active_timers = slots.timers | selectattr('is_active') | list %}
+        {% set num_active_timers = active_timers | length %}
+        {% set paused_timers = slots.timers | rejectattr('is_active') | list %}
+        {% set num_paused_timers = paused_timers | length %}
+        {% set next_timer = None %}
+
         {% if num_timers == 0: %}
-        No timers
-        {% elif num_timers == 1: %}
-        {% set timer = slots.timers[0] %}
+          No timers.
+        {% elif num_active_timers == 0: %}
+          {# No active timers #}
+          {% if num_paused_timers == 1: %}
+            {% set next_timer = paused_timers[0] %}
+            Timer is paused.
+          {% else: %}
+            {{ num_paused_timers }} paused timers.
+          {% endif %}
         {% else: %}
-        {% set sorted_timers = slots.timers | sort(attribute='total_seconds_left') %}
-        {% set timer = sorted_timers[0] %}
-        {{ num_timers }} timers running.
+          {# At least one active timer #}
+          {% if num_active_timers == 1: %}
+            {% set next_timer = active_timers[0] %}
+          {% else: %}
+            {# Get active timer that will finish soonest #}
+            {% set sorted_timers = active_timers | sort(attribute='total_seconds_left') %}
+            {% set next_timer = sorted_timers[0] %}
+            {{ num_active_timers }} running timers.
+          {% endif %}
+
+          {% if num_paused_timers == 1: %}
+            1 paused timer.
+          {% elif num_paused_timers > 0: %}
+            {{ num_paused_timers }} paused timers.
+          {% endif %}
         {% endif %}
 
-        {% if timer: %}
-        {% if (timer.rounded_hours_left == 1) and (timer.rounded_minutes_left > 0): %}
-        1 hour and {{ timer.rounded_minutes_left }} minutes
-        {% elif (timer.rounded_hours_left == 1): %}
-        1 hour
-        {% elif (timer.rounded_hours_left > 1) and (timer.rounded_minutes_left > 0): %}
-        {{ timer.rounded_hours_left }} hours and {{ timer.rounded_minutes_left }} minutes
-        {% elif (timer.rounded_hours_left > 1): %}
-        {{ timer.rounded_hours_left }} hours
-        {% elif (timer.rounded_minutes_left == 1) and (timer.rounded_seconds_left > 0): %}
-        1 minute and {{ timer.rounded_seconds_left }} seconds
-        {% elif (timer.rounded_minutes_left == 1): %}
-        1 minute
-        {% elif (timer.rounded_minutes_left > 1) and (timer.rounded_seconds_left > 0): %}
-        {{ timer.rounded_minutes_left }} minutes and {{ timer.rounded_seconds_left }} seconds
-        {% elif (timer.rounded_minutes_left > 1): %}
-        {{ timer.rounded_minutes_left }} minutes
-        {% elif (timer.rounded_seconds_left == 1): %}
-        1 second
-        {% elif (timer.rounded_seconds_left > 1): %}
-        {{ timer.rounded_seconds_left }} seconds
-        {% endif %}
+        {% if next_timer: %}
+          {# At least one active timer #}
+          {% if (next_timer.rounded_hours_left == 1) and (next_timer.rounded_minutes_left > 0): %}
+            1 hour and {{ next_timer.rounded_minutes_left }} minutes
+          {% elif (next_timer.rounded_hours_left == 1): %}
+            1 hour
+          {% elif (next_timer.rounded_hours_left > 1) and (next_timer.rounded_minutes_left > 0): %}
+            {{ next_timer.rounded_hours_left }} hours and {{ next_timer.rounded_minutes_left }} minutes
+          {% elif (next_timer.rounded_hours_left > 1): %}
+            {{ next_timer.rounded_hours_left }} hours
+          {% elif (next_timer.rounded_minutes_left == 1) and (next_timer.rounded_seconds_left > 0): %}
+            1 minute and {{ next_timer.rounded_seconds_left }} seconds
+          {% elif (next_timer.rounded_minutes_left == 1): %}
+            1 minute
+          {% elif (next_timer.rounded_minutes_left > 1) and (next_timer.rounded_seconds_left > 0): %}
+            {{ next_timer.rounded_minutes_left }} minutes and {{ next_timer.rounded_seconds_left }} seconds
+          {% elif (next_timer.rounded_minutes_left > 1): %}
+            {{ next_timer.rounded_minutes_left }} minutes
+          {% elif (next_timer.rounded_seconds_left == 1): %}
+            1 second
+          {% elif (next_timer.rounded_seconds_left > 1): %}
+            {{ next_timer.rounded_seconds_left }} seconds
+          {% endif %}
 
-        {% if num_timers == 1: %}
-        left.
-        {% elif num_timers > 1: %}
-        left on
-        {% if (timer.start_hours > 0) and (timer.start_minutes > 0): %}
-        {{ timer.start_hours }} hour and {{ timer.start_minutes }} minute
-        {% elif (timer.start_hours > 0): %}
-        {{ timer.start_hours }} hour
-        {% elif (timer.start_minutes > 0) and (timer.start_seconds > 0): %}
-        {{ timer.start_minutes }} minute and {{ timer.start_seconds }} second
-        {% elif (timer.start_minutes > 0): %}
-        {{ timer.start_minutes }} minute
-        {% elif (timer.start_seconds > 0): %}
-        {{ timer.start_seconds }} second
-        {% endif %}
+          {% if num_active_timers > 1: %}
+            {# Give some extra information to disambiguate #}
+            left on
+            {% if (next_timer.start_hours > 0) and (next_timer.start_minutes > 0): %}
+              {{ next_timer.start_hours }} hour and {{ next_timer.start_minutes }} minute
+            {% elif (next_timer.start_hours > 0): %}
+              {{ next_timer.start_hours }} hour
+            {% elif (next_timer.start_minutes > 0) and (next_timer.start_seconds > 0): %}
+              {{ next_timer.start_minutes }} minute and {{ next_timer.start_seconds }} second
+            {% elif (next_timer.start_minutes > 0): %}
+              {{ next_timer.start_minutes }} minute
+            {% elif (next_timer.start_seconds > 0): %}
+              {{ next_timer.start_seconds }} second
+            {% endif %}
 
-        {% if timer.name: %}
-        {{ timer.name }}
-        {% endif %}
+            {% if next_timer.name: %}
+              {{ next_timer.name }}
+            {% elif next_timer.area: %}
+              {{ next_timer.area }}
+            {% endif %}
 
-        timer.
-        {% endif %}
+            timer.
+          {% else: %}
+            left.
+          {% endif %}
         {% endif %}

--- a/responses/en/HassUnpauseTimer.yaml
+++ b/responses/en/HassUnpauseTimer.yaml
@@ -1,0 +1,6 @@
+---
+language: en
+responses:
+  intents:
+    HassUnpauseTimer:
+      default: "Timer resumed"

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -261,6 +261,7 @@ TESTS_FIXTURES = vol.Schema(
                 vol.Required("rounded_seconds_left"): int,
                 vol.Optional("name"): str,
                 vol.Optional("area"): str,
+                vol.Optional("is_active"): bool,
             }
         ],
     }

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -252,7 +252,9 @@ TESTS_FIXTURES = vol.Schema(
         ],
         vol.Optional("timers"): [
             {
-                vol.Required(vol.Any("start_hours", "start_minutes", "start_seconds")): int,
+                vol.Required(
+                    vol.Any("start_hours", "start_minutes", "start_seconds")
+                ): int,
                 vol.Required("total_seconds_left"): int,
                 vol.Required("rounded_hours_left"): int,
                 vol.Required("rounded_minutes_left"): int,

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -99,6 +99,9 @@ INTENTS_SCHEMA = vol.Schema(
             vol.Optional("slot_combinations"): {
                 str: [str],
             },
+            vol.Optional("slot_groups"): {
+                str: [str],
+            },
             vol.Optional("response_variables"): {
                 str: {
                     vol.Required("description"): str,
@@ -245,6 +248,17 @@ TESTS_FIXTURES = vol.Schema(
                     str, {vol.Required("in"): str, vol.Required("out"): str}
                 ),
                 vol.Optional("attributes"): {str: match_anything},
+            }
+        ],
+        vol.Optional("timers"): [
+            {
+                vol.Required(vol.Any("start_hours", "start_minutes", "start_seconds")): int,
+                vol.Required("total_seconds_left"): int,
+                vol.Required("rounded_hours_left"): int,
+                vol.Required("rounded_minutes_left"): int,
+                vol.Required("rounded_seconds_left"): int,
+                vol.Optional("name"): str,
+                vol.Optional("area"): str,
             }
         ],
     }
@@ -464,6 +478,20 @@ def validate_language(
         sentence_content = sentence_files.pop(test_file.name)
         _domain, intent = test_file.stem.rsplit("_", maxsplit=1)
 
+        # Ensure test file has the correct intent
+        has_correct_intent = True
+        for test in content["tests"]:
+            test_intent = test["intent"]["name"]
+            if test_intent != intent:
+                errors.append(
+                    f"{path}: expected intent {intent} but found {test_intent}"
+                )
+                has_correct_intent = False
+                break
+
+        if not has_correct_intent:
+            continue
+
         test_count = sum(len(test["sentences"]) for test in content["tests"])
 
         # Happens if the sentence file is invalid
@@ -527,10 +555,14 @@ def validate_language(
                 continue
 
             possible_response_keys: set[str] = set()
-            slots = {
+            slots: dict[str, Any] = {
                 slot_name: f"<{slot_name}>"
                 for slot_name in intent_schemas[intent_name].get("slots", {})
             }
+
+            # For timer intents
+            slots["timers"] = []
+
             for response_key, response_template in intent_responses.items():
                 possible_response_keys.add(response_key)
                 if response_key not in used_intent_response_keys:

--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -330,6 +330,21 @@ lists:
       from: 0
       to: 100
 
+  timer_seconds:
+    range:
+      from: 1
+      to: 100
+  timer_minutes:
+    range:
+      from: 1
+      to: 100
+  timer_hours:
+    range:
+      from: 1
+      to: 100
+  timer_name:
+    wildcard: true
+
 expansion_rules:
   name: "[the] {name}"
   area: "[the] {area}"
@@ -357,6 +372,18 @@ expansion_rules:
 
   # Questions
   what_is_the_class_of_name: "(<what_is> the <class> (of|in|from|(indicated|measured) by) <name> [in <area>]|<what_is> <name>['s] <class> [in <area>]|<what_is> <area> <name>['s] <class>)"
+
+  # Timers
+  timer_duration_seconds: "{timer_seconds:seconds} second[s]"
+  timer_duration_minutes: "{timer_minutes:minutes} minute[s][ [and ]{timer_seconds:seconds} second[s]]"
+  timer_duration_hours: "{timer_hours:hours} hour[s][ [and ]{timer_minutes:minutes} minute[s]][ [and ]{timer_seconds:seconds} second[s]]"
+  timer_duration: "<timer_duration_seconds>|<timer_duration_minutes>|<timer_duration_hours>"
+
+  timer_start_seconds: "{timer_seconds:start_seconds} second[s]"
+  timer_start_minutes: "{timer_minutes:start_minutes} minute[s][ [and ]{timer_seconds:start_seconds} second[s]]"
+  timer_start_hours: "{timer_hours:start_hours} hour[s][ [and ]{timer_minutes:start_minutes} minute[s]][ [and ]{timer_seconds:start_seconds} second[s]]"
+  timer_start: "<timer_start_seconds>|<timer_start_minutes>|<timer_start_hours>"
+
 skip_words:
   - "please"
   - "can you"

--- a/sentences/en/homeassistant_HassCancelTimer.yaml
+++ b/sentences/en/homeassistant_HassCancelTimer.yaml
@@ -1,0 +1,10 @@
+---
+language: "en"
+intents:
+  HassCancelTimer:
+    data:
+      - sentences:
+          - "cancel timer"
+          - "cancel <timer_start> timer"
+          - "cancel {area} timer"
+          - "cancel {timer_name:name} timer"

--- a/sentences/en/homeassistant_HassDecreaseTimer.yaml
+++ b/sentences/en/homeassistant_HassDecreaseTimer.yaml
@@ -1,0 +1,10 @@
+---
+language: "en"
+intents:
+  HassDecreaseTimer:
+    data:
+      - sentences:
+          - "remove <timer_duration> from timer"
+          - "remove <timer_duration> from <timer_start> timer"
+          - "remove <timer_duration> from {area} timer"
+          - "remove <timer_duration> from {timer_name:name} timer"

--- a/sentences/en/homeassistant_HassIncreaseTimer.yaml
+++ b/sentences/en/homeassistant_HassIncreaseTimer.yaml
@@ -1,0 +1,10 @@
+---
+language: "en"
+intents:
+  HassIncreaseTimer:
+    data:
+      - sentences:
+          - "add <timer_duration> to timer"
+          - "add <timer_duration> to <timer_start> timer"
+          - "add <timer_duration> to {area} timer"
+          - "add <timer_duration> to {timer_name:name} timer"

--- a/sentences/en/homeassistant_HassPauseTimer.yaml
+++ b/sentences/en/homeassistant_HassPauseTimer.yaml
@@ -1,0 +1,10 @@
+---
+language: "en"
+intents:
+  HassPauseTimer:
+    data:
+      - sentences:
+          - "pause timer"
+          - "pause <timer_start> timer"
+          - "pause {area} timer"
+          - "pause {timer_name:name} timer"

--- a/sentences/en/homeassistant_HassStartTimer.yaml
+++ b/sentences/en/homeassistant_HassStartTimer.yaml
@@ -1,0 +1,8 @@
+---
+language: "en"
+intents:
+  HassStartTimer:
+    data:
+      - sentences:
+          - "start a <timer_duration> timer"
+          - "start a <timer_duration> timer named {timer_name:name}"

--- a/sentences/en/homeassistant_HassTimerStatus.yaml
+++ b/sentences/en/homeassistant_HassTimerStatus.yaml
@@ -1,0 +1,10 @@
+---
+language: "en"
+intents:
+  HassTimerStatus:
+    data:
+      - sentences:
+          - "timer status"
+          - "<timer_start> timer status"
+          - "{area} timer status"
+          - "{timer_name:name} timer status"

--- a/sentences/en/homeassistant_HassUnpauseTimer.yaml
+++ b/sentences/en/homeassistant_HassUnpauseTimer.yaml
@@ -1,0 +1,10 @@
+---
+language: "en"
+intents:
+  HassUnpauseTimer:
+    data:
+      - sentences:
+          - "resume timer"
+          - "resume <timer_start> timer"
+          - "resume {area} timer"
+          - "resume {timer_name:name} timer"

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -54,6 +54,33 @@ class AreaEntry:
     aliases: Set[str] = field(default_factory=set)
 
 
+@dataclass
+class Timer:
+    """Minimal HA-like object for intent timers."""
+
+    start_hours: Optional[int]
+    start_minutes: Optional[int]
+    start_seconds: Optional[int]
+    rounded_hours_left: int
+    rounded_minutes_left: int
+    rounded_seconds_left: int
+    name: Optional[str]
+    area: Optional[str]
+
+    def asdict(self) -> Dict[str, Any]:
+        """Convert to dict for response template."""
+        return {
+            "start_hours": self.start_hours or 0,
+            "start_minutes": self.start_minutes or 0,
+            "start_seconds": self.start_seconds or 0,
+            "rounded_hours_left": self.rounded_hours_left,
+            "rounded_minutes_left": self.rounded_minutes_left,
+            "rounded_seconds_left": self.rounded_seconds_left,
+            "name": self.name or "",
+            "area": self.area or "",
+        }
+
+
 def get_matched_states(
     states: List[State], areas: List[AreaEntry], result: RecognizeResult
 ) -> Tuple[List[State], List[State]]:
@@ -143,6 +170,63 @@ def get_matched_states(
     return matched, unmatched
 
 
+def get_matched_timers(timers: List[Timer], result: RecognizeResult) -> List[Timer]:
+    if result.intent.name not in (
+        "HassTimerStatus",
+        "HassCancelTimer",
+        "HassIncreaseTimer",
+        "HassDecreaseTimer",
+        "HassPauseTimer",
+        "HassUnpauseTimer",
+    ):
+        return []
+
+    slots = {slot.name: slot.value for slot in result.entities.values()}
+    start_hours: Optional[int] = None
+    start_minutes: Optional[int] = None
+    start_seconds: Optional[int] = None
+
+    if "start_hours" in slots:
+        start_hours = slots["start_hours"]
+
+    if "start_minutes" in slots:
+        start_minutes = slots["start_minutes"]
+
+    if "start_seconds" in slots:
+        start_seconds = slots["start_seconds"]
+
+    if (
+        (start_hours is not None)
+        or (start_minutes is not None)
+        or (start_seconds is not None)
+    ):
+        timers = [
+            t
+            for t in timers
+            if (t.start_hours == start_hours)
+            and (t.start_minutes == start_minutes)
+            and (t.start_seconds == start_seconds)
+        ]
+        if not timers:
+            return []
+
+    name = slots.get("name")
+    if name:
+        name = _normalize_name(name)
+        timers = [t for t in timers if t.name == name]
+        if not timers:
+            return []
+
+    area = slots.get("area")
+    if area:
+        area = _normalize_name(area)
+        timers = [t for t in timers if t.area == area]
+        if not timers:
+            return []
+
+    return timers
+
+
 def _normalize_name(name: str) -> str:
     return name.strip().casefold()
 
@@ -158,6 +242,7 @@ def render_response(
     matched: List[State],
     unmatched: Optional[List[State]] = None,
     env: Optional[Environment] = None,
+    timers: Optional[List[Timer]] = None,
 ) -> str:
     """Renders a response template using Jinja2."""
     assert response_template, "Empty response template"
@@ -174,12 +259,20 @@ def render_response(
     if env is None:
         env = get_jinja2_environment()
 
+    slots: dict[str, Any] = {
+        entity.name: entity.text_clean or entity.value
+        for entity in result.entities_list
+    }
+
+    # For timer intents
+    if timers:
+        slots["timers"] = [t.asdict() for t in timers]
+    else:
+        slots["timers"] = []
+
     return env.from_string(response_template).render(
         {
-            "slots": {
-                entity.name: entity.text_clean or entity.value
-                for entity in result.entities_list
-            },
+            "slots": slots,
             "state": state1,
             "query": {
                 "matched": matched,
@@ -314,3 +407,30 @@ def get_areas(fixtures: dict[str, Any]) -> List[AreaEntry]:
             AreaEntry(id=area["id"], name=area_names[0], aliases=set(area_names[1:]))
         )
     return areas
+
+
+def get_timers(fixtures: dict[str, Any]) -> List[Timer]:
+    """Load timers from test fixtures."""
+    timers: List[Timer] = []
+    for timer in fixtures.get("timers", []):
+        timer_name = timer.get("name")
+        if timer_name:
+            timer_name = _normalize_name(timer_name)
+
+        timer_area = timer.get("area")
+        if timer_area:
+            timer_area = _normalize_name(timer_area)
+
+        timers.append(
+            Timer(
+                start_hours=timer.get("start_hours"),
+                start_minutes=timer.get("start_minutes"),
+                start_seconds=timer.get("start_seconds"),
+                rounded_hours_left=timer["rounded_hours_left"],
+                rounded_minutes_left=timer["rounded_minutes_left"],
+                rounded_seconds_left=timer["rounded_seconds_left"],
+                name=timer_name,
+                area=timer_area,
+            )
+        )
+    return timers

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -58,6 +58,7 @@ class AreaEntry:
 class Timer:
     """Minimal HA-like object for intent timers."""
 
+    is_active: bool
     start_hours: Optional[int]
     start_minutes: Optional[int]
     start_seconds: Optional[int]
@@ -66,10 +67,12 @@ class Timer:
     rounded_seconds_left: int
     name: Optional[str]
     area: Optional[str]
+    total_seconds_left: int
 
     def asdict(self) -> Dict[str, Any]:
         """Convert to dict for response template."""
         return {
+            "is_active": self.is_active,
             "start_hours": self.start_hours or 0,
             "start_minutes": self.start_minutes or 0,
             "start_seconds": self.start_seconds or 0,
@@ -78,6 +81,7 @@ class Timer:
             "rounded_seconds_left": self.rounded_seconds_left,
             "name": self.name or "",
             "area": self.area or "",
+            "total_seconds_left": self.total_seconds_left,
         }
 
 
@@ -423,6 +427,7 @@ def get_timers(fixtures: dict[str, Any]) -> List[Timer]:
 
         timers.append(
             Timer(
+                is_active=timer.get("is_active", True),
                 start_hours=timer.get("start_hours"),
                 start_minutes=timer.get("start_minutes"),
                 start_seconds=timer.get("start_seconds"),
@@ -431,6 +436,7 @@ def get_timers(fixtures: dict[str, Any]) -> List[Timer]:
                 rounded_seconds_left=timer["rounded_seconds_left"],
                 name=timer_name,
                 area=timer_area,
+                total_seconds_left=timer["total_seconds_left"],
             )
         )
     return timers

--- a/tests/en/_fixtures.yaml
+++ b/tests/en/_fixtures.yaml
@@ -731,3 +731,21 @@ entities:
   - name: "Rover"
     id: "vacuum.rover"
     state: "idle"
+timers:
+  - start_hours: 1
+    total_seconds_left: 100
+    rounded_hours_left: 0
+    rounded_minutes_left: 1
+    rounded_seconds_left: 40
+  - name: pizza
+    start_minutes: 30
+    total_seconds_left: 1505
+    rounded_hours_left: 0
+    rounded_minutes_left: 25
+    rounded_seconds_left: 0
+  - area: kitchen
+    start_minutes: 5
+    total_seconds_left: 190
+    rounded_hours_left: 0
+    rounded_minutes_left: 3
+    rounded_seconds_left: 0

--- a/tests/en/_fixtures.yaml
+++ b/tests/en/_fixtures.yaml
@@ -732,7 +732,8 @@ entities:
     id: "vacuum.rover"
     state: "idle"
 timers:
-  - start_hours: 1
+  - is_active: false
+    start_hours: 1
     total_seconds_left: 100
     rounded_hours_left: 0
     rounded_minutes_left: 1

--- a/tests/en/homeassistant_HassCancelTimer.yaml
+++ b/tests/en/homeassistant_HassCancelTimer.yaml
@@ -1,0 +1,32 @@
+---
+language: en
+tests:
+  - sentences:
+      - "cancel timer"
+    intent:
+      name: HassCancelTimer
+    response: Timer cancelled
+
+  - sentences:
+      - "cancel 5 minute timer"
+    intent:
+      name: HassCancelTimer
+      slots:
+        start_minutes: 5
+    response: Timer cancelled
+
+  - sentences:
+      - "cancel pizza timer"
+    intent:
+      name: HassCancelTimer
+      slots:
+        name: "pizza "
+    response: Timer cancelled
+
+  - sentences:
+      - "cancel kitchen timer"
+    intent:
+      name: HassCancelTimer
+      slots:
+        area: Kitchen
+    response: Timer cancelled

--- a/tests/en/homeassistant_HassDecreaseTimer.yaml
+++ b/tests/en/homeassistant_HassDecreaseTimer.yaml
@@ -1,0 +1,37 @@
+---
+language: en
+tests:
+  - sentences:
+      - "remove 5 minutes from timer"
+    intent:
+      name: HassDecreaseTimer
+      slots:
+        minutes: 5
+    response: Removed time
+
+  - sentences:
+      - "remove 5 minutes from 1 hour timer"
+    intent:
+      name: HassDecreaseTimer
+      slots:
+        minutes: 5
+        start_hours: 1
+    response: Removed time
+
+  - sentences:
+      - "remove 5 minutes from pizza timer"
+    intent:
+      name: HassDecreaseTimer
+      slots:
+        minutes: 5
+        name: "pizza "
+    response: Removed time
+
+  - sentences:
+      - "remove 5 minutes from kitchen timer"
+    intent:
+      name: HassDecreaseTimer
+      slots:
+        minutes: 5
+        area: Kitchen
+    response: Removed time

--- a/tests/en/homeassistant_HassDecreaseTimer.yaml
+++ b/tests/en/homeassistant_HassDecreaseTimer.yaml
@@ -7,7 +7,7 @@ tests:
       name: HassDecreaseTimer
       slots:
         minutes: 5
-    response: Removed time
+    response: Timer updated
 
   - sentences:
       - "remove 5 minutes from 1 hour timer"
@@ -16,7 +16,7 @@ tests:
       slots:
         minutes: 5
         start_hours: 1
-    response: Removed time
+    response: Timer updated
 
   - sentences:
       - "remove 5 minutes from pizza timer"
@@ -25,7 +25,7 @@ tests:
       slots:
         minutes: 5
         name: "pizza "
-    response: Removed time
+    response: Timer updated
 
   - sentences:
       - "remove 5 minutes from kitchen timer"
@@ -34,4 +34,4 @@ tests:
       slots:
         minutes: 5
         area: Kitchen
-    response: Removed time
+    response: Timer updated

--- a/tests/en/homeassistant_HassIncreaseTimer.yaml
+++ b/tests/en/homeassistant_HassIncreaseTimer.yaml
@@ -7,7 +7,7 @@ tests:
       name: HassIncreaseTimer
       slots:
         minutes: 5
-    response: Added time
+    response: Timer updated
 
   - sentences:
       - "add 5 minutes to 1 hour timer"
@@ -16,7 +16,7 @@ tests:
       slots:
         minutes: 5
         start_hours: 1
-    response: Added time
+    response: Timer updated
 
   - sentences:
       - "add 5 minutes to pizza timer"
@@ -25,7 +25,7 @@ tests:
       slots:
         minutes: 5
         name: "pizza "
-    response: Added time
+    response: Timer updated
 
   - sentences:
       - "add 5 minutes to kitchen timer"
@@ -34,4 +34,4 @@ tests:
       slots:
         minutes: 5
         area: Kitchen
-    response: Added time
+    response: Timer updated

--- a/tests/en/homeassistant_HassIncreaseTimer.yaml
+++ b/tests/en/homeassistant_HassIncreaseTimer.yaml
@@ -1,0 +1,37 @@
+---
+language: en
+tests:
+  - sentences:
+      - "add 5 minutes to timer"
+    intent:
+      name: HassIncreaseTimer
+      slots:
+        minutes: 5
+    response: Added time
+
+  - sentences:
+      - "add 5 minutes to 1 hour timer"
+    intent:
+      name: HassIncreaseTimer
+      slots:
+        minutes: 5
+        start_hours: 1
+    response: Added time
+
+  - sentences:
+      - "add 5 minutes to pizza timer"
+    intent:
+      name: HassIncreaseTimer
+      slots:
+        minutes: 5
+        name: "pizza "
+    response: Added time
+
+  - sentences:
+      - "add 5 minutes to kitchen timer"
+    intent:
+      name: HassIncreaseTimer
+      slots:
+        minutes: 5
+        area: Kitchen
+    response: Added time

--- a/tests/en/homeassistant_HassPauseTimer.yaml
+++ b/tests/en/homeassistant_HassPauseTimer.yaml
@@ -1,0 +1,32 @@
+---
+language: en
+tests:
+  - sentences:
+      - "pause timer"
+    intent:
+      name: HassPauseTimer
+    response: Timer paused
+
+  - sentences:
+      - "pause 1 hour timer"
+    intent:
+      name: HassPauseTimer
+      slots:
+        start_hours: 1
+    response: Timer paused
+
+  - sentences:
+      - "pause pizza timer"
+    intent:
+      name: HassPauseTimer
+      slots:
+        name: "pizza "
+    response: Timer paused
+
+  - sentences:
+      - "pause kitchen timer"
+    intent:
+      name: HassPauseTimer
+      slots:
+        area: Kitchen
+    response: Timer paused

--- a/tests/en/homeassistant_HassStartTimer.yaml
+++ b/tests/en/homeassistant_HassStartTimer.yaml
@@ -1,0 +1,72 @@
+---
+language: en
+tests:
+  - sentences:
+      - "start a 1 hour timer"
+    intent:
+      name: HassStartTimer
+      slots:
+        hours: 1
+    response: Timer started
+
+  - sentences:
+      - "start a 1 hour and 15 minute timer"
+    intent:
+      name: HassStartTimer
+      slots:
+        hours: 1
+        minutes: 15
+    response: Timer started
+
+  - sentences:
+      - "start a 1 hour and 30 second timer"
+    intent:
+      name: HassStartTimer
+      slots:
+        hours: 1
+        seconds: 30
+    response: Timer started
+
+  - sentences:
+      - "start a 1 hour 15 minute and 30 second timer"
+    intent:
+      name: HassStartTimer
+      slots:
+        hours: 1
+        minutes: 15
+        seconds: 30
+    response: Timer started
+
+  - sentences:
+      - "start a 5 minute timer"
+    intent:
+      name: HassStartTimer
+      slots:
+        minutes: 5
+    response: Timer started
+
+  - sentences:
+      - "start a 5 minute timer named pizza"
+    intent:
+      name: HassStartTimer
+      slots:
+        minutes: 5
+        name: "pizza"
+    response: Timer started
+
+  - sentences:
+      - "start a 5 minute and 10 second timer"
+    intent:
+      name: HassStartTimer
+      slots:
+        minutes: 5
+        seconds: 10
+    response: Timer started
+
+  - sentences:
+      - "start a 45 second timer"
+    intent:
+      name: HassStartTimer
+      slots:
+        seconds: 45
+    response: Timer started

--- a/tests/en/homeassistant_HassTimerStatus.yaml
+++ b/tests/en/homeassistant_HassTimerStatus.yaml
@@ -6,7 +6,7 @@ tests:
     intent:
       name: HassTimerStatus
     response: |
-      3 timers running. 1 minute and 40 seconds left on 1 hour timer.
+      2 running timers. 1 paused timer. 3 minutes left on 5 minute kitchen timer.
 
   - sentences:
       - "1 hour timer status"
@@ -15,7 +15,7 @@ tests:
       slots:
         start_hours: 1
     response: |
-      1 minute and 40 seconds left.
+      Timer is paused. 1 minute and 40 seconds left.
 
   - sentences:
       - "pizza timer status"

--- a/tests/en/homeassistant_HassTimerStatus.yaml
+++ b/tests/en/homeassistant_HassTimerStatus.yaml
@@ -1,0 +1,36 @@
+---
+language: en
+tests:
+  - sentences:
+      - "timer status"
+    intent:
+      name: HassTimerStatus
+    response: |
+      3 timers running. 1 minute and 40 seconds left on 1 hour timer.
+
+  - sentences:
+      - "1 hour timer status"
+    intent:
+      name: HassTimerStatus
+      slots:
+        start_hours: 1
+    response: |
+      1 minute and 40 seconds left.
+
+  - sentences:
+      - "pizza timer status"
+    intent:
+      name: HassTimerStatus
+      slots:
+        name: "pizza "
+    response: |
+      25 minutes left.
+
+  - sentences:
+      - "kitchen timer status"
+    intent:
+      name: HassTimerStatus
+      slots:
+        area: Kitchen
+    response: |
+      3 minutes left.

--- a/tests/en/homeassistant_HassUnpauseTimer.yaml
+++ b/tests/en/homeassistant_HassUnpauseTimer.yaml
@@ -1,0 +1,32 @@
+---
+language: en
+tests:
+  - sentences:
+      - "resume timer"
+    intent:
+      name: HassUnpauseTimer
+    response: Timer resumed
+
+  - sentences:
+      - "resume 1 hour timer"
+    intent:
+      name: HassUnpauseTimer
+      slots:
+        start_hours: 1
+    response: Timer resumed
+
+  - sentences:
+      - "resume pizza timer"
+    intent:
+      name: HassUnpauseTimer
+      slots:
+        name: "pizza "
+    response: Timer resumed
+
+  - sentences:
+      - "resume kitchen timer"
+    intent:
+      name: HassUnpauseTimer
+      slots:
+        area: Kitchen
+    response: Timer resumed

--- a/tests/test_language_intents.py
+++ b/tests/test_language_intents.py
@@ -82,6 +82,7 @@ def do_test_language_sentences(
         intent_schema = intent_schemas[intent_name]
         slot_schema = intent_schema.get("slots", {})
         slot_combinations = intent_schema.get("slot_combinations")
+        slot_groups = intent_schema.get("slot_groups")
 
         for data in intent.data:
             if not data.sentences:
@@ -125,6 +126,13 @@ def do_test_language_sentences(
                         assert (
                             slot_name in found_slots
                         ), f"Missing required slot: '{slot_name}', intent='{intent_name}', sentence='{sentence.text}'"
+
+                if slot_groups:
+                    # Verify one member of each group is present
+                    for group_name, group_slots in slot_groups.items():
+                        assert found_slots.intersection(
+                            group_slots
+                        ), f"Slot group not matched: group='{group_name}' intent='{intent_name}', slots={found_slots}, sentence='{sentence.text}'"
 
                 if slot_combinations:
                     # Verify one of the combinations is matched

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import sys
-from typing import Any, List, Optional
+from typing import Any, List
 
 import pytest
 from hassil import Intents, recognize
-from hassil.recognize import RecognizeResult
 from hassil.intents import SlotList
 from hassil.util import normalize_whitespace
 from jinja2 import BaseLoader, Environment
@@ -15,6 +14,7 @@ from jinja2 import BaseLoader, Environment
 from shared import (
     AreaEntry,
     State,
+    Timer,
     get_areas,
     get_matched_states,
     get_matched_timers,
@@ -22,7 +22,6 @@ from shared import (
     get_states,
     get_timers,
     render_response,
-    Timer,
 )
 
 from . import TESTS_DIR, get_test_path, load_test


### PR DESCRIPTION
First pass at English support for Assist timers (see https://github.com/home-assistant/core/pull/117199)

This adds support for the new intents:

- `HassStartTimer` - start a new timer
- `HassCancelTimer` - cancel a timer by name, area, or start time
- `HassTimerStatus` - report status of timer(s)
- `HassIncreaseTimer` - add time to a timer
- `HassDecreaseTimer` - remove time from a timer
- `HassPauseTimer` - pause a running timer
- `HassUnpauseTimer` - resume a paused timer

Additionally, a new `timers` section is present in `_fixtures.yaml` with information about the timers used in the tests:

```yaml
timers:
  - start_hours: 1
    total_seconds_left: 100
    rounded_hours_left: 0
    rounded_minutes_left: 1
    rounded_seconds_left: 40
  - name: pizza
    start_minutes: 30
    total_seconds_left: 1505
    rounded_hours_left: 0
    rounded_minutes_left: 25
    rounded_seconds_left: 0
  - area: kitchen
    start_minutes: 5
    total_seconds_left: 190
    rounded_hours_left: 0
    rounded_minutes_left: 3
    rounded_seconds_left: 0
```