### PR TITLE
[IT] Add support for media_player control

### DIFF
--- a/responses/it/HassMediaNext.yaml
+++ b/responses/it/HassMediaNext.yaml
@@ -1,0 +1,5 @@
+language: it
+responses:
+  intents:
+    HassMediaNext:
+      default: "Riproduco successivo"

--- a/responses/it/HassMediaPause.yaml
+++ b/responses/it/HassMediaPause.yaml
@@ -1,0 +1,5 @@
+language: it
+responses:
+  intents:
+    HassMediaPause:
+      default: "Messo in pausa"

--- a/responses/it/HassMediaPrevious.yaml
+++ b/responses/it/HassMediaPrevious.yaml
@@ -1,0 +1,5 @@
+language: it
+responses:
+  intents:
+    HassMediaPrevious:
+      default: "Riproduco precedente"

--- a/responses/it/HassMediaUnpause.yaml
+++ b/responses/it/HassMediaUnpause.yaml
@@ -1,0 +1,5 @@
+language: it
+responses:
+  intents:
+    HassMediaUnpause:
+      default: "Ripreso"

--- a/responses/it/HassSetVolume.yaml
+++ b/responses/it/HassSetVolume.yaml
@@ -1,0 +1,5 @@
+language: it
+responses:
+  intents:
+    HassSetVolume:
+      default: "Volume impostato"

--- a/sentences/it/_common.yaml
+++ b/sentences/it/_common.yaml
@@ -384,6 +384,7 @@ expansion_rules:
   in: "(all'interno |dentro |in | ne[l |i |gli |llo |lla |lle |ll(`|’|')[ ]])"
   of: "(de[l |llo |lla |lle |ll(`|’|')[ ]|i |gli ]|di )"
   to: "(a[l |llo |lla |lle |ll(`|’|')[ ]|gli ])"
+  onto: "(su[l |llo |lla |lle |ll(`|’|')[ ]|gli |[ ]])"
   some: "(qualche | qualcun(o|a) | un[(o |a |(`|’|')[ ])] | de[i |gli |lle ] | alcun(o|a) | nessun(o|a))"
   what_is: "(qual[e] è | quant(o |(`|’|'))è | com(e |(`|’|'))è | che)"
   there_is: "(c'è|c(`|’|')e(`|’|')|ci sta[nno]|ci sono)"

--- a/sentences/it/media_player_HassMediaNext.yaml
+++ b/sentences/it/media_player_HassMediaNext.yaml
@@ -1,0 +1,54 @@
+language: it
+intents:
+  HassMediaNext:
+    data:
+      - sentences:
+          - "(vai avanti;[<onto>]<name>)"
+          - "([vai avanti alla ]prossima[ canzone| traccia];[<onto>]<name>)"
+          - "([vai avanti al ]prossimo[ brano| elemento| programma| episodio];[<onto>]<name>)"
+          - "([vai avanti alla ][canzone|traccia] (successiva|seguente);[<onto>]<name>)"
+          - "([vai avanti al ][brano|programma] (successivo|seguente);[<onto>]<name>)"
+          - "([vai avanti all'][elemento|episodio] (successivo|seguente);[<onto>]<name>)"
+          - "(salta [la ](canzone|traccia);[<onto>]<name>)"
+          - "(salta [questa |alla prossima ][canzone|traccia];[<onto>]<name>)"
+          - "(salta [il ] (brano|programma);[<onto>]<name>)"
+          - "(salta [questo |al prossimo ] [brano|programma];[<onto>]<name>)"
+          - "(salta [l'][elemento|episodio];[<onto>]<name>)"
+          - "(salta [questo |al prossimo ][elemento|episodio];[<onto>]<name>)"
+          - "(salta alla [canzone |traccia ](successiva|seguente);[<onto>]<name>)"
+          - "(salta al[ brano |l'elemento | programma |l'episodio ](successivo|seguente);[<onto>]<name>)"
+        requires_context:
+          domain: media_player
+      - sentences:
+          - "vai avanti"
+          - "[vai avanti alla ]prossima[ canzone| traccia]"
+          - "[vai avanti al ]prossimo[ brano| elemento| programma| episodio]"
+          - "[vai avanti alla ][canzone|traccia] (successiva|seguente)"
+          - "[vai avanti al ][brano|programma] (successivo|seguente)"
+          - "[vai avanti all'][elemento|episodio] (successivo|seguente)"
+          - "salta [la ](canzone|traccia)"
+          - "salta [questa |alla prossima ][canzone|traccia]"
+          - "salta [il ] (brano|programma)"
+          - "salta [questo |al prossimo ] [brano|programma]"
+          - "salta [l'][elemento|episodio]"
+          - "salta [questo |al prossimo ][elemento|episodio]"
+          - "salta alla [canzone |traccia ](successiva|seguente)"
+          - "salta al[ brano |l'elemento | programma |l'episodio ](successivo|seguente)"
+        requires_context:
+          area:
+            slot: true
+      - sentences:
+          - "(vai avanti;[<in>]<area>)"
+          - "([vai avanti alla ]prossima[ canzone| traccia];[<in>]<area>)"
+          - "([vai avanti al ]prossimo[ brano| elemento| programma| episodio];[<in>]<area>)"
+          - "([vai avanti alla ][canzone|traccia] (successiva|seguente);[<in>]<area>)"
+          - "([vai avanti al ][brano|programma] (successivo|seguente);[<in>]<area>)"
+          - "([vai avanti all'][elemento|episodio] (successivo|seguente);[<in>]<area>)"
+          - "(salta [la ](canzone|traccia);[<in>]<area>)"
+          - "(salta [questa |alla prossima ][canzone|traccia];[<in>]<area>)"
+          - "(salta [il ] (brano|programma);[<in>]<area>)"
+          - "(salta [questo |al prossimo ] [brano|programma];[<in>]<area>)"
+          - "(salta [l'][elemento|episodio];[<in>]<area>)"
+          - "(salta [questo |al prossimo ][elemento|episodio];[<in>]<area>)"
+          - "(salta alla [canzone |traccia ](successiva|seguente);[<in>]<area>)"
+          - "(salta al[ brano |l'elemento | programma |l'episodio ](successivo|seguente);[<in>]<area>)"

--- a/sentences/it/media_player_HassMediaPause.yaml
+++ b/sentences/it/media_player_HassMediaPause.yaml
@@ -1,0 +1,17 @@
+language: it
+intents:
+  HassMediaPause:
+    data:
+      - sentences:
+          - "((metti in pausa|pausa);<name>)"
+        requires_context:
+          domain: media_player
+      - sentences:
+          - "(metti in pausa|pausa) [[la [mia ]]musica|[il [mio ]](programma|episodio)]"
+          - "(metti in pausa|pausa) [il |i |su |sul |sui ]media player"
+        requires_context:
+          area:
+            slot: true
+      - sentences:
+          - "(metti in pausa|pausa) [[la [mia ]]musica|[il [mio ]](programma|episodio)][ <in>] <area>"
+          - "(metti in pausa|pausa) [il |i |su |sul |sui ]media player[ <in>] <area>"

--- a/sentences/it/media_player_HassMediaPrevious.yaml
+++ b/sentences/it/media_player_HassMediaPrevious.yaml
@@ -1,0 +1,30 @@
+language: it
+intents:
+  HassMediaPrevious:
+    data:
+      - sentences:
+          - "((vai indietro|ripeti);[<onto>]<name>)"
+          - "([vai indietro all'|torna all'|ripeti [l']|riproduci [di nuovo ][l']]ultima [ canzone| traccia];[<onto>]<name>)"
+          - "([vai indietro all'|torna all'|ripeti [l']|riproduci [di nuovo ][l']]ultimo [ brano| elemento| programma| episodio];[<onto>]<name>)"
+          - "([vai indietro alla |torna alla |ripeti [la ]|riproduci [di nuovo ][la ]][canzone|traccia] precedente;[<onto>]<name>)"
+          - "([vai indietro al |torna al |ripeti [il ]|riproduci [di nuovo ][il ]][brano|programma] precedente;[<onto>]<name>)"
+          - "([vai indietro all'|torna all'|ripeti [l']|riproduci [di nuovo ][l']][elemento|episodio] precedente;[<onto>]<name>)"
+        requires_context:
+          domain: media_player
+      - sentences:
+          - "(vai indietro|ripeti)"
+          - "[vai indietro all'|torna all'|ripeti [l']|riproduci [di nuovo ][l']]ultima [ canzone| traccia]"
+          - "[vai indietro all'|torna all'|ripeti [l']|riproduci [di nuovo ][l']]ultimo [ brano| elemento| programma| episodio]"
+          - "[vai indietro alla |torna alla |ripeti [la ]|riproduci [di nuovo ][la ]][canzone|traccia] precedente"
+          - "[vai indietro al |torna al |ripeti [il ]|riproduci [di nuovo ][il ]][brano|programma] precedente"
+          - "[vai indietro all'|torna all'|ripeti [l']|riproduci [di nuovo ][l']][elemento|episodio] precedente"
+        requires_context:
+          area:
+            slot: true
+      - sentences:
+          - "((vai indietro|ripeti);[<in>]<area>)"
+          - "([vai indietro all'|torna all'|ripeti [l']|riproduci [di nuovo ][l']]ultima [ canzone| traccia];[<in>]<area>)"
+          - "([vai indietro all'|torna all'|ripeti [l']|riproduci [di nuovo ][l']]ultimo [ brano| elemento| programma| episodio];[<in>]<area>)"
+          - "([vai indietro alla |torna alla |ripeti [la ]|riproduci [di nuovo ][la ]][canzone|traccia] precedente;[<in>]<area>)"
+          - "([vai indietro al |torna al |ripeti [il ]|riproduci [di nuovo ][il ]][brano|programma] precedente;[<in>]<area>)"
+          - "([vai indietro all'|torna all'|ripeti [l']|riproduci [di nuovo ][l']][elemento|episodio] precedente;[<in>]<area>)"

--- a/sentences/it/media_player_HassMediaUnpause.yaml
+++ b/sentences/it/media_player_HassMediaUnpause.yaml
@@ -1,0 +1,17 @@
+language: it
+intents:
+  HassMediaUnpause:
+    data:
+      - sentences:
+          - "(riprendi;<name>)"
+        requires_context:
+          domain: media_player
+      - sentences:
+          - "riprendi [[la [mia ]]musica|[il [mio ]](programma|episodio)]"
+          - "riprendi [il |i |su |sul |sui ]media player"
+        requires_context:
+          area:
+            slot: true
+      - sentences:
+          - "riprendi [[la [mia ]]musica|[il [mio ]](programma|episodio)][ <in>] <area>"
+          - "riprendi [il |i |su |sul |sui ]media player[ <in>] <area>"

--- a/sentences/it/media_player_HassSetVolume.yaml
+++ b/sentences/it/media_player_HassSetVolume.yaml
@@ -1,0 +1,17 @@
+language: it
+intents:
+  HassSetVolume:
+    data:
+      - sentences:
+          - "<numeric_value_set> [il ]volume [<of>]<name> <to><volume>"
+          - "(<numeric_value_set> [il ]volume <to><volume>;[<onto>]<name>)"
+        requires_context:
+          domain: media_player
+      - sentences:
+          - "<numeric_value_set> [il ]volume <to><volume>"
+        requires_context:
+          area:
+            slot: true
+      - sentences:
+          - "<numeric_value_set> [il ]volume [<in>]<area> <to><volume>"
+          - "(<numeric_value_set> [il ]volume <to><volume>;[<in>]<area>)"

--- a/tests/it/_fixtures.yaml
+++ b/tests/it/_fixtures.yaml
@@ -69,6 +69,12 @@ entities:
     attributes:
       temperature: "8"
       temperature_unit: "°C"
+  - name: "TV"
+    id: "media_player.tv"
+    area: "soggiorno"
+    state: "idle"
+    attributes:
+      volume_level: "50"
 timers:
   - is_active: false
     start_hours: 1

--- a/tests/it/media_player_HassMediaNext.yaml
+++ b/tests/it/media_player_HassMediaNext.yaml
@@ -1,0 +1,66 @@
+language: it
+tests:
+  - sentences:
+      - "vai avanti su TV"
+      - "prossima canzone su TV"
+      - "prossimo elemento su TV"
+      - "traccia successiva sulla TV"
+      - "programma successivo sulla TV"
+      - "vai avanti all'elemento seguente sulla TV"
+      - "salta la canzone sulla TV"
+      - "salta questa canzone sulla TV"
+      - "salta l'episodio sulla TV"
+      - "salta brano sulla TV"
+      - "salta alla canzone successiva sulla TV"
+      - "salta alla prossima traccia sulla TV"
+      - "salta il brano sulla TV"
+      - "salta la traccia sulla TV"
+      - "salta questo elemento sulla TV"
+      - "salta sulla TV"
+      - "TV salta"
+    intent:
+      name: HassMediaNext
+      slots:
+        name: "TV"
+    response: "Riproduco successivo"
+  - sentences:
+      - "vai avanti"
+      - "prossimo elemento"
+      - "vai avanti all'elemento seguente"
+      - "salta la traccia"
+      - "salta canzone"
+      - "salta l'episodio"
+      - "salta brano"
+      - "salta alla prossima canzone"
+      - "salta al brano successivo"
+      - "salta questa canzone"
+      - "salta il brano"
+      - "salta questo elemento"
+      - "salta"
+    intent:
+      name: HassMediaNext
+      slots:
+        area: "Soggiorno"
+      context:
+        area: Soggiorno
+    response: "Riproduco successivo"
+  - sentences:
+      - "vai avanti in soggiorno"
+      - "prossimo elemento in soggiorno"
+      - "prossima canzone in soggiorno"
+      - "brano successivo in soggiorno"
+      - "traccia seguente in soggiorno"
+      - "in soggiorno vai avanti all'elemento seguente"
+      - "salta la traccia in soggiorno"
+      - "salta canzone in soggiorno"
+      - "salta l'episodio in soggiorno"
+      - "in soggiorno salta questo elemento"
+      - "salta alla canzone seguente in soggiorno"
+      - "salta al programma successivo in soggiorno"
+    intent:
+      name: HassMediaNext
+      slots:
+        area: "Soggiorno"
+      context:
+        area: Soggiorno
+    response: "Riproduco successivo"

--- a/tests/it/media_player_HassMediaPause.yaml
+++ b/tests/it/media_player_HassMediaPause.yaml
@@ -1,0 +1,30 @@
+language: it
+tests:
+  - sentences:
+      - "metti in pausa TV"
+      - "TV pausa"
+    intent:
+      name: HassMediaPause
+      slots:
+        name: "TV"
+    response: "Messo in pausa"
+  - sentences:
+      - "pausa"
+    intent:
+      name: HassMediaPause
+      slots:
+        area: "Soggiorno"
+      context:
+        area: Soggiorno
+    response: "Messo in pausa"
+  - sentences:
+      - "metti in pausa musica in soggiorno"
+      - "metti in pausa il mio programma in soggiorno"
+      - "metti in pausa il media player in soggiorno"
+    intent:
+      name: HassMediaPause
+      slots:
+        area: "Soggiorno"
+      context:
+        area: Soggiorno
+    response: "Messo in pausa"

--- a/tests/it/media_player_HassMediaPrevious.yaml
+++ b/tests/it/media_player_HassMediaPrevious.yaml
@@ -1,0 +1,45 @@
+language: it
+tests:
+  - sentences:
+      - "vai indietro su TV"
+      - "torna alla canzone precedente sulla TV"
+      - "torna all'ultima canzone sulla TV"
+      - "ripeti l'ultimo brano sulla TV"
+      - "TV vai indietro alla traccia precedente"
+      - "TV torna all'ultima canzone"
+      - "TV riproduci l'ultima traccia"
+      - "TV riproduci la canzone precedente"
+      - "TV riproduci di nuovo la canzone precedente"
+      - "TV ripeti l'ultima traccia"
+    intent:
+      name: HassMediaPrevious
+      slots:
+        name: "TV"
+    response: "Riproduco precedente"
+  - sentences:
+      - "vai indietro"
+      - "vai indietro alla canzone precedente"
+      - "torna all'ultima traccia"
+      - "ripeti l'ultima traccia"
+      - "riproduci di nuovo l'ultima canzone"
+      - "ripeti"
+    intent:
+      name: HassMediaPrevious
+      slots:
+        area: "Soggiorno"
+      context:
+        area: Soggiorno
+    response: "Riproduco precedente"
+  - sentences:
+      - "vai indietro nel soggiorno"
+      - "torna alla canzone precedente nel soggiorno"
+      - "torna all'ultima traccia nel soggiorno"
+      - "ripeti l'ultima traccia nel soggiorno"
+      - "in soggiorno riproduci di nuovo l'ultima canzone"
+    intent:
+      name: HassMediaPrevious
+      slots:
+        area: "Soggiorno"
+      context:
+        area: Soggiorno
+    response: "Riproduco precedente"

--- a/tests/it/media_player_HassMediaUnpause.yaml
+++ b/tests/it/media_player_HassMediaUnpause.yaml
@@ -1,0 +1,30 @@
+language: it
+tests:
+  - sentences:
+      - "riprendi TV"
+      - "TV riprendi"
+    intent:
+      name: HassMediaUnpause
+      slots:
+        name: "TV"
+    response: "Ripreso"
+  - sentences:
+      - "riprendi"
+    intent:
+      name: HassMediaUnpause
+      slots:
+        area: "Soggiorno"
+      context:
+        area: Soggiorno
+    response: "Ripreso"
+  - sentences:
+      - "riprendi musica in soggiorno"
+      - "riprendi il mio programma in soggiorno"
+      - "riprendi su media player in soggiorno"
+    intent:
+      name: HassMediaUnpause
+      slots:
+        area: "Soggiorno"
+      context:
+        area: Soggiorno
+    response: "Ripreso"

--- a/tests/it/media_player_HassSetVolume.yaml
+++ b/tests/it/media_player_HassSetVolume.yaml
@@ -1,0 +1,45 @@
+language: it
+tests:
+  - sentences:
+      - "imposta volume TV a 90 percento"
+      - "cambia il volume della TV a 90"
+      - "abbassa volume TV a 90 percento"
+      - "sulla TV aumenta il volume a 90 percento"
+      - "abbassa il volume a 90 percento sulla TV"
+      - "aumenta il volume a 90 sulla TV"
+    intent:
+      name: HassSetVolume
+      slots:
+        name: "TV"
+        volume_level: 90
+    response: "Volume impostato"
+  - sentences:
+      - "imposta volume a 90 percento"
+      - "cambia il volume a 90"
+      - "abbassa il volume a 90 percento"
+      - "aumenta il volume a 90 percento"
+      - "abbassa il volume al 90 percento"
+      - "aumenta il volume a 90"
+    intent:
+      name: HassSetVolume
+      context:
+        area: Soggiorno
+      slots:
+        area: "Soggiorno"
+        volume_level: 90
+    response: "Volume impostato"
+  - sentences:
+      - "imposta volume soggiorno a 90 percento"
+      - "cambia il volume nel Soggiorno a 90"
+      - "abbassa il volume a 90 percento in Soggiorno"
+      - "aumenta il volume in soggiorno a 90 percento"
+      - "nel soggiorno abbassa il volume a 90 percento"
+      - "aumenta il volume a 90 nel soggiorno"
+    intent:
+      name: HassSetVolume
+      context:
+        area: Soggiorno
+      slots:
+        area: "Soggiorno"
+        volume_level: 90
+    response: "Volume impostato"

--- a/tests/it/media_player_HassSetVolume.yaml
+++ b/tests/it/media_player_HassSetVolume.yaml
@@ -30,8 +30,8 @@ tests:
     response: "Volume impostato"
   - sentences:
       - "imposta volume soggiorno a 90 percento"
-      - "cambia il volume nel Soggiorno a 90"
-      - "abbassa il volume a 90 percento in Soggiorno"
+      - "cambia il volume nel soggiorno a 90"
+      - "abbassa il volume a 90 percento in soggiorno"
       - "aumenta il volume in soggiorno a 90 percento"
       - "nel soggiorno abbassa il volume a 90 percento"
       - "aumenta il volume a 90 nel soggiorno"


### PR DESCRIPTION
Add sentences, responses and tests for the following timer-related intents for the Italian language:
- HassMediaNext
- HassMediaPause
- HassMediaPrevious
- HassMediaUnpause
- HassSetVolume

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced Italian language support for the following intents:
    - `HassMediaNext`: "Riproduco successivo"
    - `HassMediaPause`: "Messo in pausa"
    - `HassMediaPrevious`: "Riproduco precedente"
    - `HassMediaUnpause`: "Ripreso"
    - `HassSetVolume`: "Volume impostato"
  - Added variations of commands and intents for media control (next, pause, previous, unpause, set volume) in Italian.
  
- **Chores**
  - Added a new entity "TV" for testing in Italian, including its ID, area, state, and attributes.
  - Introduced corresponding test cases for each newly supported Italian intent, covering various media control scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->