### PR TITLE
Require context area for media intents with no name

### DIFF
--- a/sentences/en/media_player_HassMediaNext.yaml
+++ b/sentences/en/media_player_HassMediaNext.yaml
@@ -10,3 +10,6 @@ intents:
       - sentences:
           - "next [track|item]"
           - "(skip [(to [the ]next [(song|track)]|([the ](song|track)|this [(song|track)]))])"
+        requires_context:
+          area:
+            slot: true

--- a/sentences/en/media_player_HassMediaPause.yaml
+++ b/sentences/en/media_player_HassMediaPause.yaml
@@ -8,3 +8,6 @@ intents:
           domain: media_player
       - sentences:
           - "pause"
+        requires_context:
+          area:
+            slot: true

--- a/sentences/en/media_player_HassMediaUnpause.yaml
+++ b/sentences/en/media_player_HassMediaUnpause.yaml
@@ -8,3 +8,6 @@ intents:
           domain: media_player
       - sentences:
           - "(unpause|resume)"
+        requires_context:
+          area:
+            slot: true

--- a/sentences/en/media_player_HassSetVolume.yaml
+++ b/sentences/en/media_player_HassSetVolume.yaml
@@ -14,3 +14,6 @@ intents:
           - "turn volume (up|down) to <volume> [percent]"
           - "<numeric_value_set> the volume to <volume> [percent]"
           - "turn (the volume;(up|down)) to <volume> [percent]"
+        requires_context:
+          area:
+            slot: true

--- a/tests/en/_fixtures.yaml
+++ b/tests/en/_fixtures.yaml
@@ -724,6 +724,7 @@ entities:
 
   - name: "TV"
     id: "media_player.tv"
+    area: "living_room"
     state: "idle"
     attributes:
       volume_level: "50"

--- a/tests/en/media_player_HassMediaNext.yaml
+++ b/tests/en/media_player_HassMediaNext.yaml
@@ -28,4 +28,8 @@ tests:
       - "skip this"
     intent:
       name: HassMediaNext
+      slots:
+        area: "Living Room"
+      context:
+        area: Living Room
     response: "Playing next"

--- a/tests/en/media_player_HassMediaPause.yaml
+++ b/tests/en/media_player_HassMediaPause.yaml
@@ -12,4 +12,8 @@ tests:
       - "pause"
     intent:
       name: HassMediaPause
+      slots:
+        area: "Living Room"
+      context:
+        area: Living Room
     response: "Paused"

--- a/tests/en/media_player_HassMediaUnpause.yaml
+++ b/tests/en/media_player_HassMediaUnpause.yaml
@@ -15,4 +15,8 @@ tests:
       - "resume"
     intent:
       name: HassMediaUnpause
+      slots:
+        area: "Living Room"
+      context:
+        area: Living Room
     response: "Unpaused"

--- a/tests/en/media_player_HassSetVolume.yaml
+++ b/tests/en/media_player_HassSetVolume.yaml
@@ -22,6 +22,9 @@ tests:
       - "turn up the volume to 90"
     intent:
       name: HassSetVolume
+      context:
+        area: Living Room
       slots:
+        area: "Living Room"
         volume_level: 90
     response: "Volume set"


### PR DESCRIPTION
Saying "pause", etc. without a device name will only affect the area of the voice satellite.