### PR TITLE
Add enhanced media sentences for English

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -337,14 +337,6 @@ HassMediaPause:
     area:
       description: "Name of an area"
       required: false
-  slot_combinations:
-    name_only:
-      - "name"
-    area_only:
-      - "area"
-    area_name:
-      - "name"
-      - "area"
 
 HassMediaUnpause:
   supported: true
@@ -357,14 +349,6 @@ HassMediaUnpause:
     area:
       description: "Name of an area"
       required: false
-  slot_combinations:
-    name_only:
-      - "name"
-    area_only:
-      - "area"
-    area_name:
-      - "name"
-      - "area"
 
 HassMediaNext:
   supported: true
@@ -377,14 +361,6 @@ HassMediaNext:
     area:
       description: "Name of an area"
       required: false
-  slot_combinations:
-    name_only:
-      - "name"
-    area_only:
-      - "area"
-    area_name:
-      - "name"
-      - "area"
 
 HassSetVolume:
   supported: true
@@ -400,14 +376,6 @@ HassSetVolume:
     volume_level:
       description: "Volume level from 0 to 100"
       required: true
-  slot_combinations:
-    name_only:
-      - "name"
-    area_only:
-      - "area"
-    area_name:
-      - "name"
-      - "area"
 
 # -----------------------------------------------------------------------------
 # timers

--- a/sentences/en/media_player_HassMediaNext.yaml
+++ b/sentences/en/media_player_HassMediaNext.yaml
@@ -7,3 +7,6 @@ intents:
           - "(skip [(to [the ]next [(song|track)]|([the ](song|track)|this [(song|track)]) )];[on ]<name>)"
         requires_context:
           domain: media_player
+      - sentences:
+          - "next [track|item]"
+          - "(skip [(to [the ]next [(song|track)]|([the ](song|track)|this [(song|track)]))])"

--- a/sentences/en/media_player_HassMediaPause.yaml
+++ b/sentences/en/media_player_HassMediaPause.yaml
@@ -6,3 +6,5 @@ intents:
           - "(pause;<name>)"
         requires_context:
           domain: media_player
+      - sentences:
+          - "pause"

--- a/sentences/en/media_player_HassMediaUnpause.yaml
+++ b/sentences/en/media_player_HassMediaUnpause.yaml
@@ -6,3 +6,5 @@ intents:
           - "((unpause|resume);<name>)"
         requires_context:
           domain: media_player
+      - sentences:
+          - "(unpause|resume)"

--- a/sentences/en/media_player_HassSetVolume.yaml
+++ b/sentences/en/media_player_HassSetVolume.yaml
@@ -9,3 +9,8 @@ intents:
           - "(turn (the volume;(up|down)) to <volume> [percent];[on ]<name>)"
         requires_context:
           domain: media_player
+      - sentences:
+          - "<numeric_value_set> volume to <volume> [percent]"
+          - "turn volume (up|down) to <volume> [percent]"
+          - "<numeric_value_set> the volume to <volume> [percent]"
+          - "turn (the volume;(up|down)) to <volume> [percent]"

--- a/tests/en/media_player_HassMediaNext.yaml
+++ b/tests/en/media_player_HassMediaNext.yaml
@@ -16,3 +16,16 @@ tests:
       slots:
         name: "TV"
     response: "Playing next"
+  - sentences:
+      - "next item"
+      - "skip song"
+      - "skip track"
+      - "skip to the next song"
+      - "skip to next track"
+      - "skip this song"
+      - "skip the track"
+      - "skip"
+      - "skip this"
+    intent:
+      name: HassMediaNext
+    response: "Playing next"

--- a/tests/en/media_player_HassMediaPause.yaml
+++ b/tests/en/media_player_HassMediaPause.yaml
@@ -8,3 +8,8 @@ tests:
       slots:
         name: "TV"
     response: "Paused"
+  - sentences:
+      - "pause"
+    intent:
+      name: HassMediaPause
+    response: "Paused"

--- a/tests/en/media_player_HassMediaUnpause.yaml
+++ b/tests/en/media_player_HassMediaUnpause.yaml
@@ -10,3 +10,9 @@ tests:
       slots:
         name: "TV"
     response: "Unpaused"
+  - sentences:
+      - "unpause"
+      - "resume"
+    intent:
+      name: HassMediaUnpause
+    response: "Unpaused"

--- a/tests/en/media_player_HassSetVolume.yaml
+++ b/tests/en/media_player_HassSetVolume.yaml
@@ -13,3 +13,15 @@ tests:
         name: "TV"
         volume_level: 90
     response: "Volume set"
+  - sentences:
+      - "set volume to 90 percent"
+      - "change the volume to 90"
+      - "turn volume down to 90 percent"
+      - "increase the volume to 90 percent"
+      - "turn the volume down to 90 percent"
+      - "turn up the volume to 90"
+    intent:
+      name: HassSetVolume
+      slots:
+        volume_level: 90
+    response: "Volume set"


### PR DESCRIPTION
HA now supports "enhanced" media control via voice (see https://github.com/home-assistant/core/pull/115445).

This will use the area/floor of the voice satellite and state/features of media players to figure out which media player(s) to target (when no name is provided). For example, "pause" will pause any playing media players in the current area.