### PR TITLE
[EN] Add half an hour/minute for timers

### DIFF
--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -349,6 +349,10 @@ lists:
     range:
       from: 1
       to: 100
+  timer_half:
+    values:
+      - in: "half"
+        out: 30
   timer_name:
     wildcard: true
   timer_command:
@@ -386,8 +390,8 @@ expansion_rules:
   timer_set: "(start|set|create)"
   timer_cancel: "(cancel|stop)"
   timer_duration_seconds: "{timer_seconds:seconds} second[s]"
-  timer_duration_minutes: "{timer_minutes:minutes} minute[s][ [and ]{timer_seconds:seconds} second[s]]"
-  timer_duration_hours: "{timer_hours:hours} hour[s][ [and ]{timer_minutes:minutes} minute[s]][ [and ]{timer_seconds:seconds} second[s]]"
+  timer_duration_minutes: "({timer_minutes:minutes} minute[s][ [and ]{timer_seconds:seconds} second[s]])|({timer_minutes:minutes} and[ a] {timer_half:seconds} minute[s])|({timer_half:seconds} a minute[s])"
+  timer_duration_hours: "({timer_hours:hours} hour[s][ [and ]{timer_minutes:minutes} minute[s]][ [and ]{timer_seconds:seconds} second[s]])|({timer_hours:hours} and[ a] {timer_half:minutes} hour[s])|({timer_half:minutes} an hour[s])"
   timer_duration: "<timer_duration_seconds>|<timer_duration_minutes>|<timer_duration_hours>"
 
   timer_start_seconds: "{timer_seconds:start_seconds} second[s]"

--- a/tests/en/homeassistant_HassStartTimer.yaml
+++ b/tests/en/homeassistant_HassStartTimer.yaml
@@ -16,6 +16,48 @@ tests:
     response: Timer started
 
   - sentences:
+      - "set a timer for 5 and a half minutes"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        minutes: 5
+        seconds: 30
+    response: Timer started
+
+  - sentences:
+      - "set a timer for half a minute"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        seconds: 30
+    response: Timer started
+
+  - sentences:
+      - "set a timer for 1 and a half hours"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        hours: 1
+        minutes: 30
+    response: Timer started
+
+  - sentences:
+      - "set a timer for half an hour"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        minutes: 30
+    response: Timer started
+
+  - sentences:
       - "start a 1 hour and 15 minute timer"
       - "timer for 1 hour and 15 minutes"
       - "set timer for 1 hour and 15 minutes"


### PR DESCRIPTION
Adds support for sentences like "start a timer for 1 and a half hours" and "start a timer for 3 and a half minutes"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced timer duration input to support natural language patterns like "half an hour" or "a minute and a half".
	- Introduced new time unit "half" for more intuitive timer settings.

- **Tests**
	- Added test cases for new timer settings such as 5.5 minutes, half a minute, 1.5 hours, and half an hour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->