### PR TITLE
[EN] Add "1/2" alongside "half"

### DIFF
--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -353,6 +353,8 @@ lists:
     values:
       - in: "half"
         out: 30
+      - in: "1/2"
+        out: 30
   timer_name:
     wildcard: true
   timer_command:

--- a/tests/en/homeassistant_HassStartTimer.yaml
+++ b/tests/en/homeassistant_HassStartTimer.yaml
@@ -28,6 +28,7 @@ tests:
 
   - sentences:
       - "set a timer for half a minute"
+      - "set a timer for 1/2 a minute"
     intent:
       name: HassStartTimer
       context:
@@ -38,6 +39,7 @@ tests:
 
   - sentences:
       - "set a timer for 1 and a half hours"
+      - "set a timer for 1 and a 1/2 hours"
     intent:
       name: HassStartTimer
       context:
@@ -49,6 +51,7 @@ tests:
 
   - sentences:
       - "set a timer for half an hour"
+      - "set a timer for 1/2 an hour"
     intent:
       name: HassStartTimer
       context:


### PR DESCRIPTION
HA cloud transcribes "half" and "1/2" sometimes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced input recognition in lists to support "1/2" as "half" with a value of 30.

- **Tests**
  - Updated test sentences for setting timers in Home Assistant to include fractional and decimal variations:
    - "set a timer for 1/2 a minute"
    - "set a timer for 1 and a 1/2 hours"
    - "set a timer for 1/2 an hour"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->