### PR TITLE
Parallelize tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 This repository contains training data for Home Assistant's local voice control.
 
- - [Progress per language and intent](https://home-assistant.github.io/intents/)
- - [How to contribute](https://developers.home-assistant.io/docs/voice/intent-recognition/contributing/)
- - [Language leaders](https://developers.home-assistant.io/docs/voice/language-leaders/)
- - [Supported intents](https://developers.home-assistant.io/docs/intent_builtin/)
- - [Supported languages](https://developers.home-assistant.io/docs/voice/intent-recognition/supported-languages/)
+- [Progress per language and intent](https://home-assistant.github.io/intents/)
+- [How to contribute](https://developers.home-assistant.io/docs/voice/intent-recognition/contributing/)
+- [Language leaders](https://developers.home-assistant.io/docs/voice/language-leaders/)
+- [Supported intents](https://developers.home-assistant.io/docs/intent_builtin/)
+- [Supported languages](https://developers.home-assistant.io/docs/voice/intent-recognition/supported-languages/)
 
 Repository layout:
 
@@ -46,7 +46,7 @@ Run the tests. This will parse the sentences and verifies them with the test sen
 pytest tests --language nl -k fan_HassTurnOn
 ```
 
-Leave off `--language` to test all languages. Leave off `-k` to test all files.
+Leave off `--language` to test all languages. Leave off `-k` to test all files. Add `-n auto` to use test parallelization.
 
 ## Test parsing sentences
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ isort==5.13.2
 mypy==1.10.0
 pylint==3.2.2
 pytest==8.2.1
+pytest-xdist[psutil]==3.6.1

--- a/script/test
+++ b/script/test
@@ -16,4 +16,4 @@ if [ -d "${venv}" ]; then
 fi
 
 python3 -m script.intentfest validate
-pytest -vv "$@"
+pytest -vv -n auto "$@"

--- a/script/test_file
+++ b/script/test_file
@@ -37,6 +37,7 @@ def main():
 
     if select_language or file_name in ("_fixtures.yaml", "_common.yaml"):
         print(f"Running all tests for {language.upper()}")
+        test_cmd.extend(["-n", "auto"])
 
     else:
         print("Running tests for file", file_name)

--- a/tests/test_language_intents.py
+++ b/tests/test_language_intents.py
@@ -230,7 +230,7 @@ def gen_tests() -> None:
         if test_file.name != "_common.yaml"
     }
 
-    for name in names:
+    for name in sorted(names):
         gen_test(name)
 
 

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -238,7 +238,7 @@ def gen_tests() -> None:
         if test_file.name != "_fixtures.yaml"
     }
 
-    for name in names:
+    for name in sorted(names):
         gen_test(name)
 
 


### PR DESCRIPTION
This will make use of [`pytest-xdist`](https://pytest-xdist.readthedocs.io/en/stable/index.html) to parallelize tests and those save CI time and also improve testing times locally.
To make it work, the [order and amount of test must be consistent](https://pytest-xdist.readthedocs.io/en/stable/known-limitations.html#order-and-amount-of-test-must-be-consistent)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added parallel test execution capability to improve testing speed.

- **Documentation**
  - Updated README with new test parallelization instructions and revised URLs.

- **Tests**
  - Enhanced test scripts to sort names before iteration, ensuring consistent test order.
  - Updated test command to include parallel execution option.

- **Chores**
  - Updated `pytest-xdist[psutil]` to version `3.6.1` in `requirements.txt`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->