### PR TITLE
[FR] Make timers great again

### DIFF
--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -309,9 +309,9 @@ responses:
     duplicate_entities_in_floor: "Désolé, plusieurs appareils de cet étage sont nommés {{entity}}"
 
     # Errors for timers
-    timer_not_found: Désole, je n'ai pas trouvé ce minuteur
-    multiple_timers_matched: Désole, je ne peux pas cibler plusieurs minutuers
-    no_timer_support: Désolé, cet appareil ne supporte pas les fonctions lié aux minuteurs.
+    timer_not_found: "Désolé, je n'ai pas trouvé ce minuteur"
+    multiple_timers_matched: "Désolé, je ne peux pas cibler plusieurs minuteurs"
+    no_timer_support: "Désolé, cet appareil ne supporte pas les fonctions lié aux minuteurs"
 
 lists:
   color:

--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -624,16 +624,35 @@ lists:
     range:
       from: 1
       to: 100
+
   timer_minutes:
     range:
       from: 1
       to: 100
+
   timer_hours:
     range:
       from: 1
       to: 100
+
+  timer_words_seconds:
+    values:
+      - in: "un|une"
+        out: "1"
+
+  timer_words_minutes:
+    values:
+      - in: "un|une"
+        out: "1"
+
+  timer_words_hours:
+    values:
+      - in: "un|une"
+        out: "1"
+
   timer_name:
     wildcard: true
+
   timer_command:
     wildcard: true
 
@@ -690,15 +709,32 @@ expansion_rules:
   volume: "(volume|son|watt[s])"
   minuteur: "(compte a rebours)|(compte à rebours)|(minuteur)|(décompte)"
 
-  # Timers
-  timer_duration_seconds: "{timer_seconds:seconds} seconde[s]"
-  timer_duration_minutes: "{timer_minutes:minutes} minute[s][ [et ]{timer_seconds:seconds} seconde[s]]"
-  timer_duration_hours: "{timer_hours:hours} heure[s][ [et ]{timer_minutes:minutes} minute[s]][ [et ]{timer_seconds:seconds} seconde[s]]"
+  ### Timers ###
+  # mix numerical and litteral value for seconds, minutes and hours for the setting of the duration of the timmer
+  nb_seconds_duration: "({timer_seconds:seconds}|{timer_words_seconds:seconds})"
+  nb_minutes_duration: "({timer_minutes:minutes}|{timer_words_minutes:minutes})"
+  nb_hours_duration: "({timer_hours:hours}|{timer_words_hours:hours})"
+
+  # mix numerical and litteral value for seconds, minutes and hours for the request of the status of a timmer by its initial duration
+  nb_seconds_start: "({timer_seconds:start_seconds}|{timer_words_seconds:start_seconds})"
+  nb_minutes_start: "({timer_minutes:start_minutes}|{timer_words_minutes:start_minutes})"
+  nb_hours_start: "({timer_hours:start_hours}|{timer_words_hours:start_hours})"
+
+  # definition of the units for seconds, minutes and hours
+  second_unit: "(seconde|secondes|sec|s)"
+  minute_unit: "(minute|minutes|min|m)"
+  hour_unit: "(heure|heures|h)"
+
+  # definition of all possible values for the setting of the duration of the timmer
+  timer_duration_seconds: "<nb_seconds_duration>[ ]<second_unit>"
+  timer_duration_minutes: "<nb_minutes_duration>[ ]<minute_unit>[[ ][et][ ]<nb_seconds_duration>[ ][<second_unit>]]"
+  timer_duration_hours: "<nb_hours_duration>[ ]<hour_unit>[[ ][et][ ]<nb_minutes_duration>[ ][<minute_unit>]][[ ][et][ ]<nb_seconds_duration>[ ][<second_unit>]]"
   timer_duration: "<timer_duration_seconds>|<timer_duration_minutes>|<timer_duration_hours>"
 
-  timer_start_seconds: "{timer_seconds:start_seconds} seconde[s]"
-  timer_start_minutes: "{timer_minutes:start_minutes} minute[s][ [et ]{timer_seconds:start_seconds} seconde[s]]"
-  timer_start_hours: "{timer_hours:start_hours} heure[s][ [et ]{timer_minutes:start_minutes} minute[s]][ [et ]{timer_seconds:start_seconds} seconde[s]]"
+  # definition of all possible values for the request of the status of a timmer by its initial duration
+  timer_start_seconds: "<nb_seconds_start>[ ]<second_unit>"
+  timer_start_minutes: "<nb_minutes_start>[ ]<minute_unit>[[ ][et][ ]<nb_seconds_start>[ ][<second_unit>]]"
+  timer_start_hours: "<nb_hours_start>[ ]<hour_unit>[[ ][et][ ]<nb_minutes_start>[ ][<minute_unit>]][[ ][et][ ]<nb_seconds_start>[ ][<second_unit>]]"
   timer_start: "<timer_start_seconds>|<timer_start_minutes>|<timer_start_hours>"
 
   # Others

--- a/tests/fr/homeassistant_HassCancelTimer.yaml
+++ b/tests/fr/homeassistant_HassCancelTimer.yaml
@@ -23,7 +23,7 @@ tests:
   # duration
   - sentences:
       - "Supprime le minuteur de 5 minutes"
-      - "Arrête le minuteur de 5 minutes"
+      - "Arrête le minuteur de 5 min"
     intent:
       name: HassCancelTimer
       slots:

--- a/tests/fr/homeassistant_HassDecreaseTimer.yaml
+++ b/tests/fr/homeassistant_HassDecreaseTimer.yaml
@@ -4,7 +4,7 @@ tests:
   # No name
   - sentences:
       - "Enlève 2 minute du minuteur"
-      - "Enlève 2 minute au minuteur"
+      - "Enlève 2 min au minuteur"
       - "Enlève 2 minute sur le minuteur"
     intent:
       name: HassDecreaseTimer
@@ -16,7 +16,7 @@ tests:
   - sentences:
       - "Enlève 2 minute du minuteur de la cuisine"
       - "Enlève 2 minute au minuteur de la cuisine"
-      - "Enlève 2 minute sur le minuteur de la cuisine"
+      - "Enlève 2 min sur le minuteur de la cuisine"
     intent:
       name: HassDecreaseTimer
       slots:
@@ -27,7 +27,7 @@ tests:
   # duration
   - sentences:
       - "Enlève 2 minute du minuteur de 5 minutes"
-      - "Enlève 2 minute au minuteur de 5 minutes"
+      - "Enlève 2 min au minuteur de 5 min"
       - "Enlève 2 minute sur le minuteur de 5 minutes"
     intent:
       name: HassDecreaseTimer

--- a/tests/fr/homeassistant_HassIncreaseTimer.yaml
+++ b/tests/fr/homeassistant_HassIncreaseTimer.yaml
@@ -3,7 +3,7 @@ language: fr
 tests:
   # No name
   - sentences:
-      - "Ajoute 2 minute du minuteur"
+      - "Ajoute 2 min du minuteur"
       - "Ajoute 2 minute au minuteur"
       - "Ajoute 2 minute sur le minuteur"
     intent:
@@ -16,7 +16,7 @@ tests:
   - sentences:
       - "Ajoute 2 minute du minuteur de la cuisine"
       - "Ajoute 2 minute au minuteur de la cuisine"
-      - "Ajoute 2 minute sur le minuteur de la cuisine"
+      - "Ajoute 2 min sur le minuteur de la cuisine"
     intent:
       name: HassIncreaseTimer
       slots:
@@ -27,8 +27,8 @@ tests:
   # duration
   - sentences:
       - "Ajoute 2 minute du minuteur de 5 minutes"
-      - "Ajoute 2 minute au minuteur de 5 minutes"
-      - "Ajoute 2 minute sur le minuteur de 5 minutes"
+      - "Ajoute 2 min au minuteur de 5 min"
+      - "Ajoute 2 minute sur le minuteur de 5 min"
     intent:
       name: HassIncreaseTimer
       slots:
@@ -39,7 +39,7 @@ tests:
   # name
   - sentences:
       - "Ajoute 2 minute du minuteur chocolatine"
-      - "Ajoute 2 minute au minuteur chocolatine"
+      - "Ajoute 2 min au minuteur chocolatine"
       - "Ajoute 2 minute sur le minuteur chocolatine"
     intent:
       name: HassIncreaseTimer

--- a/tests/fr/homeassistant_HassPauseTimer.yaml
+++ b/tests/fr/homeassistant_HassPauseTimer.yaml
@@ -26,9 +26,9 @@ tests:
   # duration
   - sentences:
       - "Mets le minuteur de 5 minutes en pause"
-      - "Mets le minuteur de 5 minutes sur pause"
+      - "Mets le minuteur de 5 min sur pause"
       - "Mets en pause le minuteur de 5 minutes"
-      - "Mets sur pause le minuteur de 5 minutes"
+      - "Mets sur pause le minuteur de 5 min"
     intent:
       name: HassPauseTimer
       slots:

--- a/tests/fr/homeassistant_HassStartTimer.yaml
+++ b/tests/fr/homeassistant_HassStartTimer.yaml
@@ -3,9 +3,9 @@ language: fr
 tests:
   # No name / No Verb
   - sentences:
-      - "Minuteur 5 minutes"
+      - "Minuteur 5 min"
       - "Minuteur pour 5 minutes"
-      - "Minuteur de 5 minutes"
+      - "Minuteur de 5 min"
     intent:
       name: HassStartTimer
       context:
@@ -14,22 +14,42 @@ tests:
         minutes: 5
     response: Minuteur lancé
   - sentences:
-      - "Minuteur d'1 heure"
+      - "Minuteur d'une heure"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Cuisine
+      slots:
+        hours: "1"
+    response: Minuteur lancé
+  - sentences:
+      - "Minuteur 02h16" # Real and problematic STT output for HA Cloud (To be kept in the test suit)
+      - "Minuteur 2 h et 16 Min"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Cuisine
+      slots:
+        hours: 2
+        minutes: 16
+    response: Minuteur lancé
+  - sentences:
+      - "Minuteur 01h30" # Real and problematic STT output for HA Cloud (To be kept in the test suit)
     intent:
       name: HassStartTimer
       context:
         area: Cuisine
       slots:
         hours: 1
+        minutes: 30
     response: Minuteur lancé
-
   # No name / Verb
   - sentences:
       - "Crée un minuteur de 5 minutes"
-      - "Crée un minuteur pour 5 minutes"
+      - "Crée un minuteur pour 5 min"
       - "Démarre un minuteur de 5 minutes"
       - "Démarre un minuteur pour 5 minutes"
-      - "Mets un minuteur de 5 minutes"
+      - "Mets un minuteur de 5 min"
       - "Mets un minuteur pour 5 minutes"
     intent:
       name: HassStartTimer
@@ -39,22 +59,22 @@ tests:
         minutes: 5
     response: Minuteur lancé
   - sentences:
-      - "Crée un minuteur d'1 heure"
-      - "Démarre un minuteur d'1 heure"
-      - "Mets un minuteur d'1 heure"
+      - "Crée un minuteur d'une heure"
+      - "Démarre un minuteur d'une heure"
+      - "Mets un minuteur d'une heure"
     intent:
       name: HassStartTimer
       context:
         area: Cuisine
       slots:
-        hours: 1
+        hours: "1"
     response: Minuteur lancé
 
   # Name / No Verb
   - sentences:
       # - "Minuteur chocolatine 5 minutes"
       - "Minuteur chocolatine pour 5 minutes"
-      - "Minuteur chocolatine de 5 minutes"
+      - "Minuteur chocolatine de 5 min"
       - "Minuteur 5 minutes appelé chocolatine"
       - "Minuteur pour 5 minutes appelé chocolatine"
       - "Minuteur de 5 minutes appelé chocolatine"
@@ -70,15 +90,15 @@ tests:
     response: Minuteur lancé
   - sentences:
       # - "Minuteur chocolatine 1 heure"
-      - "Minuteur chocolatine d'1 heure"
-      - "Minuteur d'1 heure appelé chocolatine"
-      - "Minuteur 1 heure appelé chocolatine"
+      - "Minuteur chocolatine d'une heure"
+      - "Minuteur d'une heure appelé chocolatine"
+      - "Minuteur une heure appelé chocolatine"
     intent:
       name: HassStartTimer
       context:
         area: Cuisine
       slots:
-        hours: 1
+        hours: "1"
         name:
           - "chocolatine "
           - "chocolatine"
@@ -88,16 +108,16 @@ tests:
   - sentences:
       - "Crée un minuteur chocolatine de 5 minutes"
       - "Crée un minuteur chocolatine pour 5 minutes"
-      - "Démarre un minuteur chocolatine de 5 minutes"
+      - "Démarre un minuteur chocolatine de 5 min"
       - "Démarre un minuteur chocolatine pour 5 minutes"
       - "Mets un minuteur chocolatine de 5 minutes"
       - "Mets un minuteur chocolatine pour 5 minutes"
-      - "Crée un minuteur de 5 minutes appelé chocolatine"
+      - "Crée un minuteur de 5 min appelé chocolatine"
       - "Crée un minuteur pour 5 minutes appelé chocolatine"
       - "Démarre un minuteur de 5 minutes appelé chocolatine"
-      - "Démarre un minuteur pour 5 minutes appelé chocolatine"
+      - "Démarre un minuteur pour 5 min appelé chocolatine"
       - "Mets un minuteur de 5 minutes appelé chocolatine"
-      - "Mets un minuteur pour 5 minutes appelé chocolatine"
+      - "Mets un minuteur pour 5 min appelé chocolatine"
     intent:
       name: HassStartTimer
       context:
@@ -109,18 +129,18 @@ tests:
           - "chocolatine"
     response: Minuteur lancé
   - sentences:
-      - "Crée un minuteur chocolatine d'1 heure"
-      - "Démarre un minuteur chocolatine d'1 heure"
-      - "Mets un minuteur chocolatine d'1 heure"
-      - "Crée un minuteur d'1 heure appelé chocolatine"
-      - "Démarre un minuteur d'1 heure appelé chocolatine"
-      - "Mets un minuteur d'1 heure appelé chocolatine"
+      - "Crée un minuteur chocolatine d'une heure"
+      - "Démarre un minuteur chocolatine d'une heure"
+      - "Mets un minuteur chocolatine d'une heure"
+      - "Crée un minuteur d'une heure appelé chocolatine"
+      - "Démarre un minuteur d'une heure appelé chocolatine"
+      - "Mets un minuteur d'une heure appelé chocolatine"
     intent:
       name: HassStartTimer
       context:
         area: Cuisine
       slots:
-        hours: 1
+        hours: "1"
         name:
           - "chocolatine "
           - "chocolatine"

--- a/tests/fr/homeassistant_HassTimerStatus.yaml
+++ b/tests/fr/homeassistant_HassTimerStatus.yaml
@@ -26,7 +26,7 @@ tests:
   # duration
   - sentences:
       - "Combien de temps reste-t-il au minuteur de 5 minutes"
-      - "Combien de temps reste-t-il sur le minuteur de 5 minutes"
+      - "Combien de temps reste-t-il sur le minuteur de 5 min"
       - "Combien de temps reste-t-il dans le minuteur de 5 minutes"
     intent:
       name: HassTimerStatus

--- a/tests/fr/homeassistant_HassUnpauseTimer.yaml
+++ b/tests/fr/homeassistant_HassUnpauseTimer.yaml
@@ -19,6 +19,7 @@ tests:
 
   # duration
   - sentences:
+      - "Reprends le minuteur de 5 min"
       - "Reprends le minuteur de 5 minutes"
     intent:
       name: HassUnpauseTimer


### PR DESCRIPTION
## Context
Timers in French were completely broken (mostly because I went way to fast on my first PR)

## Issues
The standard STT engine of HA Cloud yields very complex results regarding time.
It was challenging to fix.

Here are a few examples:
- `1` is almost always literal. `Minuteur une minute` vs `Minuteur 2 minutes`. This prohibited users from setting 1-minute timers.
- Minutes, Hours, and Seconds are always shortened. This prohibited users from setting ... everything. It was never working
  - `Minuteur 2 min`
  - `Minuteur 2 sec`
  - `Minuteur 2 h`
- Mixing hours and minutes surfaced a new pattern
  - `Minuteur 02h16.` (Notice the lack of the "minute" key and the lack of spacing.)

## Solution
A painful set of expansion rules:

For seconds, minutes, and hours, we now have:
1/ A numerical range
```yaml
  timer_seconds:
    range:
      from: 1
      to: 100
```
2/ A literal list
```yaml
  timer_words_seconds:
    values:
      - in: "un|une"
        out: "1"
```

We then merge them for both duration and start, ie:
```yaml
  nb_seconds_duration: "({timer_seconds:seconds}|{timer_words_seconds:seconds})"
  nb_seconds_start: "({timer_seconds:start_seconds}|{timer_words_seconds:start_seconds})"
```

We use these intermediate expansion rules to define the final duration and start., ie:
```yaml
  timer_duration_seconds: "<nb_seconds_duration>[ ]<second_unit>"
  timer_start_seconds: "<nb_seconds_start>[ ]<second_unit>"
```

There are a small of smaller nuances such as the units that are mandatory for the first key of the tuple (h,m,s) but optional for the rest (To accommodate for the `02h16`), ie:
```yaml
  timer_start_minutes: "<nb_minutes_start>[ ]<minute_unit>[[ ][et][ ]<nb_seconds_start>[ ][<second_unit>]]"
```

The tests have been edited to reflect all this ~~madness~~ complexity




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced timer functionality with more refined error messages and added flexibility in timer configurations (seconds, minutes, hours).
  
- **Bug Fixes**
  - Improved clarity and conciseness in French language phrases for timer commands.

- **Tests**
  - Updated test cases for canceling, decreasing, increasing, pausing, starting, querying, and resuming timers to reflect the phrasing changes for improved consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->