### PR TITLE
[NL] Small fix for timer status response template

### DIFF
--- a/responses/nl/HassTimerStatus.yaml
+++ b/responses/nl/HassTimerStatus.yaml
@@ -15,7 +15,7 @@ responses:
           Geen timers.
         {% elif num_active_timers == 0: %}
           {# No active timers #}
-          {{ num_paused_timers }} gepauzeerde timer{{ 's' if paused_timers > 1 }}.
+          {{ num_paused_timers }} gepauzeerde timer{{ 's' if num_paused_timers > 1 }}.
         {% else: %}
           {# At least one active timer #}
           {% if num_active_timers == 1: %}


### PR DESCRIPTION
Used the wrong variable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the grammar for pluralizing "timer" in Dutch based on the number of paused timers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->