### PR TITLE
[DE] add degrees to HassClimateGetTemperature

### DIFF
--- a/responses/de/HassClimateGetTemperature.yaml
+++ b/responses/de/HassClimateGetTemperature.yaml
@@ -2,4 +2,4 @@ language: de
 responses:
   intents:
     HassClimateGetTemperature:
-      default: "{{ state_attr(state.entity_id, 'current_temperature') }}"
+      default: "{{ state_attr(state.entity_id, 'current_temperature') }} Grad"

--- a/tests/de/climate_HassClimateGetTemperature.yaml
+++ b/tests/de/climate_HassClimateGetTemperature.yaml
@@ -15,7 +15,7 @@ tests:
       name: HassClimateGetTemperature
       slots:
         area: Wohnzimmer
-    response: "22"
+    response: "22 Grad"
 
   - sentences:
       - Wie hoch ist die Temperatur der Küche?
@@ -23,13 +23,13 @@ tests:
       name: HassClimateGetTemperature
       slots:
         area: Küche
-    response: "24"
+    response: "24 Grad"
 
   - sentences:
       - Wie hoch ist die Temperatur?
     intent:
       name: HassClimateGetTemperature
-    response: "22"
+    response: "22 Grad"
 
   - sentences:
       - Wie hoch ist die Temperatur von dem Wohnzimmerthermostat?
@@ -40,7 +40,7 @@ tests:
       name: HassClimateGetTemperature
       slots:
         name: Wohnzimmerthermostat
-    response: "22"
+    response: "22 Grad"
 
   - sentences:
       - Wie hoch ist die Temperatur von dem Thermostat im Wohnzimmer?
@@ -51,4 +51,4 @@ tests:
       name: HassClimateGetTemperature
       slots:
         area: Wohnzimmer
-    response: "22"
+    response: "22 Grad"


### PR DESCRIPTION
Adds "Grad" to HassClimateGetTemperature responses. Much more natural sounding response for "Wie hoch ist die Temperatur im Wohnzimmer" (before: "24" / after: "24 Grad").

fixes #2216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Improved temperature response by including the unit "Grad" for increased clarity.

- **Tests**
    - Updated test scenarios to reflect the inclusion of the unit "Grad" in temperature responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->