### PR TITLE
[RO] Add timer intents

### DIFF
--- a/responses/ro/HassCancelTimer.yaml
+++ b/responses/ro/HassCancelTimer.yaml
@@ -1,0 +1,6 @@
+---
+language: ro
+responses:
+  intents:
+    HassCancelTimer:
+      default: "Am anulat temporizatorul"

--- a/responses/ro/HassDecreaseTimer.yaml
+++ b/responses/ro/HassDecreaseTimer.yaml
@@ -1,0 +1,6 @@
+---
+language: ro
+responses:
+  intents:
+    HassDecreaseTimer:
+      default: "Am actualizat temporizatorul"

--- a/responses/ro/HassIncreaseTimer.yaml
+++ b/responses/ro/HassIncreaseTimer.yaml
@@ -1,0 +1,6 @@
+---
+language: ro
+responses:
+  intents:
+    HassIncreaseTimer:
+      default: "Am actualizat temporizatorul"

--- a/responses/ro/HassPauseTimer.yaml
+++ b/responses/ro/HassPauseTimer.yaml
@@ -1,0 +1,6 @@
+---
+language: ro
+responses:
+  intents:
+    HassPauseTimer:
+      default: "Am pus pe pauză temporizatorul"

--- a/responses/ro/HassStartTimer.yaml
+++ b/responses/ro/HassStartTimer.yaml
@@ -1,0 +1,6 @@
+---
+language: ro
+responses:
+  intents:
+    HassStartTimer:
+      default: "Am pornit temporizatorul"

--- a/responses/ro/HassTimerStatus.yaml
+++ b/responses/ro/HassTimerStatus.yaml
@@ -67,13 +67,7 @@ responses:
 
           {% if num_timers > 1: %}
             {# Give some extra information to disambiguate #}
-            până la finele temporizatorului
-
-            {% if next_timer.name: %}
-              {{ next_timer.name }}
-            {% elif next_timer.area: %}
-              din {{ next_timer.area }}
-            {% endif %}
+            până la finele temporizatorului de
 
             {% if (next_timer.start_hours > 0) and (next_timer.start_minutes > 0): %}
               {{ next_timer.start_hours }} ore și {{ next_timer.start_minutes }} {{ 'de ' if next_timer.start_minutes > 0 and next_timer.start_minutes % 100 | abs >= 20 }}minute
@@ -85,6 +79,12 @@ responses:
               {{ next_timer.start_minutes }}  {{ 'de ' if next_timer.start_minutes > 0 and next_timer.start_minutes % 100 | abs >= 20 }}minute
             {% elif (next_timer.start_seconds > 0): %}
               {{ next_timer.start_seconds }} {{ 'de ' if next_timer.start_seconds > 0 and next_timer.start_seconds % 100 | abs >= 20 }}secunde
+            {% endif %}
+
+            {% if next_timer.name: %}
+              {{ next_timer.name }}
+            {% elif next_timer.area: %}
+              din {{ next_timer.area }}
             {% endif %}
           {% endif %}
         {% endif %}

--- a/responses/ro/HassTimerStatus.yaml
+++ b/responses/ro/HassTimerStatus.yaml
@@ -1,0 +1,90 @@
+---
+language: ro
+responses:
+  intents:
+    HassTimerStatus:
+      default: |
+        {% set num_timers = slots.timers | length %}
+        {% set active_timers = slots.timers | selectattr('is_active') | list %}
+        {% set num_active_timers = active_timers | length %}
+        {% set paused_timers = slots.timers | rejectattr('is_active') | list %}
+        {% set num_paused_timers = paused_timers | length %}
+        {% set next_timer = None %}
+
+        {% if num_timers == 0: %}
+          Nu există temporizatoare.
+        {% elif num_active_timers == 0: %}
+          {# No active timers #}
+          {% if num_paused_timers == 1: %}
+            {% set next_timer = paused_timers[0] %}
+            Temporizatorul este în pauză.
+          {% else: %}
+            {{ num_paused_timers }} temporizatoare oprit temporar.
+          {% endif %}
+        {% else: %}
+          {# At least one active timer #}
+          {% if num_active_timers == 1: %}
+            {% set next_timer = active_timers[0] %}
+          {% else: %}
+            {# Get active timer that will finish soonest #}
+            {% set sorted_timers = active_timers | sort(attribute='total_seconds_left') %}
+            {% set next_timer = sorted_timers[0] %}
+            {{ num_active_timers }} temporizatoare pornite.
+          {% endif %}
+
+          {% if num_paused_timers == 1: %}
+            Un temporizator oprit temporar.
+          {% elif num_paused_timers > 0: %}
+            {{ num_paused_timers }} temporizatoare oprite temporar.
+          {% endif %}
+        {% endif %}
+
+        {% if next_timer: %}
+          Mai durează
+
+          {# At least one active timer #}
+          {% if (next_timer.rounded_hours_left == 1) and (next_timer.rounded_minutes_left > 0): %}
+            O oră și {{ next_timer.rounded_minutes_left }} {{ 'de ' if next_timer.rounded_minutes_left > 0 and next_timer.rounded_minutes_left % 100 | abs >= 20 }}minute
+          {% elif (next_timer.rounded_hours_left == 1): %}
+            O oră
+          {% elif (next_timer.rounded_hours_left > 1) and (next_timer.rounded_minutes_left > 0): %}
+            {{ next_timer.rounded_hours_left }} ore și {{ next_timer.rounded_minutes_left }} {{ 'de ' if next_timer.rounded_minutes_left > 0 and next_timer.rounded_minutes_left % 100 | abs >= 20 }}minute
+          {% elif (next_timer.rounded_hours_left > 1): %}
+            {{ next_timer.rounded_hours_left }} ore
+          {% elif (next_timer.rounded_minutes_left == 1) and (next_timer.rounded_seconds_left > 0): %}
+            Un minut și {{ next_timer.rounded_seconds_left }} {{ 'de ' if next_timer.rounded_seconds_left > 0 and next_timer.rounded_seconds_left % 100 | abs >= 20 }}secunde
+          {% elif (next_timer.rounded_minutes_left == 1): %}
+            Un minut
+          {% elif (next_timer.rounded_minutes_left > 1) and (next_timer.rounded_seconds_left > 0): %}
+            {{ next_timer.rounded_minutes_left }} {{ 'de ' if next_timer.rounded_minutes_left > 0 and next_timer.rounded_minutes_left % 100 | abs >= 20 }}minute și {{ next_timer.rounded_seconds_left }} {{ 'de ' if next_timer.rounded_seconds_left > 0 and next_timer.rounded_seconds_left % 100 | abs >= 20 }}secunde
+          {% elif (next_timer.rounded_minutes_left > 1): %}
+            {{ next_timer.rounded_minutes_left }} {{ 'de ' if next_timer.rounded_minutes_left > 0 and next_timer.rounded_minutes_left % 100 | abs >= 20 }}minute
+          {% elif (next_timer.rounded_seconds_left == 1): %}
+            O secundă
+          {% elif (next_timer.rounded_seconds_left > 1): %}
+            {{ next_timer.rounded_seconds_left }} {{ 'de ' if next_timer.rounded_seconds_left > 0 and next_timer.rounded_seconds_left % 100 | abs >= 20 }}secunde
+          {% endif %}
+
+          {% if num_timers > 1: %}
+            {# Give some extra information to disambiguate #}
+            până la finele temporizatorului
+
+            {% if next_timer.name: %}
+              {{ next_timer.name }}
+            {% elif next_timer.area: %}
+              din {{ next_timer.area }}
+            {% endif %}
+
+            {% if (next_timer.start_hours > 0) and (next_timer.start_minutes > 0): %}
+              {{ next_timer.start_hours }} ore și {{ next_timer.start_minutes }} {{ 'de ' if next_timer.start_minutes > 0 and next_timer.start_minutes % 100 | abs >= 20 }}minute
+            {% elif (next_timer.start_hours > 0): %}
+              {{ next_timer.start_hours }} ore
+            {% elif (next_timer.start_minutes > 0) and (next_timer.start_seconds > 0): %}
+              {{ next_timer.start_minutes }} {{ 'de ' if next_timer.start_minutes > 0 and next_timer.start_minutes % 100 | abs >= 20 }}minute și {{ next_timer.start_seconds }} {{ 'de ' if next_timer.start_seconds > 0 and next_timer.start_seconds % 100 | abs >= 20 }}secunde
+            {% elif (next_timer.start_minutes > 0): %}
+              {{ next_timer.start_minutes }}  {{ 'de ' if next_timer.start_minutes > 0 and next_timer.start_minutes % 100 | abs >= 20 }}minute
+            {% elif (next_timer.start_seconds > 0): %}
+              {{ next_timer.start_seconds }} {{ 'de ' if next_timer.start_seconds > 0 and next_timer.start_seconds % 100 | abs >= 20 }}secunde
+            {% endif %}
+          {% endif %}
+        {% endif %}

--- a/responses/ro/HassUnpauseTimer.yaml
+++ b/responses/ro/HassUnpauseTimer.yaml
@@ -1,0 +1,6 @@
+---
+language: ro
+responses:
+  intents:
+    HassUnpauseTimer:
+      default: "Am repornit temporizatorul"

--- a/sentences/ro/_common.yaml
+++ b/sentences/ro/_common.yaml
@@ -620,6 +620,9 @@ expansion_rules:
   temporar: "(temporar|pu(ț|t)in|un pic|pentru moment|deocamdat(ă|a))"
 
   # Sentences
+  adauga_amount_la_complement: "(adaug(ă|a) (<amount>;<la> <object>)|(cre(ș|s)te|m(ă|a)re(ș|s)te) (cu <amount>;<object>))"
+  scade_amount_din_complement: "(scade (<amount>;<din> <object>)|(mic(ș|s)oreaz(ă|a)|redu) (cu <amount>;<object>))"
+
   name_dinZona_verbState: "(<name>[ <din_zona>]; <verb_state>)"
   name_dinZona_este_state: "(<name>[ <din_zona>]; (<este> <state_singular>|sunt <state_plural>))"
   name_class_dinZona_verbState: "([<class>[ <din>] ]<name>[ <din_zona>]; <verb_state>)"

--- a/sentences/ro/_common.yaml
+++ b/sentences/ro/_common.yaml
@@ -590,6 +590,7 @@ expansion_rules:
   intrerupatorul: "((î|i)ntrerup(ă|a)tor[ul]|comutator[ul])"
   intrerupatoarele: "((î|i)ntrerup(ă|a)toare[le]|comutatoare[le])"
   temporizatorul: "(un temporizator|temporizator[ul]|o temporizare|temporizare[a]|un cronometru|cronometru[l])"
+  temporizatorului: "(temporizatorului|temporiz(ă|a)rii|cronometrului)"
 
   # Attributes
   luminozitatea: "(luminozitate[a])"

--- a/sentences/ro/_common.yaml
+++ b/sentences/ro/_common.yaml
@@ -541,7 +541,6 @@ expansion_rules:
   opreste: "(stop|opre(ș|s)te|(î|i)nchide|stinge|dezactiveaz(ă|a))"
   porneste_timer: "(start|porne(ș|s)te|activeaz(ă|a))"
   opreste_timer: "(stop|opre(ș|s)te|dezactiveaz(ă|a)|anuleaz(ă|a))"
-  suspenda_timer: "((opre(ș|s)te|dezactiveaz(ă|a)) <temporar> <complement_direct>|suspend(ă|a) <complement_direct>|pune [<temporar> ][pe ]pauz(ă|a) [la ]<complement_direct>)"
   reia_timer: "(re<porneste_timer>|reia)"
   seteaza: "(seteaz(ă|a)|pune|a[d]justeaz(ă|a)|schimb(ă|a)|modific(ă|a))"
   deschide: "(deschide|ridic(ă|a))"
@@ -620,6 +619,7 @@ expansion_rules:
   temporar: "(temporar|pu(ț|t)in|un pic|pentru moment|deocamdat(ă|a))"
 
   # Sentences
+  suspenda_timer: "((opre(ș|s)te|dezactiveaz(ă|a)) <temporar> <object>|suspend(ă|a) <object>|pune [<temporar> ][pe ]pauz(ă|a) [la ]<object>)"
   adauga_amount_la_complement: "(adaug(ă|a) (<amount>;<la> <object>)|(cre(ș|s)te|m(ă|a)re(ș|s)te) (cu <amount>;<object>))"
   scade_amount_din_complement: "(scade (<amount>;<din> <object>)|(mic(ș|s)oreaz(ă|a)|redu) (cu <amount>;<object>))"
 

--- a/sentences/ro/_common.yaml
+++ b/sentences/ro/_common.yaml
@@ -4,6 +4,8 @@ responses:
     # General errors
     no_intent: "Îmi pare rău, nu am înțeles cererea. Poți, te rog, să repeți?"
     handle_error: "Îmi pare rău, a intervenit o eroare în timpul procesării cererii"
+    entity_wrong_state: "Îmi pare rău, niciun dispozitiv nu este {{ state | lower }}"
+    feature_not_supported: "Îmi pare rău, niciun dispozitiv nu permite operațiunea"
 
     # Errors for when user is not logged in
     no_area: "Îmi pare rău, nu cunosc niciun spațiu numit {{ area }}"
@@ -33,6 +35,11 @@ responses:
     duplicate_entities: "Îmi pare rău, există mai multe entități numite {{ entity }}"
     duplicate_entities_in_area: "Îmi pare rău, există mai multe entități numite {{ entity }} în spațiul {{ area }}"
     duplicate_entities_in_floor: "Îmi pare rău, există mai multe entități numite {{ entity }} la nivelul {{ floor }}"
+
+    # Errors for timers
+    timer_not_found: "Îmi pare rău, nu am găsit acel temporizator"
+    multiple_timers_matched: "Îmi pare rău, nu pot opera doar cu mai multe temporizatoare deodată"
+    no_timer_support: "Îmi pare rău, acest dispozitiv nu admite temporizatoare"
 lists:
   # Attributes
   color:

--- a/sentences/ro/_common.yaml
+++ b/sentences/ro/_common.yaml
@@ -478,6 +478,21 @@ lists:
       from: 0
       to: 100
 
+  timer_seconds:
+    range:
+      from: 1
+      to: 100
+  timer_minutes:
+    range:
+      from: 1
+      to: 100
+  timer_hours:
+    range:
+      from: 1
+      to: 100
+  timer_name:
+    wildcard: true
+
 expansion_rules:
   # Placeholders
   area: "[(zona|regiunea|spa(ț|t)iul) ]{area}"
@@ -504,12 +519,30 @@ expansion_rules:
   toti: "(toate|to(ț|t)i)"
   la_suta: "[ ][(%|la sut(ă|a)|[de ]procent[e])]"
 
+  # Timers
+  ore: "([de ]ore|or(ă|a))"
+  minute: "([de ]minute|minut)"
+  secunde: "([de ]secunde|secund(ă|a))"
+  timer_duration_seconds: "{timer_seconds:seconds} <secunde>"
+  timer_duration_minutes: "{timer_minutes:minutes} <minute>[ [(ș|s)i ]{timer_seconds:seconds} <secunde>]"
+  timer_duration_hours: "{timer_hours:hours} <ore>[ [(ș|s)i ]{timer_minutes:minutes} <minute>][ [(ș|s)i ]{timer_seconds:seconds} <secunde>]"
+  timer_duration: "<timer_duration_seconds>|<timer_duration_minutes>|<timer_duration_hours>"
+
+  timer_start_seconds: "{timer_seconds:start_seconds} <secunde>"
+  timer_start_minutes: "{timer_minutes:start_minutes} <minute>[ [(ș|s)i ]{timer_seconds:start_seconds} <secunde>]"
+  timer_start_hours: "{timer_hours:start_hours} <ore>[ [(ș|s)i ]{timer_minutes:start_minutes} <minute>][ [(ș|s)i ]{timer_seconds:start_seconds} <secunde>]"
+  timer_start: "<timer_start_seconds>|<timer_start_minutes>|<timer_start_hours>"
+
   # Verbs
   este: "e[ste]"
   exista: "(<este>|exist(ă|a))"
   exista_vreun: "<exista> <vreun>"
   porneste: "(start|porne(ș|s)te|deschide|aprinde|activeaz(ă|a))"
   opreste: "(stop|opre(ș|s)te|(î|i)nchide|stinge|dezactiveaz(ă|a))"
+  porneste_timer: "(start|porne(ș|s)te|activeaz(ă|a))"
+  opreste_timer: "(stop|opre(ș|s)te|dezactiveaz(ă|a)|anuleaz(ă|a))"
+  suspenda_timer: "((opre(ș|s)te|dezactiveaz(ă|a)) <temporar> <complement_direct>|suspend(ă|a) <complement_direct>|pune [<temporar> ][pe ]pauz(ă|a) [la ]<complement_direct>)"
+  reia_timer: "(re<porneste_timer>|reia)"
   seteaza: "(seteaz(ă|a)|pune|a[d]justeaz(ă|a)|schimb(ă|a)|modific(ă|a))"
   deschide: "(deschide|ridic(ă|a))"
   inchide: "((î|i)nchide|coboar(ă|a))"
@@ -525,7 +558,8 @@ expansion_rules:
   in: "((î|i)n)"
   din: "(din|(î|i)n|pentru|[de ]la|[de ]pe|de)" # used particularly for areas
   la: "(la|(î|i)n)" # used particularly for zones
-  pana_la: "([p(â|a)n(ă|a) ]la)" # used particularly for quantities
+  pana_la: "([p(â|a)n(ă|a) ]la)" # used particularly for quantity targets
+  de: "([(î|i)n valoare ]de|pentru)" # used for quantities
 
   # Adjectives
   pornit: "(pornit[(ă|a)]|deschis[(ă|a)]|aprins[(ă|a)]|activat[(ă|a)])"
@@ -555,6 +589,7 @@ expansion_rules:
   ventilatoarele: "(ventilatoare[le]|aerisiri[le])"
   intrerupatorul: "((î|i)ntrerup(ă|a)tor[ul]|comutator[ul])"
   intrerupatoarele: "((î|i)ntrerup(ă|a)toare[le]|comutatoare[le])"
+  temporizatorul: "(un temporizator|temporizator[ul]|o temporizare|temporizare[a]|un cronometru|cronometru[l])"
 
   # Attributes
   luminozitatea: "(luminozitate[a])"
@@ -580,6 +615,8 @@ expansion_rules:
   din_zona: "<din> <area>"
   urmatorul: "(urm(a|ă)to(are[a]|r[ul]))"
   precedentul: "(precedent(a|ă|[ul]))"
+  numit: "(numit[(ă|a)]|cu numele|pe nume|intitulat[(ă|a)])"
+  temporar: "(temporar|pu(ț|t)in|un pic|pentru moment|deocamdat(ă|a))"
 
   # Sentences
   name_dinZona_verbState: "(<name>[ <din_zona>]; <verb_state>)"

--- a/sentences/ro/homeassistant_HassCancelTimer.yaml
+++ b/sentences/ro/homeassistant_HassCancelTimer.yaml
@@ -1,0 +1,9 @@
+language: ro
+intents:
+  HassCancelTimer:
+    data:
+      - sentences:
+          - "<opreste_timer> <temporizatorul>"
+          - "<opreste_timer> <temporizatorul> [<de> ]<timer_start>"
+          - "<opreste_timer> <temporizatorul> <din_zona>"
+          - "<opreste_timer> <temporizatorul> [(<numit>|pentru) ]{timer_name:name}"

--- a/sentences/ro/homeassistant_HassDecreaseTimer.yaml
+++ b/sentences/ro/homeassistant_HassDecreaseTimer.yaml
@@ -1,0 +1,12 @@
+language: ro
+intents:
+  HassDecreaseTimer:
+    data:
+      - sentences:
+          - "<scade_amount_din_complement>"
+        expansion_rules:
+          amount: "<timer_duration>"
+          object: "<temporizatorul>[ ([<de> ]<timer_start>|<din_zona>|[(<numit>|pentru) ]{timer_name:name})]"
+
+      - sentences:
+          - "{timer_name:name} trebuie[ s(ă|a) (fie[ gata]|(î|i)nceap(ă|a)|se termine)] (mai (repede|devreme);[cu ]<timer_duration>)"

--- a/sentences/ro/homeassistant_HassIncreaseTimer.yaml
+++ b/sentences/ro/homeassistant_HassIncreaseTimer.yaml
@@ -1,0 +1,12 @@
+language: ro
+intents:
+  HassIncreaseTimer:
+    data:
+      - sentences:
+          - "<adauga_amount_la_complement>"
+        expansion_rules:
+          amount: "<timer_duration>"
+          object: "<temporizatorul>[ ([<de> ]<timer_start>|<din_zona>|[(<numit>|pentru) ]{timer_name:name})]"
+
+      - sentences:
+          - "[mai ](a(ș|s)teapt(ă|a)|stai) [(î|i)nc(ă|a) ]<timer_duration>[ ([dup(ă|a) ]<temporizatorul> ([<de> ]<timer_start>|<din_zona>|[(<numit>|pentru) ]{timer_name:name})|[(dup(ă|a)|pentru) ]{timer_name:name})]"

--- a/sentences/ro/homeassistant_HassPauseTimer.yaml
+++ b/sentences/ro/homeassistant_HassPauseTimer.yaml
@@ -1,0 +1,8 @@
+language: ro
+intents:
+  HassPauseTimer:
+    data:
+      - sentences:
+          - "<suspenda_timer>"
+        expansion_rules:
+          complement_direct: "<temporizatorul>[ ([<de> ]<timer_start>|<din_zona>|[(<numit>|pentru) ]{timer_name:name})]"

--- a/sentences/ro/homeassistant_HassPauseTimer.yaml
+++ b/sentences/ro/homeassistant_HassPauseTimer.yaml
@@ -5,4 +5,4 @@ intents:
       - sentences:
           - "<suspenda_timer>"
         expansion_rules:
-          complement_direct: "<temporizatorul>[ ([<de> ]<timer_start>|<din_zona>|[(<numit>|pentru) ]{timer_name:name})]"
+          object: "<temporizatorul>[ ([<de> ]<timer_start>|<din_zona>|[(<numit>|pentru) ]{timer_name:name})]"

--- a/sentences/ro/homeassistant_HassStartTimer.yaml
+++ b/sentences/ro/homeassistant_HassStartTimer.yaml
@@ -1,0 +1,10 @@
+language: ro
+intents:
+  HassStartTimer:
+    data:
+      - sentences:
+          - "[<porneste_timer> ]<temporizatorul> [<de> ]<timer_duration>"
+          - "[<porneste_timer> ]<temporizatorul> ([<de> ]<timer_duration>;(<numit>|pentru) {timer_name:name})"
+        requires_context:
+          area:
+            slot: false

--- a/sentences/ro/homeassistant_HassTimerStatus.yaml
+++ b/sentences/ro/homeassistant_HassTimerStatus.yaml
@@ -1,0 +1,8 @@
+language: ro
+intents:
+  HassTimerStatus:
+    data:
+      - sentences:
+          - "status[ul] <temporizatorul>[ ([<de> ]<timer_start>|<din_zona>|[(<numit>|pentru) ]{timer_name:name})]"
+          - "[<care> <este> ]status[ul] <temporizatorului>[ ([<de> ]<timer_start>|<din_zona>|[(<numit>|pentru) ]{timer_name:name})]"
+          - "<cat_quant>[ timp] (a [mai ]r(ă|a)mas <din>|mai <este> <din>|mai are) <temporizatorul>[ ([<de> ]<timer_start>|<din_zona>|[(<numit>|pentru) ]{timer_name:name})]"

--- a/sentences/ro/homeassistant_HassUnpauseTimer.yaml
+++ b/sentences/ro/homeassistant_HassUnpauseTimer.yaml
@@ -1,0 +1,9 @@
+language: ro
+intents:
+  HassUnpauseTimer:
+    data:
+      - sentences:
+          - "<reia_timer> <temporizatorul>"
+          - "<reia_timer> <temporizatorul> [<de> ]<timer_start>"
+          - "<reia_timer> <temporizatorul> <din_zona>"
+          - "<reia_timer> <temporizatorul> [(<numit>|pentru) ]{timer_name:name}"

--- a/tests/ro/_fixtures.yaml
+++ b/tests/ro/_fixtures.yaml
@@ -425,3 +425,24 @@ entities:
   - name: "Aspiratorul"
     id: "vacuum.rover"
     state: "idle"
+
+  # Timer
+timers:
+  - is_active: false
+    start_hours: 2
+    total_seconds_left: 100
+    rounded_hours_left: 0
+    rounded_minutes_left: 1
+    rounded_seconds_left: 40
+  - name: pizza
+    start_minutes: 30
+    total_seconds_left: 1505
+    rounded_hours_left: 0
+    rounded_minutes_left: 25
+    rounded_seconds_left: 0
+  - area: Bucatarie #TODO https://github.com/home-assistant/intents/discussions/2193#discussioncomment-9617522
+    start_minutes: 5
+    total_seconds_left: 190
+    rounded_hours_left: 0
+    rounded_minutes_left: 3
+    rounded_seconds_left: 0

--- a/tests/ro/homeassistant_HassCancelTimer.yaml
+++ b/tests/ro/homeassistant_HassCancelTimer.yaml
@@ -1,0 +1,45 @@
+language: ro
+tests:
+  - sentences:
+      - "opreste temporizatorul"
+      - "dezactiveaza temporizarea"
+      - "anuleaza temporizare"
+      - "stop cronometru"
+    intent:
+      name: HassCancelTimer
+    response: Am anulat temporizatorul
+
+  - sentences:
+      - "opreste temporizatorul de 5 minute"
+      - "dezactiveaza temporizarea de 5 minute"
+      - "anuleaza temporizare pentru 5 minute"
+      - "stop cronometru de 5 minute"
+    intent:
+      name: HassCancelTimer
+      slots:
+        start_minutes: 5
+    response: Am anulat temporizatorul
+
+  - sentences:
+      - "opreste temporizatorul pentru pizza"
+      - "dezactiveaza temporizarea numita pizza"
+      - "anuleaza temporizare cu numele pizza"
+      - "stop cronometru intitulat pizza"
+    intent:
+      name: HassCancelTimer
+      slots:
+        name:
+          - "pizza "
+          - "pizza"
+    response: Am anulat temporizatorul
+
+  - sentences:
+      - "opreste temporizatorul din sufragerie"
+      - "dezactiveaza temporizarea din sufragerie"
+      - "anuleaza temporizare din sufragerie"
+      - "stop cronometru in sufragerie"
+    intent:
+      name: HassCancelTimer
+      slots:
+        area: Sufragerie
+    response: Am anulat temporizatorul

--- a/tests/ro/homeassistant_HassDecreaseTimer.yaml
+++ b/tests/ro/homeassistant_HassDecreaseTimer.yaml
@@ -1,0 +1,49 @@
+language: ro
+tests:
+  - sentences:
+      - "scade 5 minute din temporizare"
+      - "micsoreaza cronometrul cu 5 minute"
+      - "redu temporizarea cu 5 minute"
+    intent:
+      name: HassDecreaseTimer
+      slots:
+        minutes: 5
+    response: Am actualizat temporizatorul
+
+  - sentences:
+      - "scade 5 minute din temporizarea de 2 ore"
+      - "micsoreaza cronometrul de 2 ore cu 5 minute"
+      - "redu cu 5 minute temporizarea de 2 ore"
+    intent:
+      name: HassDecreaseTimer
+      slots:
+        minutes: 5
+        start_hours: 2
+    response: Am actualizat temporizatorul
+
+  - sentences:
+      - "scade 5 minute din temporizarea numita pizza"
+      - "micsoreaza cronometrul pentru pizza cu 5 minute"
+      - "redu cu 5 minute temporizarea intitulata pizza"
+      - "pizza trebuie sa fie gata cu 5 minute mai repede"
+      - "pizza trebuie cu 5 minute mai devreme"
+      - "pizza trebuie sa se termine mai repede cu 5 minute"
+    intent:
+      name: HassDecreaseTimer
+      slots:
+        minutes: 5
+        name:
+          - "pizza "
+          - "pizza"
+    response: Am actualizat temporizatorul
+
+  - sentences:
+      - "scade 5 minute din temporizarea din bucatarie"
+      - "micsoreaza cronometrul din bucatarie cu 5 minute"
+      - "redu cu 5 minute temporizarea din bucatarie"
+    intent:
+      name: HassDecreaseTimer
+      slots:
+        minutes: 5
+        area: Bucatarie
+    response: Am actualizat temporizatorul

--- a/tests/ro/homeassistant_HassIncreaseTimer.yaml
+++ b/tests/ro/homeassistant_HassIncreaseTimer.yaml
@@ -1,0 +1,56 @@
+language: ro
+tests:
+  - sentences:
+      - "adauga 5 minute la temporizare"
+      - "mareste cronometrul cu 5 minute"
+      - "creste temporizarea cu 5 minute"
+      - "asteapta 5 minute"
+      - "mai stai inca 5 minute"
+    intent:
+      name: HassIncreaseTimer
+      slots:
+        minutes: 5
+    response: Am actualizat temporizatorul
+
+  - sentences:
+      - "adauga 5 minute la temporizarea de 2 ore"
+      - "mareste cronometrul de 2 ore cu 5 minute"
+      - "creste cu 5 minute temporizarea de 2 ore"
+      - "asteapta 5 minute dupa temporizarea de 2 ore"
+      - "mai stai inca 5 minute dupa temporizatorul de 2 ore"
+    intent:
+      name: HassIncreaseTimer
+      slots:
+        minutes: 5
+        start_hours: 2
+    response: Am actualizat temporizatorul
+
+  - sentences:
+      - "adauga 5 minute la temporizarea numita pizza"
+      - "mareste cronometrul pentru pizza cu 5 minute"
+      - "creste cu 5 minute temporizarea intitulata pizza"
+      - "asteapta 5 minute dupa temporizarea cu numele pizza"
+      - "asteapta inca 5 minute pentru pizza"
+      - "mai stai inca 5 minute dupa temporizatorul pizza"
+      - "mai stai 5 minute dupa pizza"
+    intent:
+      name: HassIncreaseTimer
+      slots:
+        minutes: 5
+        name:
+          - "pizza "
+          - "pizza"
+    response: Am actualizat temporizatorul
+
+  - sentences:
+      - "adauga 5 minute la temporizarea din bucatarie"
+      - "mareste cronometrul din bucatarie cu 5 minute"
+      - "creste cu 5 minute temporizarea din bucatarie"
+      - "asteapta 5 minute dupa temporizarea din bucatarie"
+      - "mai stai inca 5 minute dupa temporizatorul din bucatarie"
+    intent:
+      name: HassIncreaseTimer
+      slots:
+        minutes: 5
+        area: Bucatarie
+    response: Am actualizat temporizatorul

--- a/tests/ro/homeassistant_HassPauseTimer.yaml
+++ b/tests/ro/homeassistant_HassPauseTimer.yaml
@@ -1,0 +1,45 @@
+language: ro
+tests:
+  - sentences:
+      - "opreste putin cronometrul"
+      - "suspenda temporizarea"
+      - "dezactiveaza un pic temporizatorul"
+      - "pune pentru moment pauza la cronometru"
+    intent:
+      name: HassPauseTimer
+    response: Am pus pe pauză temporizatorul
+
+  - sentences:
+      - "opreste putin cronometrul de 2 ore"
+      - "suspenda temporizarea de 2 ore"
+      - "dezactiveaza un pic temporizatorul de 2 ore"
+      - "pune pentru moment pauza la cronometrul de 2 ore"
+    intent:
+      name: HassPauseTimer
+      slots:
+        start_hours: 2
+    response: Am pus pe pauză temporizatorul
+
+  - sentences:
+      - "opreste putin cronometrul pentru pizza"
+      - "suspenda temporizarea numita pizza"
+      - "dezactiveaza un pic temporizatorul cu numele pizza"
+      - "pune pentru moment pauza la cronometrul intitulat pizza"
+    intent:
+      name: HassPauseTimer
+      slots:
+        name:
+          - "pizza "
+          - "pizza"
+    response: Am pus pe pauză temporizatorul
+
+  - sentences:
+      - "opreste putin cronometrul din sufragerie"
+      - "suspenda temporizarea din sufragerie"
+      - "dezactiveaza un pic temporizatorul din sufragerie"
+      - "pune pentru moment pauza la cronometrul din sufragerie"
+    intent:
+      name: HassPauseTimer
+      slots:
+        area: Sufragerie
+    response: Am pus pe pauză temporizatorul

--- a/tests/ro/homeassistant_HassStartTimer.yaml
+++ b/tests/ro/homeassistant_HassStartTimer.yaml
@@ -1,0 +1,105 @@
+language: ro
+tests:
+  - sentences:
+      - "temporizator 2 ore"
+      - "porneste o temporizare de 2 ore"
+      - "start cronometru pentru 2 ore"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Sufragerie
+      slots:
+        hours: 2
+    response: Am pornit temporizatorul
+
+  - sentences:
+      - "temporizator 2 ore si 15 minute"
+      - "porneste o temporizare de 2 ore si 15 minute"
+      - "start cronometru pentru 2 ore si 15 minute"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Sufragerie
+      slots:
+        hours: 2
+        minutes: 15
+    response: Am pornit temporizatorul
+
+  - sentences:
+      - "temporizator 2 ore si 30 de secunde"
+      - "porneste o temporizare de 2 ore si 30 de secunde"
+      - "start cronometru pentru 2 ore si 30 de secunde"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Sufragerie
+      slots:
+        hours: 2
+        seconds: 30
+    response: Am pornit temporizatorul
+
+  - sentences:
+      - "temporizator 2 ore, 15 minute si 30 de secunde"
+      - "porneste o temporizare de 2 ore, 15 minute si 30 de secunde"
+      - "start cronometru pentru 2 ore, 15 minute si 30 de secunde"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Sufragerie
+      slots:
+        hours: 2
+        minutes: 15
+        seconds: 30
+    response: Am pornit temporizatorul
+
+  - sentences:
+      - "temporizator 15 minute"
+      - "porneste o temporizare de 15 minute"
+      - "start cronometru pentru 15 minute"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Sufragerie
+      slots:
+        minutes: 15
+    response: Am pornit temporizatorul
+
+  - sentences:
+      - "temporizator 15 minute si 30 de secunde"
+      - "porneste o temporizare de 15 minute si 30 de secunde"
+      - "start cronometru pentru 15 minute si 30 de secunde"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Sufragerie
+      slots:
+        minutes: 15
+        seconds: 30
+    response: Am pornit temporizatorul
+
+  - sentences:
+      - "temporizator 30 de secunde"
+      - "porneste o temporizare de 30 de secunde"
+      - "start cronometru pentru 30 de secunde"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Sufragerie
+      slots:
+        seconds: 30
+    response: Am pornit temporizatorul
+
+  - sentences:
+      - "temporizator 15 minute cu numele pizza"
+      - "porneste o temporizare numita pizza de 15 minute"
+      - "start cronometru pentru 15 minute intitulat pizza"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Sufragerie
+      slots:
+        minutes: 15
+        name:
+          - "pizza"
+          - "pizza "
+    response: Am pornit temporizatorul

--- a/tests/ro/homeassistant_HassTimerStatus.yaml
+++ b/tests/ro/homeassistant_HassTimerStatus.yaml
@@ -1,0 +1,53 @@
+language: ro
+tests:
+  - sentences:
+      - "care e statusul temporizatorului?"
+      - "status cronometru"
+      - "cat mai are temporizarea?"
+      - "cat timp a mai ramas pe temporizator?"
+      - "cat mai este din cronometru?"
+    intent:
+      name: HassTimerStatus
+    response: |
+      2 temporizatoare pornite. Un temporizator oprit temporar. Mai durează 3 minute până la finele temporizatorului de 5 minute din bucatarie
+
+  - sentences:
+      - "care e statusul temporizatorului de 2 ore?"
+      - "status cronometru de 2 ore"
+      - "cat mai are temporizarea de 2 ore?"
+      - "cat timp a mai ramas pe temporizatorul de 2 ore?"
+      - "cat mai este din cronometrul de 2 ore?"
+    intent:
+      name: HassTimerStatus
+      slots:
+        start_hours: 2
+    response: |
+      Temporizatorul este în pauză. Mai durează Un minut și 40 de secunde
+
+  - sentences:
+      - "care e statusul temporizatorului pentru pizza?"
+      - "status cronometru pizza"
+      - "cat mai are temporizarea numita pizza?"
+      - "cat timp a mai ramas pe temporizatorul cu numele pizza?"
+      - "cat mai este din cronometrul pizza?"
+    intent:
+      name: HassTimerStatus
+      slots:
+        name:
+          - "pizza "
+          - "pizza"
+    response: |
+      Mai durează 25 de minute
+
+  - sentences:
+      - "care e statusul temporizatorului din bucatarie?"
+      - "status cronometru in bucatarie"
+      - "cat mai are temporizarea din bucatarie?"
+      - "cat timp a mai ramas pe temporizatorul de la bucatarie?"
+      - "cat mai este din cronometrul din bucatarie?"
+    intent:
+      name: HassTimerStatus
+      slots:
+        area: Bucatarie
+    response: |
+      Mai durează 3 minute

--- a/tests/ro/homeassistant_HassUnpauseTimer.yaml
+++ b/tests/ro/homeassistant_HassUnpauseTimer.yaml
@@ -1,0 +1,45 @@
+language: ro
+tests:
+  - sentences:
+      - "reporneste temporizatorul"
+      - "reia temporizarea"
+      - "restart cronometru"
+      - "reactiveaza cronometrul"
+    intent:
+      name: HassUnpauseTimer
+    response: Am repornit temporizatorul
+
+  - sentences:
+      - "reporneste temporizatorul de 2 ore"
+      - "reia temporizarea de 2 ore"
+      - "restart cronometru de 2 ore"
+      - "reactiveaza cronometrul de 2 ore"
+    intent:
+      name: HassUnpauseTimer
+      slots:
+        start_hours: 2
+    response: Am repornit temporizatorul
+
+  - sentences:
+      - "reporneste temporizatorul numit pizza"
+      - "reia temporizarea intitulata pizza"
+      - "restart cronometru cu numele pizza"
+      - "reactiveaza cronometrul pizza"
+    intent:
+      name: HassUnpauseTimer
+      slots:
+        name:
+          - "pizza "
+          - "pizza"
+    response: Am repornit temporizatorul
+
+  - sentences:
+      - "reporneste temporizatorul din sufragerie"
+      - "reia temporizarea din sufragerie"
+      - "restart cronometru din sufragerie"
+      - "reactiveaza cronometrul din sufragerie"
+    intent:
+      name: HassUnpauseTimer
+      slots:
+        area: Sufragerie
+    response: Am repornit temporizatorul


### PR DESCRIPTION
RO translation of #2179, #2182, #2183, #2185, #2190

Adds area-aware sentences for creating/starting/stopping/pausing/unpausing/increasing/decreasing timers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Romanian language support for various Home Assistant timer intents, including starting, pausing, unpausing, canceling, increasing, decreasing, and checking the status of timers.

- **Tests**
  - Introduced comprehensive test cases in Romanian for all new timer-related intents in Home Assistant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->