### PR TITLE
[DE] add queries for window states

### DIFF
--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -185,7 +185,7 @@ lists:
       - in: "(auf|offen|geöffnet)"
         out: "on"
       - in: "(zu|geschlossen)"
-        out: "closed"
+        out: "off"
   bs_gas_states:
     values:
       - in: "<erkannt>"

--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -182,7 +182,7 @@ lists:
         out: "off"
   bs_window_states:
     values:
-      - in: "(auf|offen|geöffnet)"
+      - in: "(auf|offen|geöffnet|gekippt)"
         out: "on"
       - in: "(zu|geschlossen)"
         out: "off"

--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -180,6 +180,12 @@ lists:
         out: "on"
       - in: "(zu|geschlossen|unten)"
         out: "off"
+  bs_window_states:
+    values:
+      - in: "(auf|offen|geöffnet)"
+        out: "on"
+      - in: "(zu|geschlossen)"
+        out: "closed"
   bs_gas_states:
     values:
       - in: "<erkannt>"

--- a/sentences/de/binary_sensor_HassGetState.yaml
+++ b/sentences/de/binary_sensor_HassGetState.yaml
@@ -264,6 +264,19 @@ intents:
           domain: binary_sensor
           device_class: garage_door
 
+      # Window
+      - sentences:
+          - "(ist|steht) <name>[ <area>] {bs_window_states:state}"
+          - "(ist|steht) <name> {bs_window_states:state} <area>"
+          - "(ist|steht) <area> <name> {bs_window_states:state}"
+        response: einzeln_janein
+        requires_context:
+          domain: binary_sensor
+          device_class: window
+        slots:
+          domain: binary_sensor
+          device_class: window
+
       # Gas
       - sentences:
           - "(ist|wurde) <name>[ <area>] {bs_gas_states:state}"

--- a/tests/de/_fixtures.yaml
+++ b/tests/de/_fixtures.yaml
@@ -181,6 +181,24 @@ entities:
     attributes:
       device_class: garage_door
 
+  - name: "Küchenfenster"
+    id: "binary_sensor.kitchen_window"
+    area: kitchen
+    state:
+      in: "geschlossen"
+      out: "closed"
+    attributes:
+      device_class: window
+
+  - name: "Fenster"
+    id: "binary_sensor.kitchen_window_2"
+    area: kitchen
+    state:
+      in: "geschlossen"
+      out: "closed"
+    attributes:
+      device_class: window
+
   - name: "Gas"
     id: "binary_sensor.gas"
     area: kitchen

--- a/tests/de/_fixtures.yaml
+++ b/tests/de/_fixtures.yaml
@@ -186,16 +186,7 @@ entities:
     area: kitchen
     state:
       in: "geschlossen"
-      out: "closed"
-    attributes:
-      device_class: window
-
-  - name: "Fenster"
-    id: "binary_sensor.kitchen_window_2"
-    area: kitchen
-    state:
-      in: "geschlossen"
-      out: "closed"
+      out: "off"
     attributes:
       device_class: window
 

--- a/tests/de/binary_sensor_HassGetState.yaml
+++ b/tests/de/binary_sensor_HassGetState.yaml
@@ -591,19 +591,19 @@ tests:
     response: "Nein"
 
   - sentences:
-      - "ist das Fenster in der Küche offen?"
-      - "ist in der Küche das Fenster offen?"
-      - "ist das Fenster offen in der Küche?"
-      - "steht das Fenster in der Küche offen?"
-      - "steht in der Küche das Fenster offen?"
-      - "steht das Fenster offen in der Küche?"
+      - "ist das Küchenfenster in der Küche offen?"
+      - "ist in der Küche das Küchenfenster offen?"
+      - "ist das Küchenfenster offen in der Küche?"
+      - "steht das Küchenfenster in der Küche offen?"
+      - "steht in der Küche das Küchenfenster offen?"
+      - "steht das Küchenfenster offen in der Küche?"
     intent:
       name: HassGetState
       slots:
         area: "Küche"
         domain: "binary_sensor"
         device_class: "window"
-        name: "Fenster"
+        name: "Küchenfenster"
         state: "on"
     response: "Nein"
 
@@ -617,7 +617,7 @@ tests:
         domain: "binary_sensor"
         device_class: "window"
         name: "Küchenfenster"
-        state: "closed"
+        state: "off"
     response: "Ja"
 
   # Gas

--- a/tests/de/binary_sensor_HassGetState.yaml
+++ b/tests/de/binary_sensor_HassGetState.yaml
@@ -581,6 +581,7 @@ tests:
       - "steht das Küchenfenster offen?"
       - "ist das Küchenfenster auf?"
       - "ist das Küchenfenster geöffnet?"
+      - "ist das Küchenfenster gekippt?"
     intent:
       name: HassGetState
       slots:
@@ -594,6 +595,9 @@ tests:
       - "ist das Küchenfenster in der Küche offen?"
       - "ist in der Küche das Küchenfenster offen?"
       - "ist das Küchenfenster offen in der Küche?"
+      - "ist das Küchenfenster in der Küche gekippt?"
+      - "ist in der Küche das Küchenfenster gekippt?"
+      - "ist das Küchenfenster gekippt in der Küche?"
       - "steht das Küchenfenster in der Küche offen?"
       - "steht in der Küche das Küchenfenster offen?"
       - "steht das Küchenfenster offen in der Küche?"

--- a/tests/de/binary_sensor_HassGetState.yaml
+++ b/tests/de/binary_sensor_HassGetState.yaml
@@ -575,6 +575,51 @@ tests:
         state: "on"
     response: "Nein"
 
+  # Window
+  - sentences:
+      - "ist das Küchenfenster offen?"
+      - "steht das Küchenfenster offen?"
+      - "ist das Küchenfenster auf?"
+      - "ist das Küchenfenster geöffnet?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "binary_sensor"
+        device_class: "window"
+        name: "Küchenfenster"
+        state: "on"
+    response: "Nein"
+
+  - sentences:
+      - "ist das Fenster in der Küche offen?"
+      - "ist in der Küche das Fenster offen?"
+      - "ist das Fenster offen in der Küche?"
+      - "steht das Fenster in der Küche offen?"
+      - "steht in der Küche das Fenster offen?"
+      - "steht das Fenster offen in der Küche?"
+    intent:
+      name: HassGetState
+      slots:
+        area: "Küche"
+        domain: "binary_sensor"
+        device_class: "window"
+        name: "Fenster"
+        state: "on"
+    response: "Nein"
+
+  - sentences:
+      - "ist das Küchenfenster zu?"
+      - "steht das Küchenfenster zu?"
+      - "ist das Küchenfenster geschlossen?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "binary_sensor"
+        device_class: "window"
+        name: "Küchenfenster"
+        state: "closed"
+    response: "Ja"
+
   # Gas
   - sentences:
       - "wurde Gas entdeckt?"


### PR DESCRIPTION
SSIA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new states for windows, mapping German terms to "on" and "off".
  - Added a new intent for querying the state of windows in the binary sensor domain.
  - Included new sentence patterns and response types for window state queries.

- **Tests**
  - Added entities for kitchen windows with specific configurations for testing.
  - Expanded test queries to include various states and locations of kitchen windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->