### PR TITLE
[IT] Add support for script activation

### DIFF
--- a/sentences/it/_common.yaml
+++ b/sentences/it/_common.yaml
@@ -401,7 +401,7 @@ expansion_rules:
   light: "( [punt(o|i)] luce | luci | lampad[in](a|e) | lampadari[o])"
 
   # Verbi
-  turn_on: "[fa(`|’|'|i|re)](accend(i|ere) | attiv(a|are))"
+  turn_on: "[fa(`|’|'|i|re)](accend(i|ere) | attiv(a|are) | esegu(i|ire) | avvi(a|are))"
   turn_off: "((spegn|speng)(i|ere) | disattiv(a|are))"
   open: "(apr(i|ire) | alz(a|are))"
   close: "(chiud(i|ere) | abbass(a|are))"

--- a/sentences/it/script_HassTurnOn.yaml
+++ b/sentences/it/script_HassTurnOn.yaml
@@ -3,7 +3,7 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "[esegui|avvia|accendi|attiva] [script ]<name>"
+          - "[<turn_on>] [script ]<name>"
         requires_context:
           domain: script
         slots:

--- a/sentences/it/script_HassTurnOn.yaml
+++ b/sentences/it/script_HassTurnOn.yaml
@@ -1,0 +1,11 @@
+language: it
+intents:
+  HassTurnOn:
+    data:
+      - sentences:
+          - "[esegui|avvia|accendi|attiva] [script ]<name>"
+        requires_context:
+          domain: script
+        slots:
+          domain: script
+        response: script

--- a/tests/it/_fixtures.yaml
+++ b/tests/it/_fixtures.yaml
@@ -63,6 +63,8 @@ entities:
     state: "on"
   - name: "Modalità Festa"
     id: "scene.modalita_festa"
+  - name: "Modalità stealth"
+    id: "script.stealth_mode"
   - name: "Roma"
     id: "weather.roma"
     state: "rainy"

--- a/tests/it/script_HassTurnOn.yaml
+++ b/tests/it/script_HassTurnOn.yaml
@@ -1,0 +1,12 @@
+language: it
+tests:
+  - sentences:
+      - "esegui script modalità stealth"
+      - "attiva script modalità stealth"
+      - "attiva modalità stealth"
+    intent:
+      name: HassTurnOn
+      slots:
+        domain: script
+        name: "Modalità stealth"
+    response: "Ho avviato modalità stealth"


### PR DESCRIPTION
Add sentences and tests for the script_HassTurnOn intent for the Italian language

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded verbs for actions like turning on/off, opening, and closing in the Italian language module.
  - Introduced `HassTurnOn` intent for activating specific scripts in Home Assistant.
  - Added support for a new entity "Modalità stealth" for script activation.

- **Tests**
  - Added a test scenario for the `HassTurnOn` intent, including activation of the "Stealth mode" script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->