### PR TITLE
Add zh-hk leader

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -170,6 +170,10 @@ sentences/zh-cn/ @al-one
 responses/zh-cn/ @al-one
 tests/zh-cn/ @al-one
 
+sentences/zh-hk/ @swonge
+responses/zh-hk/ @swonge
+tests/zh-hk/ @swonge
+
 sentences/zh-tw/ @bluefoxlee
 responses/zh-tw/ @bluefoxlee
 tests/zh-tw/ @bluefoxlee

--- a/languages.yaml
+++ b/languages.yaml
@@ -212,6 +212,8 @@ zh-cn:
     - al-one
 zh-hk:
   nativeName: 繁體中文（香港）
+  leaders:
+    - swonge
 zh-tw:
   nativeName: 繁體中文（台灣）
   leaders:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Chinese (Hong Kong) language, including sentence and response directories.
  
- **Chores**
  - Assigned `@swonge` as the leader for Chinese (Hong Kong) language support in the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->