### PR TITLE
[RO] Fix media_player_HassMediaPause

### DIFF
--- a/sentences/ro/_common.yaml
+++ b/sentences/ro/_common.yaml
@@ -520,6 +520,7 @@ expansion_rules:
   minimum: "(minim[(ă|a|um)][ posibil[(ă|a)]])"
   toti: "(toate|to(ț|t)i)"
   la_suta: "[ ][(%|la sut(ă|a)|[de ]procent[e])]"
+  temporar: "(temporar|pu(ț|t)in|un pic|pentru moment|deocamdat(ă|a))"
 
   # Timers
   ore: "([de ]ore|or(ă|a))"
@@ -618,7 +619,6 @@ expansion_rules:
   urmatorul: "(urm(a|ă)to(are[a]|r[ul]))"
   precedentul: "(precedent(a|ă|[ul]))"
   numit: "(numit[(ă|a)]|cu numele|pe nume|intitulat[(ă|a)])"
-  temporar: "(temporar|pu(ț|t)in|un pic|pentru moment|deocamdat(ă|a))"
 
   # Sentences
   suspenda_timer: "((opre(ș|s)te|dezactiveaz(ă|a)) <temporar> <object>|suspend(ă|a) <object>|pune [<temporar> ][pe ]pauz(ă|a) [la ]<object>)"

--- a/sentences/ro/media_player_HassMediaPause.yaml
+++ b/sentences/ro/media_player_HassMediaPause.yaml
@@ -3,13 +3,13 @@ intents:
   HassMediaPause:
     data:
       - sentences:
-          - "([pune ]pauz(a|ă)|<opreste>[ redarea]) [<din> ]<name>"
+          - "([pune ]pauz(a|ă)|<opreste> (<temporar>[ redarea]|redarea)) [<din> ]<name>"
         requires_context:
           domain: media_player
       - sentences:
-          - "([pune ]pauz(a|ă)|<opreste>[ redarea])"
+          - "([pune ]pauz(a|ă)|<opreste> (<temporar>[ redarea]|redarea))"
         requires_context:
           area:
             slot: true
       - sentences:
-          - "([pune ]pauz(a|ă)|<opreste>[ redarea]) <din_zona>"
+          - "([pune ]pauz(a|ă)|<opreste> (<temporar>[ redarea]|redarea)) <din_zona>"

--- a/tests/ro/homeassistant_HassTurnOff.yaml
+++ b/tests/ro/homeassistant_HassTurnOff.yaml
@@ -7,3 +7,11 @@ tests:
       slots:
         name: "hota"
     response: "Am oprit hota"
+
+  - sentences:
+      - "opreste televizorul"
+    intent:
+      name: HassTurnOff
+      slots:
+        name: "Televizorul"
+    response: "Am oprit televizorul"

--- a/tests/ro/media_player_HassMediaPause.yaml
+++ b/tests/ro/media_player_HassMediaPause.yaml
@@ -3,6 +3,7 @@ tests:
   - sentences:
       - "pune pauza la televizorul"
       - "opreste redarea la televizorul"
+      - "opreste putin televizorul"
     intent:
       name: HassMediaPause
       slots:
@@ -11,6 +12,7 @@ tests:
   - sentences:
       - "pune pauza"
       - "opreste redarea"
+      - "opreste un pic"
     intent:
       name: HassMediaPause
       slots:
@@ -21,6 +23,7 @@ tests:
   - sentences:
       - "pune pauza in sufragerie"
       - "opreste redarea in sufragerie"
+      - "opreste un pic in sufragerie"
     intent:
       name: HassMediaPause
       slots:


### PR DESCRIPTION
There was a sentence overlap for `HassMediaPause` and `HassTurnOff` for `media_player`s.

`opreste televizorul` would have tried to pause the targeted item before trying to turn it off

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded options for pausing media playback to include temporary or permanent pauses within specific zones.
  - Added a new test case for turning off a television within the `HassTurnOff` intent.

- **Improvements**
  - Updated the expansion rule for the term "temporar" to enhance language processing for temporary actions or states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->