### PR TITLE
A few small fixes

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -365,6 +365,18 @@ HassMediaNext:
       description: "Name of an area"
       required: false
 
+HassMediaPrevious:
+  supported: true
+  domain: media_player
+  description: "Skips a media player back to the previous item"
+  slots:
+    name:
+      description: "Name of a device or entity"
+      required: false
+    area:
+      description: "Name of an area"
+      required: false
+
 HassSetVolume:
   supported: true
   domain: media_player
@@ -379,18 +391,6 @@ HassSetVolume:
     volume_level:
       description: "Volume level from 0 to 100"
       required: true
-
-HassMediaPrevious:
-  supported: false
-  domain: media_player
-  description: "Skips a media player back to the previous item"
-  slots:
-    name:
-      description: "Name of a device or entity"
-      required: false
-    area:
-      description: "Name of an area"
-      required: false
 
 # -----------------------------------------------------------------------------
 # timers

--- a/sentences/en/homeassistant_HassStartTimer.yaml
+++ b/sentences/en/homeassistant_HassStartTimer.yaml
@@ -8,11 +8,11 @@ intents:
           - "timer for <timer_duration>"
           - "<timer_duration> timer for {timer_name:name}"
           - "timer for <timer_duration> (named|called) {timer_name:name}"
-          - "<timer_set>[ a] <timer_duration> timer"
-          - "<timer_set>[ a] timer for <timer_duration>"
-          - "<timer_set>[ a] <timer_duration> timer (named|called|for) {timer_name:name}"
-          - "<timer_set>[ a] timer (named|called) {timer_name:name} for <timer_duration>"
-          - "<timer_set>[ a] timer for <timer_duration> (named|called) {timer_name:name}"
+          - "<timer_set>[ a| the| my] <timer_duration> timer"
+          - "<timer_set>[ a| the| my] timer for <timer_duration>"
+          - "<timer_set>[ a| the| my] <timer_duration> timer (named|called|for) {timer_name:name}"
+          - "<timer_set>[ a| the| my] timer (named|called) {timer_name:name} for <timer_duration>"
+          - "<timer_set>[ a| the| my] timer for <timer_duration> (named|called) {timer_name:name}"
         requires_context:
           area:
             slot: false


### PR DESCRIPTION
* Mark `HassMediaPrevious` as supported
* Add "the/my" to create timer sentences (English)
* Add `--all` option to parse script to show all possible matches (not just the first)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced `media_player` domain functionality by swapping `HassMediaPrevious` and `HassSetVolume` intents.
  - `HassMediaPrevious` now skips back to the previous item.
  - `HassSetVolume` now sets the volume with `volume_level` as a required slot.

- **Improvements**
  - Refined timer setting expressions in Home Assistant to include variations with different determiners ("a," "the," "my").

- **Bug Fixes**
  - Improved sentence parsing by listing all possible matches and including `text_chunks_matched` in the output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->