### PR TITLE
[ES] Timer halves & quarters, and HassMediaPrevious intent

### DIFF
--- a/responses/es/HassMediaPrevious.yaml
+++ b/responses/es/HassMediaPrevious.yaml
@@ -1,0 +1,5 @@
+language: es
+responses:
+  intents:
+    HassMediaPrevious:
+      default: "Reproduciendo pista anterior"

--- a/sentences/es/_common.yaml
+++ b/sentences/es/_common.yaml
@@ -507,7 +507,7 @@ lists:
         out: 1
   timer_half:
     values:
-      - in: "medi[oa]"
+      - in: "medi(o|a)"
         out: 30
       - in: "1/2"
         out: 30
@@ -528,7 +528,7 @@ lists:
 expansion_rules:
   abre: "(abr(a|e|ir|í)|<sube>)"
   ahora: "[ahora [mismo]|actual[mente]|en este momento]"
-  anterior: "(anterior|última)"
+  anterior: "(anterior|últim(o|a))"
   añadir: "(añad(a|e|ir|í)|apunt[a|e|ar|á]|pon[ga|er|é]|sum(e|a|ar|á))"
   apaga: "(apag(a|ue|ar|á)|desconect(a|e|ar|á)|desactiv(a|e|ar|á))"
   area: "[en|del|de] [el|la] {area}"
@@ -562,13 +562,13 @@ expansion_rules:
   posición: "{position}[ ][%|por[ ]cien[to]]"
   puerta: "[el|la] (puerta|portón|cancela|verja|reja|compuerta|portillo)"
   quita: "quit(a|e|ar|á)"
-  reproduce: "(reprodu(ce|cir|cí|zca)|escuchar|oir|ver|visualizar)"
+  reproduce: "(reprodu(ce|cir|cí|zca)|escuchar|o(i|í)r|ver|visualizar)"
   resta: "(rest(a|e|ar|á))"
   salta: "(salt(a|e|ar|á))"
   se_encuentra: "(se (encuentra|localiza|ubica)|está|mora)"
   sube: "(sub(a|e|ir|í)|levant(a|e|ar|á)|aument(a|e|ar|á)|increment(a|e|ar|á))"
   temp: "[el|la] (temperatura|calor|grados)"
-  temperature: "{temperature}[([ ]°[ ][{temperature_unit}])|( grados[ {temperature_unit}])]"
+  temperature: "{temperature}[([ ]°[ ][{temperature_unit}])|( {temperature_unit})|( grados[ {temperature_unit}])]"
   temporizador: "[el |la ](temporizador|cuenta atrás)"
   temporizadores: "[el |la |l(o|a)s ](temporizador[es]|cuenta[s] atrás)"
   volumen: "{volume:volume_level}[ ][%|por[ ]cien[to]]"
@@ -597,8 +597,8 @@ expansion_rules:
   nb_start_hours: "({timer_hours:start_hours}|{timer_words_hours:start_hours})"
 
   timer_duration_seconds: "<nb_seconds> segundo[s]"
-  timer_duration_minutes: "(<nb_minutes> minuto[s][[,] [y ]<timer_duration_seconds>])|(<nb_minutes> minuto[s] y {timer_half:seconds})|({timer_half:seconds} minuto)"
-  timer_duration_hours: "(<nb_hours> hora[s][[,] [y ]<timer_duration_minutes>]|(<nb_hours> hora[s] y {timer_half:minutes})|({timer_half:minutes} hora[[,] [y ]<timer_duration_seconds>]"
+  timer_duration_minutes: "((<nb_minutes> minuto[s][[,] [y ]<timer_duration_seconds>])|(<nb_minutes> minuto[s] y {timer_half:seconds})|({timer_half:seconds} minuto))"
+  timer_duration_hours: "(<nb_hours> hora[s][[,] [y ]<timer_duration_minutes>]|(<nb_hours> hora[s] y {timer_half:minutes}[[,] y (<timer_duration_seconds>|{timer_half:seconds} minuto)])|({timer_half:minutes} hora[[,] y (<timer_duration_seconds>|{timer_half:seconds} minuto)]))"
   timer_duration: "<timer_duration_seconds>|<timer_duration_minutes>|<timer_duration_hours>"
 
   timer_start_seconds: "[el |los ]<nb_start_seconds> segundo[s]"

--- a/sentences/es/_common.yaml
+++ b/sentences/es/_common.yaml
@@ -505,6 +505,21 @@ lists:
     values:
       - in: "un|una"
         out: 1
+  timer_half:
+    values:
+      - in: "medi[oa]"
+        out: 30
+      - in: "1/2"
+        out: 30
+      - in: "[un |1 ]cuarto[ de]"
+        out: 15
+      - in: "(tres|3) cuartos[ de]"
+        out: 45
+      - in: "1/4"
+        out: 15
+      - in: "3/4"
+        out: 45
+
   timer_name:
     wildcard: true
   timer_command:
@@ -513,6 +528,7 @@ lists:
 expansion_rules:
   abre: "(abr(a|e|ir|í)|<sube>)"
   ahora: "[ahora [mismo]|actual[mente]|en este momento]"
+  anterior: "(anterior|última)"
   añadir: "(añad(a|e|ir|í)|apunt[a|e|ar|á]|pon[ga|er|é]|sum(e|a|ar|á))"
   apaga: "(apag(a|ue|ar|á)|desconect(a|e|ar|á)|desactiv(a|e|ar|á))"
   area: "[en|del|de] [el|la] {area}"
@@ -538,6 +554,7 @@ expansion_rules:
   luces: "[el|la|l(a|o)s] (luz|luces|lámpara[s]|bombill(a|o)[s]|ampolleta[s]|luminaria[s]|lamparilla[s]|foco[s]|interruptor[es]|llave[s][ de la luz])"
   mide: "[que] ([es|está] (mid(e|ie)|medi|indica|marca)[ndo|d(a|o)]|tiene|hay) [por|en]"
   name: "[el|la|los|las] {name}"
+  otra_vez: "(otra vez|de nuevo|una vez más)"
   pausa: "(paus(a|ar|e|á)|<para>)"
   para: "(par(a|ar|e|á))|det(én|ener|enga|ené)"
   planta: "[en|del|de] [el|la] ([planta|piso] {floor}|{floor} (planta|piso))"
@@ -551,10 +568,11 @@ expansion_rules:
   se_encuentra: "(se (encuentra|localiza|ubica)|está|mora)"
   sube: "(sub(a|e|ir|í)|levant(a|e|ar|á)|aument(a|e|ar|á)|increment(a|e|ar|á))"
   temp: "[el|la] (temperatura|calor|grados)"
-  temperature: "{temperature} [grados] [{temperature_unit}]"
+  temperature: "{temperature}[([ ]°[ ][{temperature_unit}])|( grados[ {temperature_unit}])]"
   temporizador: "[el |la ](temporizador|cuenta atrás)"
   temporizadores: "[el |la |l(o|a)s ](temporizador[es]|cuenta[s] atrás)"
   volumen: "{volume:volume_level}[ ][%|por[ ]cien[to]]"
+  vuelve: "((vuelve|vuelva|volver|volvé)|(regres(a|e|ar|á))|(retorn(a|e|ar|á))|(retroced(e|a|er|é)))"
 
   # Context awareness expansion rules
   habitación: "(habitaci(ón|ones)|pieza[s]|cuarto[s]|aposento[s]|sala[s]|[re]cámara[s])"
@@ -579,8 +597,8 @@ expansion_rules:
   nb_start_hours: "({timer_hours:start_hours}|{timer_words_hours:start_hours})"
 
   timer_duration_seconds: "<nb_seconds> segundo[s]"
-  timer_duration_minutes: "<nb_minutes> minuto[s][[,] [y ]<nb_seconds> segundo[s]]"
-  timer_duration_hours: "<nb_hours> hora[s][[,] [y ]<nb_minutes> minuto[s]][[,] [y ]<nb_seconds> segundo[s]]"
+  timer_duration_minutes: "(<nb_minutes> minuto[s][[,] [y ]<timer_duration_seconds>])|(<nb_minutes> minuto[s] y {timer_half:seconds})|({timer_half:seconds} minuto)"
+  timer_duration_hours: "(<nb_hours> hora[s][[,] [y ]<timer_duration_minutes>]|(<nb_hours> hora[s] y {timer_half:minutes})|({timer_half:minutes} hora[[,] [y ]<timer_duration_seconds>]"
   timer_duration: "<timer_duration_seconds>|<timer_duration_minutes>|<timer_duration_hours>"
 
   timer_start_seconds: "[el |los ]<nb_start_seconds> segundo[s]"

--- a/sentences/es/homeassistant_HassStartTimer.yaml
+++ b/sentences/es/homeassistant_HassStartTimer.yaml
@@ -4,9 +4,9 @@ intents:
   HassStartTimer:
     data:
       - sentences:
-          - "[<timer_set> ][un[a] ]<temporizador>[[ dentro] de| en| para] <timer_duration>"
-          - "[<timer_set> ][un[a] ]<temporizador>[ de| con nombre| llamad(o|a)| denominad(o|a)| para] {timer_name:name}[[ dentro] de| en| para] <timer_duration>"
-          - "[<timer_set> ][un[a] ]<temporizador>[[ dentro] de| en| para] <timer_duration>[ de| con nombre| llamad(o|a)| denominad(o|a)| para] {timer_name:name}"
+          - "[<timer_set> ][un[a] |mi]<temporizador>[[ dentro] de| en| para] <timer_duration>"
+          - "[<timer_set> ][un[a] |mi]<temporizador>[ de| con nombre| llamad(o|a)| denominad(o|a)| para] {timer_name:name}[[ dentro] de| en| para] <timer_duration>"
+          - "[<timer_set> ][un[a] |mi]<temporizador>[[ dentro] de| en| para] <timer_duration>[ de| con nombre| llamad(o|a)| denominad(o|a)| para] {timer_name:name}"
         requires_context:
           area:
             slot: false

--- a/sentences/es/media_player_HassMediaPrevious.yaml
+++ b/sentences/es/media_player_HassMediaPrevious.yaml
@@ -1,0 +1,23 @@
+language: es
+intents:
+  HassMediaPrevious:
+    data:
+      - sentences:
+          - "([<reproduce>] [<otra_vez> ][el |la ]([<pista> ]<anterior>|<anterior> <pista>)[ <otra_vez>]|<reproduce> <otra_vez>) [en |para ]<name>"
+          - "(<salta>|<vuelve>) [a <reproduce> ][<otra_vez> ](a[l] [el |la ](<anterior> [<pista>]|<pista> <anterior>)[ <otra_vez>] [en |para ]<name>"
+        requires_context:
+          domain: media_player
+      - sentences:
+          - "([<reproduce>] [<otra_vez> ][el |la ](<pista> <anterior>|<anterior> <pista>)[ <otra_vez>]|<reproduce> <otra_vez>)"
+          - "(<salta>|<vuelve>) [a <reproduce> ][<otra_vez> ]a[l] [el |la ](<anterior> [<pista>]|<pista> <anterior>)[ <otra_vez>]"
+        requires_context:
+          area:
+            slot: true
+      - sentences:
+          - "([<reproduce>] [<otra_vez> ][el |la ]([<pista> ]<anterior>|<anterior> <pista>)[ <otra_vez>]|<reproduce> <otra_vez>) <area>"
+          - "<area> ([<reproduce>] [<otra_vez> ][el |la ]([<pista> ]<anterior>|<anterior> <pista>)[ <otra_vez>]|<reproduce> <otra_vez>)"
+          - "(<reproduce> <area> [<otra_vez> ][el |la ]([<pista> ]<anterior>|<anterior> <pista>)[ <otra_vez>]|<reproduce> <area> <otra_vez>)"
+          - "<reproduce> <otra_vez> <area> [el |la ]([<pista> ]<anterior>|<anterior> <pista>)[ <otra_vez>]"
+          - "(<salta>|<vuelve>) [a <reproduce> ][<otra_vez> ]a[l] [el |la ](<anterior> [<pista>]|<pista> <anterior>)[ <otra_vez>] <area>"
+          - "<area> (<salta>|<vuelve>) [a <reproduce> ][<otra_vez> ]a[l] [el |la ](<anterior> [<pista>]|<pista> <anterior>)[ <otra_vez>]"
+          - "(<salta>|<vuelve>) [a <reproduce> ]<area> [<otra_vez> ]a[l] [el |la ](<anterior> [<pista>]|<pista> <anterior>)[ <otra_vez>]"

--- a/sentences/es/media_player_HassMediaPrevious.yaml
+++ b/sentences/es/media_player_HassMediaPrevious.yaml
@@ -4,12 +4,12 @@ intents:
     data:
       - sentences:
           - "([<reproduce>] [<otra_vez> ][el |la ]([<pista> ]<anterior>|<anterior> <pista>)[ <otra_vez>]|<reproduce> <otra_vez>) [en |para ]<name>"
-          - "(<salta>|<vuelve>) [a <reproduce> ][<otra_vez> ](a[l] [el |la ](<anterior> [<pista>]|<pista> <anterior>)[ <otra_vez>] [en |para ]<name>"
+          - "(<salta>|<vuelve>) a[l] [<reproduce> ][<otra_vez> ][el |la ](<anterior> [<pista>]|<pista> <anterior>)[ <otra_vez>] [en |para ]<name>"
         requires_context:
           domain: media_player
       - sentences:
           - "([<reproduce>] [<otra_vez> ][el |la ](<pista> <anterior>|<anterior> <pista>)[ <otra_vez>]|<reproduce> <otra_vez>)"
-          - "(<salta>|<vuelve>) [a <reproduce> ][<otra_vez> ]a[l] [el |la ](<anterior> [<pista>]|<pista> <anterior>)[ <otra_vez>]"
+          - "(<salta>|<vuelve>) a[l] [<reproduce> ][<otra_vez> ][el |la ](<anterior> [<pista>]|<pista> <anterior>)[ <otra_vez>]"
         requires_context:
           area:
             slot: true
@@ -18,6 +18,6 @@ intents:
           - "<area> ([<reproduce>] [<otra_vez> ][el |la ]([<pista> ]<anterior>|<anterior> <pista>)[ <otra_vez>]|<reproduce> <otra_vez>)"
           - "(<reproduce> <area> [<otra_vez> ][el |la ]([<pista> ]<anterior>|<anterior> <pista>)[ <otra_vez>]|<reproduce> <area> <otra_vez>)"
           - "<reproduce> <otra_vez> <area> [el |la ]([<pista> ]<anterior>|<anterior> <pista>)[ <otra_vez>]"
-          - "(<salta>|<vuelve>) [a <reproduce> ][<otra_vez> ]a[l] [el |la ](<anterior> [<pista>]|<pista> <anterior>)[ <otra_vez>] <area>"
-          - "<area> (<salta>|<vuelve>) [a <reproduce> ][<otra_vez> ]a[l] [el |la ](<anterior> [<pista>]|<pista> <anterior>)[ <otra_vez>]"
-          - "(<salta>|<vuelve>) [a <reproduce> ]<area> [<otra_vez> ]a[l] [el |la ](<anterior> [<pista>]|<pista> <anterior>)[ <otra_vez>]"
+          - "(<salta>|<vuelve>) a[l] [<reproduce> ][<otra_vez> ][el |la ](<anterior> [<pista>]|<pista> <anterior>)[ <otra_vez>] <area>"
+          - "<area> (<salta>|<vuelve>) a[l] [a <reproduce> ][<otra_vez> ][el |la ](<anterior> [<pista>]|<pista> <anterior>)[ <otra_vez>]"
+          - "(<salta>|<vuelve>) a[l] [<reproduce> ]<area> [<otra_vez> ][el |la ](<anterior> [<pista>]|<pista> <anterior>)[ <otra_vez>]"

--- a/tests/es/homeassistant_HassStartTimer.yaml
+++ b/tests/es/homeassistant_HassStartTimer.yaml
@@ -28,8 +28,8 @@ tests:
     response: Temporizador iniciado
 
   - sentences:
-      - "inicia temporizador de medio minuto"
       - "comenzar cuenta atrás de 30 segundos"
+      - "inicia temporizador de medio minuto"
     intent:
       name: HassStartTimer
       context:
@@ -52,15 +52,16 @@ tests:
     response: Temporizador iniciado
 
   - sentences:
-      - "cuenta atrás de 1 hora y 30 segundos"
-      - "inicia temporizador de 1 hora y medio minuto"
-      - "temporizador en una hora y 30 segundos"
+      - "temporizador en una hora 30 minutos y 30 segundos"
+      - "inicia temporizador de 1 hora y media y medio minuto"
+      - "cuenta atrás de 1 hora y 30 minutos y medio"
     intent:
       name: HassStartTimer
       context:
         area: Salón
       slots:
         hours: 1
+        minutes: 30
         seconds: 30
     response: Temporizador iniciado
 

--- a/tests/es/homeassistant_HassStartTimer.yaml
+++ b/tests/es/homeassistant_HassStartTimer.yaml
@@ -16,8 +16,31 @@ tests:
     response: Temporizador iniciado
 
   - sentences:
+      - "inicia temporizador de 1 hora y 45 minutos"
+      - "comenzar cuenta atrás de 1 hora y tres cuartos"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Salón
+      slots:
+        hours: 1
+        minutes: 45
+    response: Temporizador iniciado
+
+  - sentences:
+      - "inicia temporizador de medio minuto"
+      - "comenzar cuenta atrás de 30 segundos"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Salón
+      slots:
+        seconds: 30
+    response: Temporizador iniciado
+
+  - sentences:
       - "comienza una cuenta atrás de 1 hora y 15 minutos"
-      - "establecer temporizador de 1 hora y 15 minutos"
+      - "establecer temporizador de 1 hora y cuarto"
       - "temporizador en una hora y 15 minutos"
     intent:
       name: HassStartTimer
@@ -30,7 +53,7 @@ tests:
 
   - sentences:
       - "cuenta atrás de 1 hora y 30 segundos"
-      - "inicia temporizador de 1 hora y 30 segundos"
+      - "inicia temporizador de 1 hora y medio minuto"
       - "temporizador en una hora y 30 segundos"
     intent:
       name: HassStartTimer
@@ -43,8 +66,8 @@ tests:
 
   - sentences:
       - "comenzar un temporizador de 1 hora 15 minutos y 30 segundos"
-      - "cuenta atrás de una hora 15 minutos 30 segundos"
-      - "establecer temporizador para 1 hora, 15 minutos, y 30 segundos"
+      - "cuenta atrás de una hora 15 minutos y medio"
+      - "establecer temporizador para 1 hora y cuarto, y 30 segundos"
     intent:
       name: HassStartTimer
       context:

--- a/tests/es/media_player_HassMediaPrevious.yaml
+++ b/tests/es/media_player_HassMediaPrevious.yaml
@@ -1,0 +1,39 @@
+language: es
+tests:
+  - sentences:
+      - "reproducir anterior en TV"
+      - "vuelve a última pista en TV"
+      - "reproducir de nuevo en la TV"
+      - "escuchar canción anterior otra vez en la TV"
+    intent:
+      name: HassMediaPrevious
+      slots:
+        name: "TV"
+    response: "Reproduciendo pista anterior"
+  - sentences:
+      - "retrocede"
+      - "volver a canción anterior"
+      - "reproduce último tema de nuevo"
+      - "ver otra vez el último medio"
+      - "reproducir una vez más"
+      - "oír de nuevo"
+    intent:
+      name: HassMediaPrevious
+      slots:
+        area: "Salón"
+      context:
+        area: Salón
+    response: "Reproduciendo pista anterior"
+  - sentences:
+      - "regresar en el salón"
+      - "volver a escuchar la última canción en el salón"
+      - "oir canción anterior en el salón"
+      - "retrocede al último tema en salón"
+      - "en el salón ver otra vez el último video"
+    intent:
+      name: HassMediaPrevious
+      slots:
+        area: "Salón"
+      context:
+        area: Salón
+    response: "Reproduciendo pista anterior"

--- a/tests/es/media_player_HassMediaPrevious.yaml
+++ b/tests/es/media_player_HassMediaPrevious.yaml
@@ -11,7 +11,6 @@ tests:
         name: "TV"
     response: "Reproduciendo pista anterior"
   - sentences:
-      - "retrocede"
       - "volver a canción anterior"
       - "reproduce último tema de nuevo"
       - "ver otra vez el último medio"
@@ -25,7 +24,7 @@ tests:
         area: Salón
     response: "Reproduciendo pista anterior"
   - sentences:
-      - "regresar en el salón"
+      - "reproducir tema anterior en el salón"
       - "volver a escuchar la última canción en el salón"
       - "oir canción anterior en el salón"
       - "retrocede al último tema en salón"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Spanish language support for playing the previous media track or episode.
  - Enhanced timer functionality with new time representations and expressions in Spanish.

- **Improvements**
  - Personalized timer setting by allowing the optional word "mi" before `<temporizador>`.
  - Expanded timer duration definitions and common phrases for improved context awareness.

- **Tests**
  - Introduced test cases for media playback control and timer initiation in Spanish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->