### PR TITLE
Make shade queries more flexible for more generic requests

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -115,6 +115,9 @@ HassGetState:
     area:
       description: "Name of an area"
       required: false
+    floor:
+      description: "Name of a floor"
+      required: false
     domain:
       description: "Domain of devices/entities in an area"
       required: false

--- a/sentences/en/cover_HassGetState.yaml
+++ b/sentences/en/cover_HassGetState.yaml
@@ -3,7 +3,7 @@ intents:
   HassGetState:
     data:
       - sentences:
-          - "is <name> {cover_states:state} [in <area>]"
+          - "is <name> {cover_states:state} [[in ](<area>|<floor>)]"
         response: one_yesno
         requires_context:
           domain: cover
@@ -11,25 +11,29 @@ intents:
           domain: cover
 
       - sentences:
-          - "(is|are) any {cover_classes:device_class} {cover_states:state} [in <area>]"
+          - "(is|are) any {cover_classes:device_class} {cover_states:state} [[in ](<area>|<floor>)]"
+          - "(is|are) any (<area>|<floor>) {cover_classes:device_class} {cover_states:state}"
         response: any
         slots:
           domain: cover
 
       - sentences:
-          - "are all [the] {cover_classes:device_class} {cover_states:state} [in <area>]"
+          - "are all [the] {cover_classes:device_class} {cover_states:state} [[in ](<area>|<floor>)]"
+          - "are all [the] (<area>|<floor>) {cover_classes:device_class} {cover_states:state}"
         response: all
         slots:
           domain: cover
 
       - sentences:
-          - "(which|what) {cover_classes:device_class} (is|are) {cover_states:state} [in <area>]"
+          - "(which|what) {cover_classes:device_class} (is|are) {cover_states:state} [[in ](<area>|<floor>)]"
+          - "(which|what) (<area>|<floor>) {cover_classes:device_class} (is|are) {cover_states:state}"
         response: which
         slots:
           domain: cover
 
       - sentences:
-          - "how many {cover_classes:device_class} (is|are) {cover_states:state} [in <area>]"
+          - "how many {cover_classes:device_class} (is|are) {cover_states:state} [[in ](<area>|<floor>)]"
+          - "how many (<area>|<floor>) {cover_classes:device_class} (is|are) {cover_states:state}"
         response: how_many
         slots:
           domain: cover

--- a/tests/en/_fixtures.yaml
+++ b/tests/en/_fixtures.yaml
@@ -1,5 +1,10 @@
 language: "en"
 areas:
+  - name: "Guest Room"
+    id: "guest_room_id"
+    # Simulates a floor alias since we can't alias floors
+    floor: "Upstairs"
+
   - name: "Kitchen"
     id: "kitchen_id"
     floor: "First Floor"
@@ -65,6 +70,13 @@ entities:
     state: "open"
     attributes:
       device_class: curtain
+
+  - name: "Shade Left"
+    id: "cover.shade_left"
+    area: "guest_room_id"
+    state: "open"
+    attributes:
+      device_class: shade
 
   - name: "Curtain Right"
     id: "cover.curtain_right"

--- a/tests/en/cover_HassGetState.yaml
+++ b/tests/en/cover_HassGetState.yaml
@@ -12,6 +12,7 @@ tests:
 
   - sentences:
       - "are any curtains open in the living room?"
+      - "are any living room curtains open?"
     intent:
       name: HassGetState
       slots:
@@ -22,7 +23,19 @@ tests:
     response: "Yes, Curtain Left"
 
   - sentences:
+      - "are any shades open upstairs?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        floor: "Upstairs"
+        device_class: shade
+        state: "open"
+    response: "Yes, Shade Left"
+
+  - sentences:
       - "are all curtains open in the living room?"
+      - "are all living room curtains open?"
     intent:
       name: HassGetState
       slots:
@@ -43,6 +56,17 @@ tests:
     response: "Bedroom Curtain and Curtain Right"
 
   - sentences:
+      - "which bedroom curtains are closed?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        area: "Bedroom"
+        device_class: curtain
+        state: "closed"
+    response: "Bedroom Curtain"
+
+  - sentences:
       - "how many curtains are closed?"
     intent:
       name: HassGetState
@@ -51,3 +75,14 @@ tests:
         device_class: curtain
         state: "closed"
     response: "2"
+
+  - sentences:
+      - "how many bedroom curtains are closed?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        device_class: curtain
+        area: "Bedroom"
+        state: "closed"
+    response: "1"


### PR DESCRIPTION
Add coverage for new sentences. These are ones that I try all the time naturally but end up failing.