### PR TITLE
[DE] Add delayed commands to timers

### DIFF
--- a/responses/de/HassStartTimer.yaml
+++ b/responses/de/HassStartTimer.yaml
@@ -4,3 +4,4 @@ responses:
   intents:
     HassStartTimer:
       default: "Timer gestartet"
+      command: "Anweisung erhalten"

--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -252,6 +252,8 @@ lists:
       to: 100
   timer_name:
     wildcard: true
+  timer_command:
+    wildcard: true
 
 expansion_rules:
   artikel_bestimmt: "[(der|die|das|dem|der|den|des)]"

--- a/sentences/de/homeassistant_HassStartTimer.yaml
+++ b/sentences/de/homeassistant_HassStartTimer.yaml
@@ -15,3 +15,7 @@ intents:
         requires_context:
           area:
             slot: false
+      - sentences:
+          - "{timer_command:conversation_command} in <timer_duration>"
+          - "in <timer_duration> {timer_command:conversation_command}"
+        response: command

--- a/tests/de/homeassistant_HassStartTimer.yaml
+++ b/tests/de/homeassistant_HassStartTimer.yaml
@@ -107,3 +107,15 @@ tests:
       slots:
         seconds: 45
     response: Timer gestartet
+
+  - sentences:
+      - "Öffne die Garagentür in 5 Minuten"
+      - "in 5 Minuten öffne die Garagentür"
+    intent:
+      name: HassStartTimer
+      slots:
+        minutes: 5
+        conversation_command:
+          - "öffne die garagentür"
+          - "öffne die garagentür "
+    response: Anweisung erhalten


### PR DESCRIPTION
see https://github.com/home-assistant/intents/pull/2196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new response option "Anweisung erhalten" to the `HassStartTimer` intent.
  - Introduced new sentences for timer commands, allowing variations in specifying timer commands and durations.
  - Added a new wildcard `timer_command` for enhanced timer functionality.

- **Tests**
  - Added a new test case for starting a timer with a 5-minute delay, including variations in the command structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->