### PR TITLE
[RO] Initial support for floors

### DIFF
--- a/responses/ro/HassTurnOff.yaml
+++ b/responses/ro/HassTurnOff.yaml
@@ -5,6 +5,7 @@ responses:
       default: "Am oprit {{ slots.name }}"
       light: "Am stins lumina"
       lights_area: "Am stins luminile"
+      lights_floor: "Am stins luminile"
       fans_area: "Am oprit ventilatoarele"
       cover: "Am închis"
       covers_area: "Am închis {{ slots.device_class }}"

--- a/responses/ro/HassTurnOn.yaml
+++ b/responses/ro/HassTurnOn.yaml
@@ -5,6 +5,7 @@ responses:
       default: "Am pornit {{ slots.name }}"
       light: "Am aprins lumina"
       lights_area: "Am aprins luminile"
+      lights_floor: "Am aprins luminile"
       fans_area: "Am pornit ventilatoarele"
       cover: "Am deschis"
       covers_area: "Am deschis {{ slots.device_class }}"

--- a/sentences/ro/_common.yaml
+++ b/sentences/ro/_common.yaml
@@ -474,6 +474,7 @@ lists:
 expansion_rules:
   # Placeholders
   area: "[(zona|regiunea|spa(ț|t)iul) ]{area}"
+  floor: "[(etajul|nivelul) ]{floor}"
   brightness: "{brightness}<la_suta>"
   brightness_percent: "{brightness}<la_suta>"
   temperature: "{temperature}[ ][[de ]grad[e]][[ ]{temperature_unit}]"

--- a/sentences/ro/_common.yaml
+++ b/sentences/ro/_common.yaml
@@ -7,24 +7,32 @@ responses:
 
     # Errors for when user is not logged in
     no_area: "Îmi pare rău, nu cunosc niciun spațiu numit {{ area }}"
+    no_floor: "Îmi pare rău, nu cunosc niciun nivel numit {{ floor }}"
     no_domain: "Îmi pare rău, nu știu să existe {{ domain }}"
     no_domain_in_area: "Îmi pare rău, nu știu să existe {{ domain }} în spațiul {{ area }}"
+    no_domain_in_floor: "Îmi pare rău, nu știu să existe {{ domain }} la nivelul {{ floor }}"
     no_device_class: "Îmi pare rău, nu știu să existe {{ device_class }}"
     no_device_class_in_area: "Îmi pare rău, nu știu să existe {{ device_class }} în spațiul {{ area }}"
+    no_device_class_in_floor: "Îmi pare rău, nu știu să existe {{ device_class }} la nivelul {{ floor }}"
     no_entity: "Îmi pare rău, nu cunosc nicio entitate numită {{ entity }}"
     no_entity_in_area: "Îmi pare rău, nu cunosc nicio entitate numită {{ entity }} în spațiul {{ area }}"
+    no_entity_in_floor: "Îmi pare rău, nu cunosc nicio entitate numită {{ entity }} la nivelul {{ floor }}"
 
     # Errors for when user is logged in and we can give more information
     no_entity_exposed: "Îmi pare rău, mai întâi trebuie sa expui {{ entity }}"
     no_entity_in_area_exposed: "Îmi pare rău, mai întâi trebuie să expui {{ entity }} din spațiul {{ area }}"
+    no_entity_in_floor_exposed: "Îmi pare rău, mai întâi trebuie să expui {{ entity }} de la nivelul {{ floor }}"
     no_domain_exposed: "Îmi pare rău, nu există dispozitive expuse de tip {{ domain }}"
     no_domain_in_area_exposed: "Îmi pare rău, nu există dispozitive expuse de tip {{ domain }} în spațiul {{ area }}"
+    no_domain_in_floor_exposed: "Îmi pare rău, nu există dispozitive expuse de tip {{ domain }} la nivelul {{ floor }}"
     no_device_class_exposed: "Îmi pare rău, nu există dispozitive expuse de tip {{ device_class }}"
     no_device_class_in_area_exposed: "Îmi pare rău, nu există dispozitive expuse de tip {{ device_class }} în spațiul {{ area }}"
+    no_device_class_in_floor_exposed: "Îmi pare rău, nu există dispozitive expuse de tip {{ device_class }} la nivelul {{ floor }}"
 
     # Used when multiple (exposed) devices have the same name
     duplicate_entities: "Îmi pare rău, există mai multe entități numite {{ entity }}"
     duplicate_entities_in_area: "Îmi pare rău, există mai multe entități numite {{ entity }} în spațiul {{ area }}"
+    duplicate_entities_in_floor: "Îmi pare rău, există mai multe entități numite {{ entity }} la nivelul {{ floor }}"
 lists:
   # Attributes
   color:

--- a/sentences/ro/light_HassTurnOff.yaml
+++ b/sentences/ro/light_HassTurnOff.yaml
@@ -22,3 +22,9 @@ intents:
           area:
             slot: true
         response: lights_area
+
+      - sentences:
+          - "<opreste> ((<lumina>|[toate ]<luminile>);[<din> ]<floor>)"
+        response: "lights_floor"
+        slots:
+          domain: "light"

--- a/sentences/ro/light_HassTurnOn.yaml
+++ b/sentences/ro/light_HassTurnOn.yaml
@@ -22,3 +22,9 @@ intents:
           area:
             slot: true
         response: lights_area
+
+      - sentences:
+          - "<porneste> ((<lumina>|[toate ]<luminile>);[<din> ]<floor>)"
+        response: "lights_floor"
+        slots:
+          domain: "light"

--- a/tests/ro/_fixtures.yaml
+++ b/tests/ro/_fixtures.yaml
@@ -2,18 +2,25 @@ language: ro
 areas:
   - name: "Bucatarie"
     id: kitchen
+    floor: Parter
   - name: "Sufragerie"
     id: living_room
+    floor: Parter
   - name: "Dormitor"
     id: bedroom
+    floor: Primul etaj
   - name: "Garaj"
     id: garage
+    floor: Afara
   - name: "Hol"
     id: hall
+    floor: Primul etaj
   - name: "Intrare"
     id: entrance
+    floor: Primul etaj
   - name: "Curte"
     id: frontyard
+    floor: Afara
 entities:
   # Lights
   - name: "lustra"

--- a/tests/ro/light_HassTurnOff.yaml
+++ b/tests/ro/light_HassTurnOff.yaml
@@ -47,3 +47,14 @@ tests:
         domain: light
         area: Dormitor
     response: "Am stins luminile"
+  - sentences:
+      - "stinge lumina de la primul etaj"
+      - "oprește lumina la primul etaj"
+      - "stop luminile din primul etaj"
+      - "stinge toate luminile de la primul etaj"
+    intent:
+      name: HassTurnOff
+      slots:
+        floor: Primul etaj
+        domain: light
+    response: "Am stins luminile"

--- a/tests/ro/light_HassTurnOn.yaml
+++ b/tests/ro/light_HassTurnOn.yaml
@@ -47,3 +47,14 @@ tests:
         domain: light
         area: Dormitor
     response: "Am aprins luminile"
+  - sentences:
+      - "start lumina de la primul etaj"
+      - "pornește lumina la primul etaj"
+      - "deschide luminile din primul etaj"
+      - "aprinde toate luminile de la primul etaj"
+    intent:
+      name: HassTurnOn
+      slots:
+        floor: Primul etaj
+        domain: light
+    response: "Am aprins luminile"


### PR DESCRIPTION
RO translation of #2111

Add floor-related light control sentences

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new responses for turning on and off lights on specific floors in home automation.
  - Added error messages and placeholders related to floor-specific commands.

- **Enhancements**
  - Expanded system's understanding of locations within a space with additional floor-related responses and error handling.
  - Updated test cases to include variations of commands for floor-specific light control.

- **Localization**
  - Improved Romanian language support with new phrases and error messages for floor-specific commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->