### PR TITLE
[FR] Media Player Intents improvements 

### DIFF
--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -632,7 +632,7 @@ expansion_rules:
   ouvre: "(ouvre|ouvrir|monte|monter)"
   regle: "(règle|régler|met|mets|mettre|ajuste|ajuster|change|changer|mets_dirty)"
   renvoie: "(renvoie|renvoyer|arrête|arrêter|stop[pe]|stopper)"
-  reprends: "(remets|remettre|reprends|reprend|reprendre|reprise)"
+  reprends: "(remets|remettre|reprends|reprend|reprendre|reprise|relance|relancer)"
   # We have some heavy STT limitations today. "Éteins" is often misunderstood as a different word. Because it's such a commun action, we're willing to support this hack for now. Ideally this should be removed once we have a better STT engine. Hence the fact that we decided to put it on a different expansion rules. The goal of this expansion rule is to be removed in the future.
   eteins_dirty: "(étant|étends|étend|étendre|état|et tant|et teins|et teint|et teints|et t'as|été|étais|était)"
   # We have some heavy STT limitations today. "mets|met|mettre" is often misunderstood as a different word. Because it's such a commun action, we're willing to support this hack for now. Ideally this should be removed once we have a better STT engine. Hence the fact that we decided to put it on a different expansion rules. The goal of this expansion rule is to be removed in the future.

--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -632,7 +632,7 @@ expansion_rules:
   ouvre: "(ouvre|ouvrir|monte|monter)"
   regle: "(règle|régler|met|mets|mettre|ajuste|ajuster|change|changer|mets_dirty)"
   renvoie: "(renvoie|renvoyer|arrête|arrêter|stop[pe]|stopper)"
-  reprends: "(remets|remettre|reprends|reprendre|reprise)"
+  reprends: "(remets|remettre|reprends|reprend|reprendre|reprise)"
   # We have some heavy STT limitations today. "Éteins" is often misunderstood as a different word. Because it's such a commun action, we're willing to support this hack for now. Ideally this should be removed once we have a better STT engine. Hence the fact that we decided to put it on a different expansion rules. The goal of this expansion rule is to be removed in the future.
   eteins_dirty: "(étant|étends|étend|étendre|état|et tant|et teins|et teint|et teints|et t'as|été|étais|était)"
   # We have some heavy STT limitations today. "mets|met|mettre" is often misunderstood as a different word. Because it's such a commun action, we're willing to support this hack for now. Ideally this should be removed once we have a better STT engine. Hence the fact that we decided to put it on a different expansion rules. The goal of this expansion rule is to be removed in the future.
@@ -645,7 +645,7 @@ expansion_rules:
   fenetre: "(fenetre[s]|fenêtre[s]|baie[s]|velux|vélux|lucarne[s])"
   appareil: "(appareil|machine|équipement)[s]"
   capteur: "(capteur|sonde|détecteur)[s]"
-  media: "(morceau|chanson|son|élément|podcast|film|vidéo|épisode|radio|média)"
+  media: "(morceau|chanson|musique|son|élément|podcast|film|vidéo|épisode|radio|média)"
   lecture: "(lecture|visionnage)"
   volume: "(volume|son|watt[s])"
 

--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -627,12 +627,12 @@ expansion_rules:
   eclaire: "(éclaire|éclairer|illumine|illuminer)"
   eteins: "(éteint|eteint|éteins|eteins|éteindre|eteindre|désactive|désactiver|stoppe|stopper|arrête|arrêter|coupe|couper|<eteins_dirty>)"
   ferme: "(ferme|fermer|baisse|baisser)"
-  lis: "(lis|lire|lecture)"
+  lis: "(lis|lire)"
   mets: "(mets|mettre|passe|passer|mets_dirty)"
   ouvre: "(ouvre|ouvrir|monte|monter)"
   regle: "(règle|régler|met|mets|mettre|ajuste|ajuster|change|changer|mets_dirty)"
   renvoie: "(renvoie|renvoyer|arrête|arrêter|stop[pe]|stopper)"
-  reprends: "(reprends|reprendre|reprise)"
+  reprends: "(remets|remettre|reprends|reprendre|reprise)"
   # We have some heavy STT limitations today. "Éteins" is often misunderstood as a different word. Because it's such a commun action, we're willing to support this hack for now. Ideally this should be removed once we have a better STT engine. Hence the fact that we decided to put it on a different expansion rules. The goal of this expansion rule is to be removed in the future.
   eteins_dirty: "(étant|étends|étend|étendre|état|et tant|et teins|et teint|et teints|et t'as|été|étais|était)"
   # We have some heavy STT limitations today. "mets|met|mettre" is often misunderstood as a different word. Because it's such a commun action, we're willing to support this hack for now. Ideally this should be removed once we have a better STT engine. Hence the fact that we decided to put it on a different expansion rules. The goal of this expansion rule is to be removed in the future.
@@ -645,7 +645,12 @@ expansion_rules:
   fenetre: "(fenetre[s]|fenêtre[s]|baie[s]|velux|vélux|lucarne[s])"
   appareil: "(appareil|machine|équipement)[s]"
   capteur: "(capteur|sonde|détecteur)[s]"
-  media: "(morceau|chanson|élément|podcast|film|vidéo|épisode|média)"
+  media: "(morceau|chanson|son|élément|podcast|film|vidéo|épisode|radio|média)"
+  lecture: "(lecture|visionnage)"
+  volume: "(volume|son|watt[s])"
+
+  # Others
+  en_route: (en route)|(en marche)
 
   # Questions
   yatil: "(y a[-][ ]t[-][']il|il y a)"

--- a/sentences/fr/media_player_HassMediaNext.yaml
+++ b/sentences/fr/media_player_HassMediaNext.yaml
@@ -7,7 +7,7 @@ intents:
           # Chanson suivante sur la TV
           - "<media> suivant[e] sur [<le>]{name}"
           # Passe au morceau suivant sur la TV
-          - "<mets> (<le>|au|à la) <media> suivant[e] [sur] [<le>]{name}"
+          - "<mets> (<le>|au |à la )<media> suivant[e] [sur] [<le>]{name}"
         requires_context:
           domain: media_player
 
@@ -18,9 +18,7 @@ intents:
           # Chansion suivante
           - "<media> suivant[e]"
           # Mets l'épisode suivant
-          - "<mets> (<le>|au|à la) <media> suivant[e]"
-        slots:
-          domain: "media_player"
+          - "<mets> (<le>|au |à la )<media> suivant[e]"
         requires_context:
           area:
             slot: true
@@ -32,6 +30,4 @@ intents:
           # Chansion suivante dans le salon
           - "<media> suivant[e] <dans> [<le>]{area}"
           # Mets l'episode suivant dans le bureau
-          - "<mets> (<le>|au|à la) <media> suivant[e] <dans> [<le>]{area}"
-        slots:
-          domain: "media_player"
+          - "<mets> (<le>|au |à la )<media> suivant[e] <dans> [<le>]{area}"

--- a/sentences/fr/media_player_HassMediaNext.yaml
+++ b/sentences/fr/media_player_HassMediaNext.yaml
@@ -2,6 +2,7 @@ language: fr
 intents:
   HassMediaNext:
     data:
+      # name
       - sentences:
           # Chanson suivante sur la TV
           - "<media> suivant[e] sur [<le>]{name}"
@@ -9,3 +10,28 @@ intents:
           - "<mets> (<le>|au|à la) <media> suivant[e] [sur] [<le>]{name}"
         requires_context:
           domain: media_player
+
+      # Area (Context awarenes)
+      - sentences:
+          # Suivant
+          - "suivant[e]"
+          # Chansion suivante
+          - "<media> suivant[e]"
+          # Mets l'épisode suivant
+          - "<mets> (<le>|au|à la) <media> suivant[e]"
+        slots:
+          domain: "media_player"
+        requires_context:
+          area:
+            slot: true
+
+      # Area
+      - sentences:
+          # Suivant dans le salon
+          - "suivant[e] <dans> [<le>]{area}"
+          # Chansion suivante dans le salon
+          - "<media> suivant[e] <dans> [<le>]{area}"
+          # Mets l'episode suivant dans le bureau
+          - "<mets> (<le>|au|à la) <media> suivant[e] <dans> [<le>]{area}"
+        slots:
+          domain: "media_player"

--- a/sentences/fr/media_player_HassMediaPause.yaml
+++ b/sentences/fr/media_player_HassMediaPause.yaml
@@ -2,12 +2,56 @@ language: fr
 intents:
   HassMediaPause:
     data:
+      # name
       - sentences:
           # Mets la TV sur pause
           - "<mets> [<le>]{name} (sur|en) pause"
           # Mettre en pause la TV
           - "<mets> (sur|en) pause [<le>]{name} "
+          # Mets la chanson en pause sur la TV
+          - "<mets> [<le>]<media> (sur|en) pause sur [<le>]{name} "
           # Pause sur la TV
           - "Pause sur [<le>]{name}"
+          # TV en pause
+          - "[<le>]{name} en pause"
+          # Arrête le film sur la TV
+          - "<eteins>  [<le>]<media> sur [<le>]{name}"
+          # Arrête le visionnage du film sur la TV
+          - "<eteins> <le> <lecture> <de> [<le>]<media> sur [<le>]{name}"
+          # Arrête le visionnage sur la TV
+          - "<eteins> <le> <lecture> sur [<le>]{name}"
         requires_context:
           domain: media_player
+
+      # Area (Context awarenes)
+      - sentences:
+          # Arrête la musique
+          - "<eteins> [<le>]<media>"
+          # Arrête la lecture de la musique
+          - "<eteins> <le> <lecture> <de> [<le>]<media>"
+          # Arrête la lecture
+          - "<eteins> <le> <lecture>"
+          # Pause
+          - "pause"
+          # Mets la chanson en pause
+          - "<mets> [<le>]<media> (sur|en) pause"
+        slots:
+          domain: "media_player"
+        requires_context:
+          area:
+            slot: true
+
+      # Area
+      - sentences:
+          # Arrête l'épisode dans la chambre
+          - "<eteins> [<le>]<media> <dans> [<le>]{area}"
+          # Arrête la lecture de l'épisode dans la chambre
+          - "<eteins> <le> <lecture> <de> [<le>]<media> <dans> [<le>]{area}"
+          # Arrête la lecture de l'épisode dans la chambre
+          - "<eteins> <le> <lecture> <dans> [<le>]{area}"
+          # Pause dans le salon
+          - "pause <dans> [<le>]{area}"
+          # Mets la chanson en pause dans la cuisine
+          - "<mets> [<le>]<media> (sur|en) pause <dans> [<le>]{area}"
+        slots:
+          domain: "media_player"

--- a/sentences/fr/media_player_HassMediaPause.yaml
+++ b/sentences/fr/media_player_HassMediaPause.yaml
@@ -35,8 +35,6 @@ intents:
           - "pause"
           # Mets la chanson en pause
           - "<mets> [<le>]<media> (sur|en) pause"
-        slots:
-          domain: "media_player"
         requires_context:
           area:
             slot: true
@@ -53,5 +51,3 @@ intents:
           - "pause <dans> [<le>]{area}"
           # Mets la chanson en pause dans la cuisine
           - "<mets> [<le>]<media> (sur|en) pause <dans> [<le>]{area}"
-        slots:
-          domain: "media_player"

--- a/sentences/fr/media_player_HassMediaUnpause.yaml
+++ b/sentences/fr/media_player_HassMediaUnpause.yaml
@@ -40,8 +40,6 @@ intents:
           - "<reprends> <le> <lecture>"
           # Remets la lecture en marche
           - "<reprends> <le> <lecture> <en_route>"
-        slots:
-          domain: "media_player"
         requires_context:
           area:
             slot: true
@@ -62,5 +60,3 @@ intents:
           - "<reprends> <le> <lecture> <dans> [<le>]{area}"
           # Remets la lecture en marche dans le caveau
           - "<reprends> <le> <lecture> <en_route> <dans> [<le>]{area}"
-        slots:
-          domain: "media_player"

--- a/sentences/fr/media_player_HassMediaUnpause.yaml
+++ b/sentences/fr/media_player_HassMediaUnpause.yaml
@@ -5,7 +5,62 @@ intents:
       - sentences:
           # Lire sur la TV
           - "<lis> sur [<le>]{name}"
+          # Lecture sur la TV
+          - "<lecture> sur [<le>]{name}"
+          # Reprend la musique sur les enceintes
+          - "<reprends> [<le>]<media> sur [<le>]{name}"
+          # Remets la musique en route sur la TV
+          - "<reprends> [<le>]<media> <en_route> sur [<le>]{name}"
+          # Reprend la lecture de l'episode sur la TV
+          - "<reprends> <le> <lecture> <de> [<le>]<media> sur [<le>]{name}"
+          # Remets la lecture de l'episode en marche sur la TV
+          - "<reprends> <le> <lecture> <de> [<le>]<media> <en_route> sur [<le>]{name}"
           # Reprend la lecture sur la TV
-          - "<reprends> [la lecture] sur [<le>]{name}"
+          - "<reprends> <le> <lecture> sur [<le>]{name}"
+          # Remets la lecture en marche sur la TV
+          - "<reprends> <le> <lecture> <en_route> sur [<le>]{name}"
+          # Remets la TV en marche
+          - "<reprends> [<le>]{name} <en_route>"
         requires_context:
           domain: media_player
+
+      # Area (Context awarenes)
+      - sentences:
+          # Lecture
+          - "<lecture>"
+          # Reprend la musique
+          - "<reprends> [<le>]<media>"
+          # Remets la musique en route
+          - "<reprends> [<le>]<media> <en_route>"
+          # Reprend la lecture de l'episode
+          - "<reprends> <le> <lecture> <de> [<le>]<media>"
+          # Remets la lecture de l'episode en marche
+          - "<reprends> <le> <lecture> <de> [<le>]<media> <en_route>"
+          # Reprend la lecture
+          - "<reprends> <le> <lecture>"
+          # Remets la lecture en marche
+          - "<reprends> <le> <lecture> <en_route>"
+        slots:
+          domain: "media_player"
+        requires_context:
+          area:
+            slot: true
+
+      # Area
+      - sentences:
+          # Lecture dans la chambre
+          - "<lecture> <dans> [<le>]{area}"
+          # Reprend la musique dans le salon
+          - "<reprends> [<le>]<media> <dans> [<le>]{area}"
+          # Remets la musique en route dans la cuisine
+          - "<reprends> [<le>]<media> <en_route> <dans> [<le>]{area}"
+          # Reprend la lecture de l'episode sur le palier
+          - "<reprends> <le> <lecture> <de> [<le>]<media> <dans> [<le>]{area}"
+          # Remets la lecture de l'episode en marche dans le garage
+          - "<reprends> <le> <lecture> <de> [<le>]<media> <en_route> <dans> [<le>]{area}"
+          # Reprend la lecture dans le bureau
+          - "<reprends> <le> <lecture> <dans> [<le>]{area}"
+          # Remets la lecture en marche dans le caveau
+          - "<reprends> <le> <lecture> <en_route> <dans> [<le>]{area}"
+        slots:
+          domain: "media_player"

--- a/sentences/fr/media_player_HassSetVolume.yaml
+++ b/sentences/fr/media_player_HassSetVolume.yaml
@@ -2,10 +2,28 @@ language: fr
 intents:
   HassSetVolume:
     data:
+      # Name
       - sentences:
           # Règle la TV à 50%
           - "<regle> [<le>]{name} [à|sur] {volume:volume_level}<pourcent>"
           # Règle le volume des enceintes sur 50%
-          - "<regle> le volume [<de>] [<le>]{name} [à|sur] {volume:volume_level}<pourcent>"
+          - "<regle> [<le>]<volume> [<de>] [<le>]{name} [à|sur] {volume:volume_level}<pourcent>"
         requires_context:
           domain: media_player
+
+      # Area (Context awarenes)
+      - sentences:
+          # Règle les watts à 50%
+          - "<regle> [<le>]<volume> [à|sur] {volume:volume_level}<pourcent>"
+        slots:
+          domain: "media_player"
+        requires_context:
+          area:
+            slot: true
+
+      # Area
+      - sentences:
+          # Règle le son à 50% dans le salon
+          - "<regle> [<le>]<volume> [à|sur] {volume:volume_level}<pourcent> <dans> [<le>]{area}"
+        slots:
+          domain: "media_player"

--- a/sentences/fr/media_player_HassSetVolume.yaml
+++ b/sentences/fr/media_player_HassSetVolume.yaml
@@ -15,8 +15,6 @@ intents:
       - sentences:
           # Règle les watts à 50%
           - "<regle> [<le>]<volume> [à|sur] {volume:volume_level}<pourcent>"
-        slots:
-          domain: "media_player"
         requires_context:
           area:
             slot: true
@@ -25,5 +23,3 @@ intents:
       - sentences:
           # Règle le son à 50% dans le salon
           - "<regle> [<le>]<volume> [à|sur] {volume:volume_level}<pourcent> <dans> [<le>]{area}"
-        slots:
-          domain: "media_player"

--- a/tests/fr/media_player_HassMediaNext.yaml
+++ b/tests/fr/media_player_HassMediaNext.yaml
@@ -21,16 +21,14 @@ tests:
         area: salon
       slots:
         area: salon
-        domain: media_player
     response: "Média suivant"
 
   - sentences:
-      - "Suivant dans la cuisine"
-      - "Chanson suivante dans la cuisine"
-      - "Mets l'épisode suivant dans la cuisine"
+      - "Suivant dans le garage"
+      - "Chanson suivante dans le garage"
+      - "Mets l'épisode suivant dans le garage"
     intent:
       name: HassMediaNext
       slots:
-        area: cuisine
-        domain: media_player
+        area: garage
     response: "Média suivant"

--- a/tests/fr/media_player_HassMediaNext.yaml
+++ b/tests/fr/media_player_HassMediaNext.yaml
@@ -2,22 +2,35 @@ language: fr
 tests:
   - sentences:
       - "Morceau suivant sur TV"
+      - "Chanson suivante sur la TV"
+      - "Passe au morceau suivant sur la TV"
+      - "Mettre le film suivant sur la TV"
     intent:
       name: HassMediaNext
       slots:
         name: "TV"
     response: "Média suivant"
+
   - sentences:
-      - "Passe au film suivant sur la TV"
+      - "Suivant"
+      - "Chanson suivante"
+      - "Mets l'épisode suivant"
     intent:
       name: HassMediaNext
+      context:
+        area: salon
       slots:
-        name: "TV"
+        area: salon
+        domain: media_player
     response: "Média suivant"
+
   - sentences:
-      - "Mets la chanson suivante sur la TV"
+      - "Suivant dans la cuisine"
+      - "Chanson suivante dans la cuisine"
+      - "Mets l'épisode suivant dans la cuisine"
     intent:
       name: HassMediaNext
       slots:
-        name: "TV"
+        area: cuisine
+        domain: media_player
     response: "Média suivant"

--- a/tests/fr/media_player_HassMediaPause.yaml
+++ b/tests/fr/media_player_HassMediaPause.yaml
@@ -4,9 +4,41 @@ tests:
       - "Mets la TV sur pause"
       - "Mets la TV en pause"
       - "Mettre en pause la TV"
+      - "Mettre la chanson en pause sur la TV"
+      - "Pause sur la TV"
+      - "TV en pause"
       - "Pause sur TV"
+      - "Arrête le film sur la TV"
+      - "Arrêter le visionnage du film sur la TV"
+      - "Arrêter le visionnage sur la TV"
     intent:
       name: HassMediaPause
       slots:
         name: "TV"
+    response: "Lecture en pause"
+
+  - sentences:
+      - "Arrête la musique"
+      - "Arrêter la lecture de la musique"
+      - "Arrête la lecture"
+      - "Pause"
+      - "Mets la chanson en pause"
+    intent:
+      name: HassMediaPause
+      context:
+        area: salon
+      slots:
+        area: salon
+    response: "Lecture en pause"
+
+  - sentences:
+      - "Arrête la musique dans la cuisine"
+      - "Arrêter la lecture de la musique dans la cuisine"
+      - "Arrête la lecture dans la cuisine"
+      - "Pause dans la cuisine"
+      - "Mets la chanson en pause dans la cuisine"
+    intent:
+      name: HassMediaPause
+      slots:
+        area: cuisine
     response: "Lecture en pause"

--- a/tests/fr/media_player_HassMediaUnpause.yaml
+++ b/tests/fr/media_player_HassMediaUnpause.yaml
@@ -1,11 +1,47 @@
 language: fr
 tests:
   - sentences:
-      - "reprends la lecture sur TV"
-      - "lecture sur TV"
-      - "lire sur TV"
+      - "Lire sur la TV"
+      - "Lecture sur la TV"
+      - "Reprendre la musique sur la TV"
+      - "Remettre la musique en route sur la TV"
+      - "Reprends la lecture de l'épisode sur la TV"
+      - "Remets le visionnage de l'épisode en marche sur la TV"
+      - "Reprends la lecture sur la TV"
+      - "Remettre la lecture en marche sur la TV"
+      - "Remets la TV en marche"
     intent:
       name: HassMediaUnpause
       slots:
         name: "TV"
+    response: "Lecture relancée"
+
+  - sentences:
+      - "Lecture"
+      - "Reprends la musique"
+      - "Remettre la musique en route"
+      - "Reprends le visionnage de l'épisode"
+      - "Remets la lecture de l'épisode en marche"
+      - "Reprendre la lecture"
+      - "Remets la lecture en marche"
+    intent:
+      name: HassMediaUnpause
+      context:
+        area: salon
+      slots:
+        area: salon
+    response: "Lecture relancée"
+
+  - sentences:
+      - "Lecture dans l'entrée"
+      - "Reprends la musique dans l'entrée"
+      - "Remettre la musique en route dans l'entrée"
+      - "Reprends la lecture de l'épisode dans l'entrée"
+      - "Remets la lecture de l'épisode en marche dans l'entrée"
+      - "Reprendre le visionnage dans l'entrée"
+      - "Remets la lecture en marche dans l'entrée"
+    intent:
+      name: HassMediaUnpause
+      slots:
+        area: entrée
     response: "Lecture relancée"

--- a/tests/fr/media_player_HassSetVolume.yaml
+++ b/tests/fr/media_player_HassSetVolume.yaml
@@ -21,3 +21,27 @@ tests:
         name: "Enceintes"
         volume_level: 70
     response: "Volume réglé"
+
+  - sentences:
+      - "Règle les watts à 80%"
+      - "Ajuster le son à 80%"
+      - "Mettre le volume sur 80%"
+    intent:
+      name: HassSetVolume
+      context:
+        area: salon
+      slots:
+        area: salon
+        volume_level: 80
+    response: "Volume réglé"
+
+  - sentences:
+      - "Règle les watts à 80% dans la cuisine"
+      - "Ajuster le son à 80% dans la cuisine"
+      - "Mettre le volume sur 80% dans la cuisine"
+    intent:
+      name: HassSetVolume
+      slots:
+        area: cuisine
+        volume_level: 80
+    response: "Volume réglé"


### PR DESCRIPTION
# Media player intent improvements

## Scope
For all media player intents:
- Pause
- Unpause
- SetVolume
- Next

We now support
- Targeting an entity by its name
- Targeting an area explicitly
- Targeting an area implicitly (Context awareness)

## Things we took into consideration
We added different type of media so that you can talk naturally regardless of what is playing
```yaml
media: "(morceau|chanson|musique|son|élément|podcast|film|vidéo|épisode|radio|média)"
```

So you can say things like:
- Morceau suivant
- Chanson suivante
- Élement suivant
- Film suivant
- Épisode suivant
- etc

We replace the hardcoded `lecture` with an expansion rule because we notice that `lecture` is usually used for radio media, but `visionnage` is used for video media.

So you can say things like:
- Arrêter le visionnage du film
- Arrêter la lecture du la musique


For pause and unpause we provide 3 choices to say the same thing
- `[<le>]<media>`
- `<le> <lecture> <de> [<le>]<media>`
- `<le> <lecture>`

This means you can say things like:
- Arrête le film sur la TV
- Arrête le visionnage du film sur la TV
- Arrête le visionnage sur la TV