### PR TITLE
[RO] Don't require area to start timer

### DIFF
--- a/sentences/ro/homeassistant_HassStartTimer.yaml
+++ b/sentences/ro/homeassistant_HassStartTimer.yaml
@@ -5,9 +5,6 @@ intents:
       - sentences:
           - "[<porneste_timer> ]<temporizatorul> [<de> ]<timer_duration>"
           - "[<porneste_timer> ]<temporizatorul> ([<de> ]<timer_duration>;(<numit>|pentru) {timer_name:name})"
-        requires_context:
-          area:
-            slot: false
       - sentences:
           - "({timer_command:conversation_command};((î|i)n|peste) <timer_duration>)"
         response: command

--- a/tests/ro/homeassistant_HassStartTimer.yaml
+++ b/tests/ro/homeassistant_HassStartTimer.yaml
@@ -13,6 +13,16 @@ tests:
     response: Am pornit temporizatorul
 
   - sentences:
+      - "temporizator 2 minute"
+      - "porneste o temporizare de 2 minute"
+      - "start cronometru pentru 2 minute"
+    intent:
+      name: HassStartTimer
+      slots:
+        minutes: 2
+    response: Am pornit temporizatorul
+
+  - sentences:
       - "temporizator 2 ore si 15 minute"
       - "porneste o temporizare de 2 ore si 15 minute"
       - "start cronometru pentru 2 ore si 15 minute"


### PR DESCRIPTION
RO translation of #2257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new sentence variations for starting a 2-minute timer using the Home Assistant skill with the `HassStartTimer` intent.
  
- **Bug Fixes**
  - Removed `requires_context` constraints related to the `area` slot for improved handling of timer commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->