### PR TITLE
[NL] Finetune cover_HassGetState

### DIFF
--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -375,15 +375,12 @@ lists:
 
 expansion_rules:
   # generic expansion rules for sentences
-  name: "[de|het] {name}"
-  area: "[de|het] {area}"
+  name: "[de |het ]{name}"
+  area: "[de |het ]{area}"
+  floor: "[de |het ]{floor}"
   in: "[in|op|van|bij]"
   met: "(door|met|bij)"
-  name_area: >
-    (
-      [[<in> de|het|een] {area}][ ]<name>
-      |[de|het|een] {name}[ ][<type>] [[in|op|van|bij] <area>]
-    )
+  name_area: "([<in> <area>][ ];<name>[ ][<type>])"
   sensor_name_area: >
     (
       [[door|met|bij] [de|het|een] {area}][ ]{name}

--- a/sentences/nl/cover_HassGetState.yaml
+++ b/sentences/nl/cover_HassGetState.yaml
@@ -3,7 +3,8 @@ intents:
   HassGetState:
     data:
       - sentences:
-          - "<is> [er] <name_area> {cover_states:state} [<in> <area>]"
+          - "<is> [er] ([<in> <area>][ ];<name>[[ ]<afdekking>]) {cover_states:state} [<in> (<area>|<floor>)]"
+          - "<is> <name>[[ ]<afdekking>] {cover_states:state} [<in> (<area>|<floor>)] "
         response: one_yesno
         requires_context:
           domain: cover
@@ -11,25 +12,29 @@ intents:
           domain: cover
 
       - sentences:
-          - <is> [er] [<in> <area>|ergens|nog] [een] {cover_classes:device_class} [<in> <area>] {cover_states:state} [<in> <area>]
+          - "<is> [er ][<in> (<area>|<floor>) |ergens |nog ][een ]{cover_classes:device_class} [<in> <area>] {cover_states:state} [<in> <area>]"
+          - "<is> [er ]{cover_classes:device_class} ({cover_states:state};<in> (<area>|<floor>))"
         response: any
         slots:
           domain: cover
 
       - sentences:
-          - <is> [<in> <area>] [<alle>] [de] {cover_classes:device_class} [<in> <area>] {cover_states:state} [<in> <area>]
+          - "<is> [<in> (<area>|<floor>) ][<alle> |de ]{cover_classes:device_class} {cover_states:state}"
+          - "<is> [<alle> | de ]{cover_classes:device_class} (<in> (<area>|<floor>);{cover_states:state})"
         response: all
         slots:
           domain: cover
 
       - sentences:
-          - Welk[e] {cover_classes:device_class} [<in> <area>] <is> {cover_states:state} [<in> <area>]
+          - "Welk[e] {cover_classes:device_class} <is> {cover_states:state}"
+          - "Welk[e] {cover_classes:device_class} ([<in> (<area>|<floor>)];<is> {cover_states:state})"
         response: which
         slots:
           domain: cover
 
       - sentences:
-          - Hoe[ ]veel {cover_classes:device_class} [<in> <area>] <is> [er] [<in> <area>] {cover_states:state} [<in> <area>]
+          - "Hoe[ ]veel {cover_classes:device_class} [<in> (<area>|<floor>) ]<is> [er ] {cover_states:state}"
+          - "Hoe[ ]veel {cover_classes:device_class} <is> [er ](<in> (<area>|<floor>);{cover_states:state})"
         response: how_many
         slots:
           domain: cover


### PR DESCRIPTION
Changes:
* Add support for floors
* Split sentences so you can't say things like: `Hoeveel gordijnen in de woonkamer staan in de woonkamer open in de woonkamer`
* Only allow the `afdekking` expansion rule for the named sentences so for a cover named like `bloemetjes` something like `is bloemetjeslamp open` won't work
* Include spaces in the optional parts so there are no double spaces when the optional part isn't used