### PR TITLE
[NL] Add context aware pause media player intent

### DIFF
--- a/sentences/nl/media_player_HassMediaPause.yaml
+++ b/sentences/nl/media_player_HassMediaPause.yaml
@@ -8,3 +8,8 @@ intents:
           - "<name> pauzeren"
         requires_context:
           domain: media_player
+      - sentences:
+          - "(pauzeren|pauzeer|pauze)"
+        requires_context:
+          area:
+            slot: true

--- a/tests/nl/media_player_HassMediaPause.yaml
+++ b/tests/nl/media_player_HassMediaPause.yaml
@@ -9,3 +9,14 @@ tests:
       slots:
         name: "TV"
     response: "Gepauzeerd"
+  - sentences:
+      - "pauze"
+      - "pauzeer"
+      - "pauzeren"
+    intent:
+      name: HassMediaPause
+      slots:
+        area: "Woonkamer"
+      context:
+        area: Woonkamer
+    response: "Gepauzeerd"


### PR DESCRIPTION
SSIA, add the area context aware version of the pause media player intent for the Dutch language.

Example sentences:

- "pauze"
- "pauzeer"
- "pauzeren"

../Frenck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for pausing media via voice commands with context awareness, such as specifying the area (e.g., living room).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->