### PR TITLE
Don't set up another venv when venv already is setup

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -16,7 +16,7 @@ base_dir="$(realpath "${this_dir}/..")"
 python_version="$(${PYTHON} --version)"
 
 # Create virtual environment
-if [ ! -n "$DEVCONTAINER" ] && [ ! -n "$CI" ]; then
+if [ ! -n "$DEVCONTAINER" ] && [ ! -n "$CI" ] && [ ! -n "$VIRTUAL_ENV" ]; then
   echo "Creating virtual environment at ${venv} (${python_version})"
   rm -rf "${venv}"
   "${PYTHON}" -m venv "${venv}"


### PR DESCRIPTION
I use pyenv for handling my virtual env across my dev environments.

This causes each project to be automatically in a virtual environment. The `script/setup` script, however, ignores the already loaded virtual environment and starts to create a new one. 

This PR adjusts the behavior by detecting if one is already in venv.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the setup script to conditionally create a virtual environment based on the presence of the `$VIRTUAL_ENV` variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->