### PR TITLE
[NL] Finetune cover_HassSetPosition

### DIFF
--- a/sentences/nl/cover_HassSetPosition.yaml
+++ b/sentences/nl/cover_HassSetPosition.yaml
@@ -3,17 +3,23 @@ intents:
   HassSetPosition:
     data:
       - sentences:
-          - "[<numeric_value_set> |open |sluit ]<name> [positie ][<naar> ]<position>"
-          - "[<doe> ]<name> ([<naar> ]<position>;(omhoog|omlaag))"
+          - "[<numeric_value_set> |open |sluit ]<name>[[ ]<afdekking>][[ ](positie|stand)] [<naar> ]<position>"
+          - "[<numeric_value_set> |open |sluit ][de ](positie|stand) [van ]<name>[[ ]<afdekking>] [<naar> ]<position>"
+          - "[<doe> ]<name>[[ ]<afdekking>][[ ](positie|stand)] ([<naar> ]<position>;(omhoog|omlaag))"
+          - "[<doe> ][de ](positie|stand) [van ]<name>[[ ]<afdekking>] ([<naar> ]<position>;(omhoog|omlaag))"
         requires_context:
           domain: cover
         slots:
           domain: cover
 
       - sentences:
-          - "(<numeric_value_set>|open|sluit) [de |het ]{cover_classes:device_class}[ positie] (<naar> <position>;<in> <area>)"
-          - "(<numeric_value_set>|open|sluit) <area>[ ]{cover_classes:device_class}[ positie] <naar> <position>"
-          - "[<doe> ][de |het ]<area>[ ]{cover_classes:device_class}[ positie] ([<naar> ]<position>;(omhoog|omlaag))"
-          - "[<doe> ](<in> <area>;[de |het ]{cover_classes:device_class}[ positie]) ([<naar> ]<position>;(omhoog|omlaag))"
+          - "(<numeric_value_set>|open|sluit) [de |het ]{cover_classes:device_class}[[ ](positie|stand)] (<naar> <position>;<in> <area>)"
+          - "(<numeric_value_set>|open|sluit) [de ](positie|stand) [van ][de |het ]{cover_classes:device_class} (<naar> <position>;<in> <area>)"
+          - "(<numeric_value_set>|open|sluit) <area>[ ]{cover_classes:device_class}[[ ](positie|stand)] <naar> <position>"
+          - "(<numeric_value_set>|open|sluit) [de ](positie|stand) [van ]<area>[ ]{cover_classes:device_class} <naar> <position>"
+          - "[<doe> ][de |het ]<area>[ ]{cover_classes:device_class}[[ ](positie|stand)] ([<naar> ]<position>;(omhoog|omlaag))"
+          - "[<doe> ][de ](positie|stand) [van ][de |het ]<area>[ ]{cover_classes:device_class} ([<naar> ]<position>;(omhoog|omlaag))"
+          - "[<doe> ](<in> <area>;[de |het ]{cover_classes:device_class}[[ ](positie|stand)]) ([<naar> ]<position>;(omhoog|omlaag))"
+          - "[<doe> ](<in> <area>;[de ](positie|stand) [van ][de |het ]{cover_classes:device_class}) ([<naar> ]<position>;(omhoog|omlaag))"
         slots:
           domain: cover

--- a/sentences/nl/cover_HassSetPosition.yaml
+++ b/sentences/nl/cover_HassSetPosition.yaml
@@ -3,14 +3,17 @@ intents:
   HassSetPosition:
     data:
       - sentences:
-          - "[<doe>|open|sluit] <name> [positie ][<naar>] <position>"
+          - "[<numeric_value_set> |open |sluit ]<name> [positie ][<naar> ]<position>"
+          - "[<doe> ]<name> ([<naar> ]<position>;(omhoog|omlaag))"
         requires_context:
           domain: cover
         slots:
           domain: cover
 
       - sentences:
-          - "(<doe>|open|sluit) [de |het ]{cover_classes:device_class}[ positie] ((op|naar) <position>;<in> <area>)"
-          - "(<doe>|open|sluit) <area>[ ]{cover_classes:device_class}[ positie] (op|naar) <position>"
+          - "(<numeric_value_set>|open|sluit) [de |het ]{cover_classes:device_class}[ positie] (<naar> <position>;<in> <area>)"
+          - "(<numeric_value_set>|open|sluit) <area>[ ]{cover_classes:device_class}[ positie] <naar> <position>"
+          - "[<doe> ][de |het ]<area>[ ]{cover_classes:device_class}[ positie] ([<naar> ]<position>;(omhoog|omlaag))"
+          - "[<doe> ](<in> <area>;[de |het ]{cover_classes:device_class}[ positie]) ([<naar> ]<position>;(omhoog|omlaag))"
         slots:
           domain: cover

--- a/tests/nl/cover_HassSetPosition.yaml
+++ b/tests/nl/cover_HassSetPosition.yaml
@@ -3,8 +3,10 @@ tests:
   - sentences:
       - "zet gordijn links naar 50%"
       - "Gordijn Links 50 procent"
+      - "Positie van gordijn links naar 50"
       - "Doe gordijn links omhoog naar 50%"
       - "Zet gordijn links naar 50% omlaag"
+      - "verlaag de stand van gordijn links naar 50%"
     intent:
       name: HassSetPosition
       slots:
@@ -14,11 +16,13 @@ tests:
     response: "Positie aangepast"
 
   - sentences:
-      - "zet de gordijnen in de slaapkamer op 50%"
+      - "zet de gordijnen positie in de slaapkamer op 50%"
       - "open de gordijnen naar 50% in de slaapkamer"
-      - "doe de gordijnen in de slaapkamer naar 50% omhoog"
+      - "doe de gordijnen stand in de slaapkamer naar 50% omhoog"
+      - "doe positie van de gordijnen in de slaapkamer naar 50% omhoog"
       - "doe in de slaapkamer de gordijnen omlaag naar 50%"
-      - "doe de slaapkamergordijnen omlaag naar 50%"
+      - "doe de slaapkamergordijnenpositie omlaag naar 50%"
+      - "doe de stand van de slaapkamergordijnen omlaag naar 50"
     intent:
       name: HassSetPosition
       slots:

--- a/tests/nl/cover_HassSetPosition.yaml
+++ b/tests/nl/cover_HassSetPosition.yaml
@@ -3,6 +3,8 @@ tests:
   - sentences:
       - "zet gordijn links naar 50%"
       - "Gordijn Links 50 procent"
+      - "Doe gordijn links omhoog naar 50%"
+      - "Zet gordijn links naar 50% omlaag"
     intent:
       name: HassSetPosition
       slots:
@@ -14,6 +16,9 @@ tests:
   - sentences:
       - "zet de gordijnen in de slaapkamer op 50%"
       - "open de gordijnen naar 50% in de slaapkamer"
+      - "doe de gordijnen in de slaapkamer naar 50% omhoog"
+      - "doe in de slaapkamer de gordijnen omlaag naar 50%"
+      - "doe de slaapkamergordijnen omlaag naar 50%"
     intent:
       name: HassSetPosition
       slots:


### PR DESCRIPTION
Changes:
 * Added sentences like `doe bloemetjesgordijn omhoog naar 50%`
 * Added sentences like `doe slaapkamergordijnen naar 25% omlaag`
 * make use of `numeric_value_set` expansion rule
 * add spaces inside optional parts instead of outside to avoid double spaces.
 * Add `stand` as variant for position
 * Allow `stand|postition` before the name (with optional `van`)
 * Add tests includling `stand|position`
 * Optionally add the `afdekking` expansion rule to names

It seems there is no support for floors for HassSetPosition. Is this intentional?
