### PR TITLE
Send area name to timer response

### DIFF
--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -423,6 +423,12 @@ def get_timers(fixtures: dict[str, Any]) -> List[Timer]:
 
         timer_area = timer.get("area")
         if timer_area:
+            # Resolve area id to name
+            for area in fixtures.get("areas", []):
+                if area["id"] == timer_area:
+                    timer_area = area["name"]
+                    break
+
             timer_area = _normalize_name(timer_area)
 
         timers.append(

--- a/tests/en/_fixtures.yaml
+++ b/tests/en/_fixtures.yaml
@@ -1,81 +1,81 @@
 language: "en"
 areas:
   - name: "Kitchen"
-    id: "kitchen"
+    id: "kitchen_id"
     floor: "First Floor"
 
   - name: "Living Room"
-    id: "living_room"
+    id: "living_room_id"
     floor: "First Floor"
 
   - name: "Bedroom"
-    id: "bedroom"
+    id: "bedroom_id"
     floor: "Second Floor"
 
   - name: "Garage"
-    id: "garage"
+    id: "garage_id"
     floor: "First Floor"
 
   - name: "Entrance"
-    id: "entrance"
+    id: "entrance_id"
     floor: "First Floor"
 
   - name: "Office"
-    id: "office"
+    id: "office_id"
     floor: "Basement"
 entities:
   - name: "Bedroom Lamp"
     id: "light.bedroom_lamp"
-    area: "bedroom"
+    area: "bedroom_id"
     state: "off"
 
   - name: "Bedroom Switch"
     id: "switch.bedroom"
-    area: "bedroom"
+    area: "bedroom_id"
     state: "off"
 
   - name: "Kitchen Switch"
     id: "switch.kitchen"
-    area: "kitchen"
+    area: "kitchen_id"
     state: "on"
 
   - name: "Kitchen countertop"
     id: "light.kitchen_countertop"
-    area: "kitchen"
+    area: "kitchen_id"
     state: "on"
 
   - name: "Kitchen ceiling"
     id: "light.kitchen_ceiling"
-    area: "kitchen"
+    area: "kitchen_id"
     state: "on"
 
   - name: "Kitchen cabinets"
     id: "light.kitchen_cabinets"
-    area: "kitchen"
+    area: "kitchen_id"
     state: "on"
 
   - name: "Ceiling Fan"
     id: "fan.ceiling"
-    area: "living_room"
+    area: "living_room_id"
     state: "off"
 
   - name: "Curtain Left"
     id: "cover.curtain_left"
-    area: "living_room"
+    area: "living_room_id"
     state: "open"
     attributes:
       device_class: curtain
 
   - name: "Curtain Right"
     id: "cover.curtain_right"
-    area: "living_room"
+    area: "living_room_id"
     state: "closed"
     attributes:
       device_class: curtain
 
   - name: "Bedroom Curtain"
     id: "cover.bedroom"
-    area: "bedroom"
+    area: "bedroom_id"
     state: "closed"
     attributes:
       device_class: curtain
@@ -83,43 +83,43 @@ entities:
 
   - name: "Outside Temperature"
     id: "sensor.outside_temperature"
-    area: "garage"
+    area: "garage_id"
     state: "42"
     attributes:
       unit_of_measurement: "°F"
 
   - name: "Living Room Lamp"
     id: "light.living_room_lamp"
-    area: "living_room"
+    area: "living_room_id"
     state: "on"
 
   - name: "Garage Light"
     id: "light.garage"
-    area: "garage"
+    area: "garage_id"
     state: "on"
 
   - name: Play Corner
     id: light.play_corner
-    area: living_room
+    area: "living_room_id"
     state: "on"
 
   - name: "Thermostat"
     id: "climate.thermostat"
-    area: "living_room"
+    area: "living_room_id"
     state: "heat"
     attributes:
       current_temperature: 68
 
   - name: "Office Thermostat"
     id: "climate.office_thermostat"
-    area: "office"
+    area: "office_id"
     state: "heat"
     attributes:
       current_temperature: 1
 
   - name: "Front Door"
     id: "lock.front_door"
-    area: "entrance"
+    area: "entrance_id"
     state: "locked"
 
   - name: "Back Door"
@@ -155,7 +155,7 @@ entities:
 
   - name: "CO2"
     id: "binary_sensor.co2"
-    area: "kitchen"
+    area: "kitchen_id"
     state:
       in: "clear"
       out: "off"
@@ -196,7 +196,7 @@ entities:
 
   - name: "Gas"
     id: "binary_sensor.gas"
-    area: "kitchen"
+    area: "kitchen_id"
     state:
       in: "clear"
       out: "off"
@@ -229,7 +229,7 @@ entities:
 
   - name: "Kitchen leak sensor"
     id: "binary_sensor.water_sensor"
-    area: kitchen
+    area: "kitchen_id"
     state:
       in: "dry"
       out: "off"
@@ -238,7 +238,7 @@ entities:
 
   - name: "Motion sensor"
     id: "binary_sensor.garage_motion"
-    area: "garage"
+    area: "garage_id"
     state:
       in: "detected"
       out: "on"
@@ -247,7 +247,7 @@ entities:
 
   - name: "Occupancy"
     id: "binary_sensor.kitchen_occupancy"
-    area: "kitchen"
+    area: "kitchen_id"
     state:
       in: "detected"
       out: "on"
@@ -288,7 +288,7 @@ entities:
 
   - name: "Pet Feeder"
     id: "binary_sensor.problem"
-    area: "kitchen"
+    area: "kitchen_id"
     state:
       in: "ok"
       out: "off"
@@ -313,7 +313,7 @@ entities:
 
   - name: "Kitchen Smoke"
     id: "binary_sensor.kitchen_smoke"
-    area: "kitchen"
+    area: "kitchen_id"
     state:
       in: "clear"
       out: "off"
@@ -322,7 +322,7 @@ entities:
 
   - name: "Siren"
     id: "binary_sensor.sound"
-    area: "garage"
+    area: "garage_id"
     state:
       in: "detected"
       out: "on"
@@ -724,7 +724,7 @@ entities:
 
   - name: "TV"
     id: "media_player.tv"
-    area: "living_room"
+    area: "living_room_id"
     state: "idle"
     attributes:
       volume_level: "50"
@@ -739,13 +739,13 @@ timers:
     rounded_hours_left: 0
     rounded_minutes_left: 1
     rounded_seconds_left: 40
-  - name: pizza
+  - name: "pizza"
     start_minutes: 30
     total_seconds_left: 1505
     rounded_hours_left: 0
     rounded_minutes_left: 25
     rounded_seconds_left: 0
-  - area: kitchen
+  - area: "kitchen_id"
     start_minutes: 5
     total_seconds_left: 190
     rounded_hours_left: 0


### PR DESCRIPTION
Fix for issue: https://github.com/home-assistant/intents/discussions/2193#discussioncomment-9617522

Area ids were being sent to the timer response instead of area names.
This PR also changes the area ids in the English test fixtures to `<area>_id` to make this issue less likely to surface in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced timer functionality by resolving area IDs to names, improving user clarity in the timer interface.

- **Tests**
  - Updated area identifiers in test fixtures to align with new naming conventions, ensuring consistency and accuracy in testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->