### PR TITLE
[FR] Add delay command in french

### DIFF
--- a/responses/fr/HassStartTimer.yaml
+++ b/responses/fr/HassStartTimer.yaml
@@ -4,3 +4,4 @@ responses:
   intents:
     HassStartTimer:
       default: "Minuteur lancé"
+      command: "Commande reçue"

--- a/sentences/fr/homeassistant_HassStartTimer.yaml
+++ b/sentences/fr/homeassistant_HassStartTimer.yaml
@@ -13,9 +13,6 @@ intents:
           - "<minuteur> de <timer_duration>"
           # Minuteur d'une heure
           - "<minuteur> d'<timer_duration>"
-        requires_context:
-          area:
-            slot: false
 
       # No name / Verb
       - sentences:
@@ -37,9 +34,6 @@ intents:
           - "<mets> un <minuteur> d'<timer_duration>"
           # Mets un minuteur pour 5 minute
           - "<mets> un <minuteur> pour <timer_duration>"
-        requires_context:
-          area:
-            slot: false
 
       # Name / No Verb
       - sentences:
@@ -59,9 +53,6 @@ intents:
           - "<minuteur> de <timer_duration> <appele> {timer_name:name}"
           # Minuteur d'une heure appelé Pizza
           - "<minuteur> d'<timer_duration> <appele> {timer_name:name}"
-        requires_context:
-          area:
-            slot: false
         expansion_rules:
           appele: "(appelé|nommé|surnomé)"
 
@@ -103,8 +94,12 @@ intents:
           - "<mets> un <minuteur> d'<timer_duration> <appele> {timer_name:name}"
           # Mets un minuteur pour 5 minute appelé Pizza
           - "<mets> un <minuteur> pour <timer_duration> <appele> {timer_name:name}"
-        requires_context:
-          area:
-            slot: false
         expansion_rules:
           appele: "(appelé|nommé|surnomé)"
+
+      - sentences:
+          # "Ouvre les volets du salon dans 5 minutes"
+          - "{timer_command:conversation_command} dans <timer_duration>"
+          # "Dans 5 minutes allume la lumière du salon"
+          - "Dans <timer_duration> {timer_command:conversation_command}"
+        response: command

--- a/tests/fr/homeassistant_HassStartTimer.yaml
+++ b/tests/fr/homeassistant_HassStartTimer.yaml
@@ -145,3 +145,15 @@ tests:
           - "chocolatine "
           - "chocolatine"
     response: Minuteur lancé
+
+  - sentences:
+      - "Ouvre les volets du salon dans 5 minutes"
+      - "Dans 5 min, ouvre les volets du salon"
+    intent:
+      name: HassStartTimer
+      slots:
+        minutes: 5
+        conversation_command:
+          - "ouvre les volets du salon"
+          - "ouvre les volets du salon "
+    response: Commande reçue


### PR DESCRIPTION
Add delay command in french

I also removed the `requires_context` for start timer to match english sentences.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new French response message to the `HassStartTimer` intent with a command confirmation.
  - Introduced new timer command intents for setting timers with specific actions in Home Assistant.

- **Tests**
  - Added a new test case for starting a timer to perform specific actions, such as opening the living room blinds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->