### PR TITLE
[NL] Align ClimateTemperatureSet with EN

### DIFF
--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -437,7 +437,7 @@ expansion_rules:
       |[een|de] (apparaat|apparaten|sensor[s|en]|iets) [[in|op|van|bij] <area>]
     )
 
-  numeric_value_set: "(zet|verander|draai|verhoog|verlaag)"
+  numeric_value_set: "(zet|doe|mag|verander|draai|verhoog|verlaag)"
   media_item: "[lied[je]|nummer|track|item|aflevering|video|film[pje]]"
   volume: "{volume:volume_level}[[ ]%| procent]"
   position: "{position}[[ ]%| procent]"

--- a/sentences/nl/climate_HassClimateSetTemperature.yaml
+++ b/sentences/nl/climate_HassClimateSetTemperature.yaml
@@ -3,8 +3,7 @@ intents:
   HassClimateSetTemperature:
     data:
       - sentences:
-          - "[<doe>|<zou>] [de] temperatuur <naar> <temperature> [graden] [[willen|kunnen] <doe>]"
-          - "[<doe>|<zou>] [de] temperatuur <naar> <temperature> [graden] <in> <area> [[willen|kunnen] <doe>]"
-          - "[<doe>|<zou>] (<area>|<name>) temperatuur <naar> <temperature> [graden] [[willen|kunnen] <doe>]"
-          - "[<doe>|<zou>] (<area>|<name>) [temperatuur] <naar> <temperature> graden [[willen|kunnen] <doe>]"
-          - "[<doe>|<zou>] de temperatuur <in> (<area>|<name>) <naar> <temperature> [graden] [[willen|kunnen] <doe>]"
+          - "<numeric_value_set>[ de] temperatuur[ <in> <area>] <naar> <temperature>[ graden]"
+          - "<numeric_value_set>[ de] temperatuur <naar> <temperature> [graden][ <in> <area>]"
+          - "<numeric_value_set>[ de] <area>[ ]temperatuur <naar> <temperature>[ graden]"
+          - "(<area>|temperatuur [<naar>]) <temperature> graden"

--- a/tests/nl/climate_HassClimateSetTemperature.yaml
+++ b/tests/nl/climate_HassClimateSetTemperature.yaml
@@ -1,33 +1,24 @@
 language: nl
 tests:
   - sentences:
-      - Zet de temperatuur op 19 graden
-      - Mag de temperatuur op 19?
-      - Zal je de temperatuur op 19 willen zetten?
+      - "Zet de temperatuur op 19 graden"
+      - "Mag de temperatuur op 19?"
+      - "Verander de temperatuur naar 19"
+      - "Verlaag de temperatuur naar 19"
+      - "Temperatuur 19 graden"
     intent:
       name: HassClimateSetTemperature
       slots:
         temperature: 19
 
   - sentences:
-      - Verander de temperatuur naar 19 graden in de woonkamer
-      - Zet de woonkamer temperatuur op 19
-      - Zal je de woonkamer temperatuur op 19 willen zetten?
+      - "Verander de temperatuur naar 19 graden in de woonkamer"
+      - "Zet de woonkamer temperatuur op 19"
+      - "Verhoog de woonkamertemperatuur naar 19 graden"
+      - "Verlaag de temperatuur in de woonkamer naar 19 graden"
+      - "Woonkamer 19 graden"
     intent:
       name: HassClimateSetTemperature
       slots:
         temperature: 19
         area: Woonkamer
-
-  - sentences:
-      - Zet woonkamerthermostaat op 19 graden
-      - Verander woonkamerthermostaat naar 19 graden
-      - Doe woonkamerthermostaat temperatuur naar 19
-      - Zet de temperatuur van de woonkamerthermostaat op 19
-      - Doe de temperatuur van de woonkamerthermostaat naar 19 graden
-      - Zal je de temperatuur van de woonkamerthermostaat naar 19 graden willen zetten?
-    intent:
-      name: HassClimateSetTemperature
-      slots:
-        temperature: 19
-        name: Woonkamerthermostaat


### PR DESCRIPTION
* Use `<numeric_value_set>`
* Remove formal sentences like `zou je de temperatuur in de woonkamer op 19 graden willen zetten`
* Remove `<name>` as target, as this isn't added in EN, and doesn't seem to be working in my tests in a production system.

Compared to EN I did add the really short intents like `woonkamer 19 graden` or `temperatuur 19 graden`. I didn't make `graden` optional there to avoid conflicts with other intents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced natural language processing for setting numeric values and temperature adjustments.
  - Expanded the range of media items recognized by the system.

- **Improvements**
  - Refined definitions for volume and position in the NL sentences for better user interaction.
  - Improved sentence patterns for setting temperatures in specific areas, ensuring more accurate and flexible commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->