### PR TITLE
[RU]Added translation of error

### DIFF
--- a/sentences/ru/_common.yaml
+++ b/sentences/ru/_common.yaml
@@ -1,12 +1,177 @@
 language: "ru"
 responses:
   errors:
-    no_intent: "обращение не распознано"
-    no_area: "нет зоны {{ area }}"
-    no_domain_in_area: "в зоне {{ area }} нет объектов {{ domain }}"
-    no_device_class_in_area: "в зоне {{ area }} нет устройств {{ device_class }}"
-    no_entity: "объекта {{ entity }} не существует"
-    handle_error: "во время обработки действий произошла ошибка"
+    # General errors
+    no_intent: "Обращение не распознано"
+    handle_error: "Во время обработки действия произошла ошибка"
+
+    # Errors for when user is not logged in
+    no_area: "Нет зоны {{ area }}"
+    no_floor: "Нет этажа {{ floor }}"
+    no_domain: |
+      {% set translations = {
+        "button": "кнопка",
+        "camera": "камера",
+        "input_button": "кнопка",
+        "alarm_control_panel": "охрана",
+        "automation": "автоматизация",
+        "fan": "вентилятор",
+        "climate": "термостат",
+        "humidifier": "увлажнитель",
+        "input_boolean": "переключатель",
+        "siren": "сирена",
+        "water_heater": "бойлер",
+        "light": "лампа",
+        "switch": "переключатель",
+        "script": "скрипт",
+        "remote": "ИК пульт",
+        "lock": "замок",
+        "vacuum": "пылесос",
+        "scene": "сцена",
+        "media_player": "плеер",
+        "lawn_mower": "газонокосилка",
+        "valve": "кран"
+        } %}
+      {% if domain in translations -%}
+        Нет объектов типа {{ translations[domain] }}
+      {%- else -%}
+        Нет объектов запрашиваемого типа
+      {%- endif %}
+    no_domain_in_area: |
+      {% set translations = {
+        "button": "кнопка",
+        "camera": "камера",
+        "input_button": "кнопка",
+        "alarm_control_panel": "охрана",
+        "automation": "автоматизация",
+        "fan": "вентилятор",
+        "climate": "термостат",
+        "humidifier": "увлажнитель",
+        "input_boolean": "переключатель",
+        "siren": "сирена",
+        "water_heater": "бойлер",
+        "light": "лампа",
+        "switch": "переключатель",
+        "script": "скрипт",
+        "remote": "ИК пульт",
+        "lock": "замок",
+        "vacuum": "пылесос",
+        "scene": "сцена",
+        "media_player": "плеер",
+        "lawn_mower": "газонокосилка",
+        "valve": "кран"
+        } %}
+      {% if domain in translations -%}
+        Нет объектов типа {{ translations[domain] }} в {{ area }}
+      {%- else -%}
+        Нет объектов запрашиваемого типа в {{ area }}
+    no_domain_in_floor: |
+      {% set translations = {
+        "button": "кнопка",
+        "camera": "камера",
+        "input_button": "кнопка",
+        "alarm_control_panel": "охрана",
+        "automation": "автоматизация",
+        "fan": "вентилятор",
+        "climate": "термостат",
+        "humidifier": "увлажнитель",
+        "input_boolean": "переключатель",
+        "siren": "сирена",
+        "water_heater": "бойлер",
+        "light": "лампа",
+        "switch": "переключатель",
+        "script": "скрипт",
+        "remote": "ИК пульт",
+        "lock": "замок",
+        "vacuum": "пылесос",
+        "scene": "сцена",
+        "media_player": "плеер",
+        "lawn_mower": "газонокосилка",
+        "valve": "кран"
+        } %}
+      {% if domain in translations -%}
+        Нет объектов типа {{ translations[domain] }} на этаже
+      {%- else -%}
+        Нет объектов запрашиваемого типа на этаже
+
+    no_device_class: |
+      {% set translations = {
+        "awning": "навесы",
+        "blind": "жалюзи",
+        "curtain": "шторы",
+        "door": "двери",
+        "garage": "гаражные ворота",
+        "gate": "ворота",
+        "shade": "рулонные шторы",
+        "shutter": "ставни",
+        "window": "окна"
+        } %}
+      {% if device_class in translations -%}
+        {{ translations[device_class] }} отсутствуют
+      {%- else -%}
+        Отсутствуют объекты класса {{ device_class }}
+      {%- endif %}
+    no_device_class_in_area: |
+      {% set translations = {
+        "awning": "навесы",
+        "blind": "жалюзи",
+        "curtain": "шторы",
+        "door": "двери",
+        "garage": "гаражные ворота",
+        "gate": "ворота",
+        "shade": "рулонные шторы",
+        "shutter": "ставни",
+        "window": "окна"
+        } %}
+      {% if device_class in translations -%}
+        Отсутствуют {{ translations[device_class] }} в {{ area }}
+      {%- else -%}
+        Отсутствуют объекты класса {{ device_class }} в {{ area }}
+      {%- endif %}
+    no_device_class_in_floor: |
+      {% set translations = {
+        "awning": "навесы",
+        "blind": "жалюзи",
+        "curtain": "шторы",
+        "door": "двери",
+        "garage": "гаражные ворота",
+        "gate": "ворота",
+        "shade": "рулонные шторы",
+        "shutter": "ставни",
+        "window": "окна"
+        } %}
+      {% if device_class in translations -%}
+        Отсутствуют {{ translations[device_class] }} на этаже
+      {%- else -%}
+        Отсутствуют объекты класса {{ device_class }} на этаже
+      {%- endif %}
+
+    no_entity: "Отсутстует объект {{ entity }}"
+    no_entity_in_area: "Отсутстует объект {{ entity }} в {{ area }}"
+    no_entity_in_floor: "Отсутстует объект {{ entity }} на этаже"
+    entity_wrong_state: "Нет объектов со статусом {{ state | lower }}"
+    feature_not_supported: "Фунция не поддерживается объектом"
+
+    # Errors for when user is logged in and we can give more information
+    no_entity_exposed: "Доступ к объекту {{ entity }} не предоставлен"
+    no_entity_in_area_exposed: "Доступа к объекту {{ entity }} в {{ area }} не предоставлен"
+    no_entity_in_floor_exposed: "Доступа к объекту {{ entity }} на этаже не предоставлен"
+    no_domain_exposed: "Доступ к {{ domain }} не предоставлен"
+    no_domain_in_area_exposed: "Доступ к {{ domain }} в {{ area }} не предоставлен"
+    no_domain_in_floor_exposed: "Доступ к {{ domain }} на этаже не предоставлен"
+    no_device_class_exposed: "Доступ к {{ device_class }} не предоставлен"
+    no_device_class_in_area_exposed: "Доступ к {{ device_class }} в {{ area }} не предоставлен"
+    no_device_class_in_floor_exposed: "Доступ к {{ device_class }} на этаже не предоставлен"
+
+    # Used when multiple (exposed) devices have the same name
+    duplicate_entities: "Дублирование названий. Несколько объектов {{ entity }}"
+    duplicate_entities_in_area: "Дублирование названий. Несколько объектов {{ entity }} в {{ area }}"
+    duplicate_entities_in_floor: "Дублирование названий. Несколько объектов {{ entity }} на этаже"
+
+    # Errors for timers
+    timer_not_found: "Таймер не найден"
+    multiple_timers_matched: "Коллизия установленных таймеров"
+    no_timer_support: "Таймеры не поддерживаются на данном устройстве"
 lists:
   color:
     values:

--- a/sentences/ru/_common.yaml
+++ b/sentences/ru/_common.yaml
@@ -154,8 +154,8 @@ responses:
 
     # Errors for when user is logged in and we can give more information
     no_entity_exposed: "Доступ к объекту {{ entity }} не предоставлен"
-    no_entity_in_area_exposed: "Доступа к объекту {{ entity }} в {{ area }} не предоставлен"
-    no_entity_in_floor_exposed: "Доступа к объекту {{ entity }} на этаже не предоставлен"
+    no_entity_in_area_exposed: "Доступ к объекту {{ entity }} в {{ area }} не предоставлен"
+    no_entity_in_floor_exposed: "Доступ к объекту {{ entity }} на этаже не предоставлен"
     no_domain_exposed: "Доступ к {{ domain }} не предоставлен"
     no_domain_in_area_exposed: "Доступ к {{ domain }} в {{ area }} не предоставлен"
     no_domain_in_floor_exposed: "Доступ к {{ domain }} на этаже не предоставлен"
@@ -170,7 +170,7 @@ responses:
 
     # Errors for timers
     timer_not_found: "Таймер не найден"
-    multiple_timers_matched: "Коллизия установленных таймеров"
+    multiple_timers_matched: "Ошибка обращения к совпадающим таймерам"
     no_timer_support: "Таймеры не поддерживаются на данном устройстве"
 lists:
   color:


### PR DESCRIPTION
All variants of available errors have been translated.

{{ floor }} для наименования этажей в соответствующих вариантах упустил сознательно, чтоб не получать кривые конструкции в ответе. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced error messages for various scenarios in the Russian localization.
  - Added new error messages for timer-related issues, entity access permissions, and duplicate entities.
  - Improved translations for existing error messages to provide more clarity and detail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->