### PR TITLE
[DE] Don't require area to start a timer

### DIFF
--- a/sentences/de/homeassistant_HassStartTimer.yaml
+++ b/sentences/de/homeassistant_HassStartTimer.yaml
@@ -12,9 +12,6 @@ intents:
           - "<timer_set>[ einen] <timer_duration> Timer namens {timer_name:name}"
           - "<timer_set>[ einen] Timer namens {timer_name:name} für <timer_duration>"
           - "<timer_set>[ einen] Timer für <timer_duration> namens {timer_name:name}"
-        requires_context:
-          area:
-            slot: false
       - sentences:
           - "{timer_command:conversation_command} in <timer_duration>"
           - "in <timer_duration> {timer_command:conversation_command}"

--- a/tests/de/homeassistant_HassStartTimer.yaml
+++ b/tests/de/homeassistant_HassStartTimer.yaml
@@ -2,6 +2,18 @@
 language: de
 tests:
   - sentences:
+      - "Starte einen 2 Stunden Timer"
+      - "Stelle Timer für 2 Stunden"
+      - "Erstelle 2 Stunden Timer"
+      - "2 Stunden Timer"
+      - "Timer für 2 Stunden"
+    intent:
+      name: HassStartTimer
+      slots:
+        hours: 2
+    response: Timer gestartet
+
+  - sentences:
       - "Starte einen 1 Stunde Timer"
       - "Stelle Timer für 1 Stunde"
       - "Erstelle 1 Stunde Timer"


### PR DESCRIPTION
see https://github.com/home-assistant/intents/pull/2257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced test coverage for starting 2-hour timers in German, improving the robustness of timer-related commands.
  
- **Refactor**
	- Simplified the structure of timer commands by removing the `requires_context` section with `area` slot under `intents`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->