### PR TITLE
Require context area for starting a timer

### DIFF
--- a/sentences/en/homeassistant_HassStartTimer.yaml
+++ b/sentences/en/homeassistant_HassStartTimer.yaml
@@ -12,3 +12,6 @@ intents:
           - "<timer_set>[ a] timer for <timer_duration>"
           - "<timer_set>[ a] <timer_duration> timer (named|called|for) {timer_name:name}"
           - "<timer_set>[ a] timer (named|called) {timer_name:name} for <timer_duration>"
+        requires_context:
+          area:
+            slot: false

--- a/tests/en/homeassistant_HassStartTimer.yaml
+++ b/tests/en/homeassistant_HassStartTimer.yaml
@@ -9,6 +9,8 @@ tests:
       - "timer for 1 hour"
     intent:
       name: HassStartTimer
+      context:
+        area: Living Room
       slots:
         hours: 1
     response: Timer started
@@ -19,6 +21,8 @@ tests:
       - "set timer for 1 hour and 15 minutes"
     intent:
       name: HassStartTimer
+      context:
+        area: Living Room
       slots:
         hours: 1
         minutes: 15
@@ -30,6 +34,8 @@ tests:
       - "set timer for 1 hour and 30 seconds"
     intent:
       name: HassStartTimer
+      context:
+        area: Living Room
       slots:
         hours: 1
         seconds: 30
@@ -41,6 +47,8 @@ tests:
       - "set timer for 1 hour, 15 minutes, and 30 seconds"
     intent:
       name: HassStartTimer
+      context:
+        area: Living Room
       slots:
         hours: 1
         minutes: 15
@@ -53,6 +61,8 @@ tests:
       - "timer for 5 minutes"
     intent:
       name: HassStartTimer
+      context:
+        area: Living Room
       slots:
         minutes: 5
     response: Timer started
@@ -64,6 +74,8 @@ tests:
       - "timer for 5 minutes called pizza"
     intent:
       name: HassStartTimer
+      context:
+        area: Living Room
       slots:
         minutes: 5
         name:
@@ -77,6 +89,8 @@ tests:
       - "5 minute 10 second timer"
     intent:
       name: HassStartTimer
+      context:
+        area: Living Room
       slots:
         minutes: 5
         seconds: 10
@@ -88,6 +102,8 @@ tests:
       - "45 second timer"
     intent:
       name: HassStartTimer
+      context:
+        area: Living Room
       slots:
         seconds: 45
     response: Timer started


### PR DESCRIPTION
This will prevent timers from being started from the HA web UI or app, which cannot display them.