### PR TITLE
Add delayed commands to timers

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -398,6 +398,9 @@ HassStartTimer:
     name:
       description: "Name attached to the timer"
       required: false
+    conversation_command:
+      description: "Command to execute when timer finishes"
+      required: false
   slot_groups:
     duration:
       - "hours"

--- a/responses/en/HassStartTimer.yaml
+++ b/responses/en/HassStartTimer.yaml
@@ -4,3 +4,4 @@ responses:
   intents:
     HassStartTimer:
       default: "Timer started"
+      command: "Command received"

--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -351,6 +351,8 @@ lists:
       to: 100
   timer_name:
     wildcard: true
+  timer_command:
+    wildcard: true
 
 expansion_rules:
   name: "[the] {name}"

--- a/sentences/en/homeassistant_HassStartTimer.yaml
+++ b/sentences/en/homeassistant_HassStartTimer.yaml
@@ -16,3 +16,7 @@ intents:
         requires_context:
           area:
             slot: false
+      - sentences:
+          - "{timer_command:conversation_command} in <timer_duration>"
+          - "in <timer_duration> {timer_command:conversation_command}"
+        response: command

--- a/tests/en/homeassistant_HassStartTimer.yaml
+++ b/tests/en/homeassistant_HassStartTimer.yaml
@@ -107,3 +107,15 @@ tests:
       slots:
         seconds: 45
     response: Timer started
+
+  - sentences:
+      - "open the garage door in 5 minutes"
+      - "in 5 minutes, open the garage door"
+    intent:
+      name: HassStartTimer
+      slots:
+        minutes: 5
+        conversation_command:
+          - "open the garage door"
+          - "open the garage door "
+    response: Command received


### PR DESCRIPTION
In the next release of HA (2024.6), timers will support "delay commands". These are text commands that are automatically sent to the `conversation` agent when the timer finishes.

This PR adds sentences for delayed commands, so things like "open the garage door in 5 minutes" will work.
