### PR TITLE
[NL] Fix cover intents for open/close

### DIFF
--- a/sentences/nl/cover_HassTurnOff.yaml
+++ b/sentences/nl/cover_HassTurnOff.yaml
@@ -19,7 +19,7 @@ intents:
           - "<zou> [de] garage[ ][deur] ((<dicht> willen | <dicht> kunnen | <dicht>[ ])<doe>|sluiten)"
           - "<zou> [de] garage[ ][deur] (kunnen|willen) [<dicht>[ ]<doe>|sluiten]"
         response: "cover_device_class"
-        requires_context:
+        slots:
           device_class: "garage"
           domain: "cover"
 
@@ -49,7 +49,7 @@ intents:
           - "<zou> [de|het] <curtain> <in> <area> (willen|kunnen) [<dicht>[ ]<doe>|sluiten]"
           - "<zou> [de|het] <curtain> (willen|kunnen) [<dicht>[ ]<doe>|sluiten] <in> <area>"
         response: "cover"
-        requires_context:
+        slots:
           device_class: "curtain"
           domain: "cover"
 
@@ -61,7 +61,7 @@ intents:
           - "<zou> [de|het] (<blind>|<shutter>|<shade>) <in> <area> (willen|kunnen) [<dicht>[ ]<doe>|sluiten]"
           - "<zou> [de|het] (<blind>|<shutter>|<shade>) (willen|kunnen) [<dicht>[ ]<doe>|sluiten] <in> <area>"
         response: "cover"
-        requires_context:
+        slots:
           device_class:
             - "blind"
             - "shutter"

--- a/sentences/nl/cover_HassTurnOn.yaml
+++ b/sentences/nl/cover_HassTurnOn.yaml
@@ -19,7 +19,7 @@ intents:
           - "<zou> [de] garage[ ][deur] ((<open> willen | <open> kunnen | <open>[ ])<doe>|openen)"
           - "<zou> [de] garage[ ][deur] (kunnen|willen) [<open>[ ]<doe>|openen]"
         response: "cover_device_class"
-        requires_context:
+        slots:
           device_class: "garage"
           domain: "cover"
 
@@ -49,7 +49,7 @@ intents:
           - "<zou> [de|het] <curtain> <in> <area> (willen|kunnen) [<open>[ ]<doe>|openen]"
           - "<zou> [de|het] <curtain> (willen|kunnen) [<open>[ ]<doe>|openen] <in> <area>"
         response: "cover"
-        requires_context:
+        slots:
           device_class: "curtain"
           domain: "cover"
 
@@ -61,7 +61,7 @@ intents:
           - "<zou> [de|het] (<blind>|<shutter>|<shade>) <in> <area> (willen|kunnen) [<open>[ ]<doe>|openen]"
           - "<zou> [de|het] (<blind>|<shutter>|<shade>) (willen|kunnen) [<open>[ ]<doe>|openen] <in> <area>"
         response: "cover"
-        requires_context:
+        slots:
           device_class:
             - "blind"
             - "shutter"

--- a/tests/nl/cover_HassTurnOff.yaml
+++ b/tests/nl/cover_HassTurnOff.yaml
@@ -59,7 +59,7 @@ tests:
       context:
         domain: cover
         device_class: curtain
-    response: Gesloten
+      response: Gesloten
 
   - sentences:
       - Sluit rolluik achterdeur in de keuken
@@ -76,7 +76,7 @@ tests:
       context:
         domain: cover
         device_class: shutter
-    response: Gesloten
+      response: Gesloten
 
   - sentences:
       - Sluit het gordijn in de woonkamer
@@ -87,7 +87,7 @@ tests:
         area: Woonkamer
         device_class: curtain
         domain: cover
-    response: Gesloten
+      response: Gesloten
 
   - sentences:
       - Mag de luxaflex dicht in de woonkamer
@@ -104,4 +104,4 @@ tests:
         area: Woonkamer
         device_class: blind
         domain: cover
-    response: Gesloten
+      response: Gesloten

--- a/tests/nl/cover_HassTurnOff.yaml
+++ b/tests/nl/cover_HassTurnOff.yaml
@@ -87,7 +87,7 @@ tests:
         area: Woonkamer
         device_class: curtain
         domain: cover
-      response: Gesloten
+    response: Gesloten
 
   - sentences:
       - Mag de luxaflex dicht in de woonkamer

--- a/tests/nl/cover_HassTurnOff.yaml
+++ b/tests/nl/cover_HassTurnOff.yaml
@@ -13,6 +13,7 @@ tests:
       context:
         domain: cover
         device_class: curtain
+      response: Gesloten
 
   - sentences:
       - Doe het rolluik achterdeur omlaag
@@ -26,6 +27,7 @@ tests:
       context:
         domain: cover
         device_class: shutter
+      response: Gesloten
 
   - sentences:
       - Sluit de garage
@@ -35,9 +37,10 @@ tests:
       - Kun je de garagedeur sluiten?
     intent:
       name: HassTurnOff
-      context:
+      slots:
         domain: cover
         device_class: garage
+      response: Garage gesloten
 
   - sentences:
       - Sluit het gordijn links in de woonkamer
@@ -82,7 +85,6 @@ tests:
       name: HassTurnOff
       slots:
         area: Woonkamer
-      context:
         device_class: curtain
         domain: cover
     response: Gesloten
@@ -100,7 +102,6 @@ tests:
       name: HassTurnOff
       slots:
         area: Woonkamer
-      context:
         device_class: blind
         domain: cover
     response: Gesloten

--- a/tests/nl/cover_HassTurnOff.yaml
+++ b/tests/nl/cover_HassTurnOff.yaml
@@ -13,7 +13,7 @@ tests:
       context:
         domain: cover
         device_class: curtain
-      response: Gesloten
+    response: Gesloten
 
   - sentences:
       - Doe het rolluik achterdeur omlaag
@@ -27,7 +27,7 @@ tests:
       context:
         domain: cover
         device_class: shutter
-      response: Gesloten
+    response: Gesloten
 
   - sentences:
       - Sluit de garage
@@ -40,7 +40,7 @@ tests:
       slots:
         domain: cover
         device_class: garage
-      response: Garage gesloten
+    response: Garage gesloten
 
   - sentences:
       - Sluit het gordijn links in de woonkamer
@@ -59,7 +59,7 @@ tests:
       context:
         domain: cover
         device_class: curtain
-      response: Gesloten
+    response: Gesloten
 
   - sentences:
       - Sluit rolluik achterdeur in de keuken
@@ -76,7 +76,7 @@ tests:
       context:
         domain: cover
         device_class: shutter
-      response: Gesloten
+    response: Gesloten
 
   - sentences:
       - Sluit het gordijn in de woonkamer
@@ -104,4 +104,4 @@ tests:
         area: Woonkamer
         device_class: blind
         domain: cover
-      response: Gesloten
+    response: Gesloten

--- a/tests/nl/cover_HassTurnOn.yaml
+++ b/tests/nl/cover_HassTurnOn.yaml
@@ -12,6 +12,7 @@ tests:
       context:
         domain: cover
         device_class: shutter
+    response: Geopend
 
   - sentences:
       - Open gordijn links
@@ -25,6 +26,7 @@ tests:
       context:
         domain: cover
         device_class: curtain
+    response: Geopend
 
   - sentences:
       - Open de garagedeur
@@ -33,10 +35,10 @@ tests:
       - Zou je de garagedeur open willen zetten
     intent:
       name: HassTurnOn
-      context:
+      slots:
         domain: cover
         device_class: garage
-    response: geopend
+    response: Garage geopend
 
   - sentences:
       - Open gordijn links in de woonkamer
@@ -81,7 +83,6 @@ tests:
       name: HassTurnOn
       slots:
         area: Woonkamer
-      context:
         device_class: curtain
         domain: cover
     response: Geopend
@@ -99,7 +100,6 @@ tests:
       name: HassTurnOn
       slots:
         area: Woonkamer
-      context:
         device_class: blind
         domain: cover
     response: Geopend

--- a/tests/nl/cover_HassTurnOn.yaml
+++ b/tests/nl/cover_HassTurnOn.yaml
@@ -12,7 +12,7 @@ tests:
       context:
         domain: cover
         device_class: shutter
-    response: Geopend
+      response: Geopend
 
   - sentences:
       - Open gordijn links
@@ -26,7 +26,7 @@ tests:
       context:
         domain: cover
         device_class: curtain
-    response: Geopend
+      response: Geopend
 
   - sentences:
       - Open de garagedeur
@@ -38,7 +38,7 @@ tests:
       slots:
         domain: cover
         device_class: garage
-    response: Garage geopend
+      response: Garage geopend
 
   - sentences:
       - Open gordijn links in de woonkamer
@@ -56,7 +56,7 @@ tests:
       context:
         domain: cover
         device_class: curtain
-    response: Geopend
+      response: Geopend
 
   - sentences:
       - Open rolluik achterdeur in de keuken
@@ -72,7 +72,7 @@ tests:
       context:
         domain: cover
         device_class: shutter
-    response: Geopend
+      response: Geopend
 
   - sentences:
       - Open het gordijn in de woonkamer
@@ -85,7 +85,7 @@ tests:
         area: Woonkamer
         device_class: curtain
         domain: cover
-    response: Geopend
+      response: Geopend
 
   - sentences:
       - Mag de luxaflex open in de woonkamer
@@ -102,4 +102,4 @@ tests:
         area: Woonkamer
         device_class: blind
         domain: cover
-    response: Geopend
+      response: Geopend

--- a/tests/nl/cover_HassTurnOn.yaml
+++ b/tests/nl/cover_HassTurnOn.yaml
@@ -12,7 +12,7 @@ tests:
       context:
         domain: cover
         device_class: shutter
-      response: Geopend
+    response: Geopend
 
   - sentences:
       - Open gordijn links
@@ -26,7 +26,7 @@ tests:
       context:
         domain: cover
         device_class: curtain
-      response: Geopend
+    response: Geopend
 
   - sentences:
       - Open de garagedeur
@@ -38,7 +38,7 @@ tests:
       slots:
         domain: cover
         device_class: garage
-      response: Garage geopend
+    response: Garage geopend
 
   - sentences:
       - Open gordijn links in de woonkamer
@@ -56,7 +56,7 @@ tests:
       context:
         domain: cover
         device_class: curtain
-      response: Geopend
+    response: Geopend
 
   - sentences:
       - Open rolluik achterdeur in de keuken
@@ -72,7 +72,7 @@ tests:
       context:
         domain: cover
         device_class: shutter
-      response: Geopend
+    response: Geopend
 
   - sentences:
       - Open het gordijn in de woonkamer
@@ -85,7 +85,7 @@ tests:
         area: Woonkamer
         device_class: curtain
         domain: cover
-      response: Geopend
+    response: Geopend
 
   - sentences:
       - Mag de luxaflex open in de woonkamer
@@ -102,4 +102,4 @@ tests:
         area: Woonkamer
         device_class: blind
         domain: cover
-      response: Geopend
+    response: Geopend


### PR DESCRIPTION
Fixes #2128

`requires_context` was used where `slots` should have been used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved control and response handling for cover devices (garage doors, curtains, blinds, shutters, shades) by updating intents to use `slots` instead of `requires_context`.

- **Tests**
  - Enhanced test cases with more detailed response messages for better clarity and accuracy in testing cover device controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->