### PR TITLE
[EN] Don't require area to start a timer

### DIFF
--- a/sentences/en/homeassistant_HassStartTimer.yaml
+++ b/sentences/en/homeassistant_HassStartTimer.yaml
@@ -13,9 +13,6 @@ intents:
           - "<timer_set>[ a| the| my] <timer_duration> timer (named|called|for) {timer_name:name}"
           - "<timer_set>[ a| the| my] timer (named|called) {timer_name:name} for <timer_duration>"
           - "<timer_set>[ a| the| my] timer for <timer_duration> (named|called) {timer_name:name}"
-        requires_context:
-          area:
-            slot: false
       - sentences:
           - "{timer_command:conversation_command} in <timer_duration>"
           - "in <timer_duration> {timer_command:conversation_command}"

--- a/tests/en/homeassistant_HassStartTimer.yaml
+++ b/tests/en/homeassistant_HassStartTimer.yaml
@@ -2,6 +2,14 @@
 language: en
 tests:
   - sentences:
+      - "10 minute timer"
+    intent:
+      name: HassStartTimer
+      slots:
+        minutes: 10
+    response: Timer started
+
+  - sentences:
       - "start a 1 hour timer"
       - "set timer for 1 hour"
       - "create 1 hour timer"


### PR DESCRIPTION
Remove requirement to have a context area to start a timer. The satellite will still need to support timers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced timer functionality with simplified command structures for easier use in Home Assistant.
  - Added a test case for starting a 10-minute timer to ensure reliability.

- **Bug Fixes**
  - Removed the `requires_context` requirement within timer setting commands for improved performance and simplification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->