### PR TITLE
[de] Weather sentences without a name

### DIFF
--- a/sentences/de/weather_HassGetWeather.yaml
+++ b/sentences/de/weather_HassGetWeather.yaml
@@ -3,6 +3,8 @@ intents:
   HassGetWeather:
     data:
       - sentences:
+          - "wie ist[ das] Wetter"
+      - sentences:
           - "wie ist[ das] Wetter[ (für|in) <name>]"
           - "wie ist[ das] <name>[er|s] Wetter"
           - "was für[ ein] Wetter (ist|hat es) in <name>"

--- a/tests/de/weather_HassGetWeather.yaml
+++ b/tests/de/weather_HassGetWeather.yaml
@@ -1,6 +1,13 @@
 language: de
 tests:
   - sentences:
+      - "wie ist das Wetter"
+      - "wie ist Wetter"
+    intent:
+      name: HassGetWeather
+    response: 8 °C und regnerisch
+
+  - sentences:
       - "wie ist das Wetter in Berlin?"
       - "wie ist das Wetter für Berlin?"
       - "was für ein Wetter ist in Berlin?"


### PR DESCRIPTION
Align with the `en` version and add a whether sentence without a name.

https://github.com/home-assistant/intents/blob/main/sentences/en/weather_HassGetWeather.yaml#L5-L6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new sentence variant "wie ist das Wetter" for the `HassGetWeather` intent in the German language.

- **Tests**
  - Added a new test case for the `HassGetWeather` intent to handle generic weather inquiries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->