### PR TITLE
[NL] Finetune HassTurnOff/On for covers and fans & align with EN

### DIFF
--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -375,9 +375,9 @@ lists:
 
 expansion_rules:
   # generic expansion rules for sentences
-  name: "[de |het ]{name}"
-  area: "[de |het ]{area}"
-  floor: "[de |het ]{floor}"
+  name: "[de|het] {name}"
+  area: "[de|het] {area}"
+  floor: "[de|het] {floor}"
   in: "[in|op|van|bij]"
   met: "(door|met|bij)"
   hier: "(hier|in deze (kamer|ruimte))"
@@ -410,7 +410,7 @@ expansion_rules:
   window: "(raam|ramen)"
   # device/entity types
   lamp: "[de|het|een] (lamp[en]|licht[en]|verlichting)"
-  ventilator: "[de |een ](ventilator[s|en]|fan[s])"
+  ventilator: "[de|een] (ventilator[s|en]|fan[s])"
   schakelaar: "[de|een] (schakelaar[s]|switch[es]|plug[gen])"
   afdekking: "[de|het] (<awning>|<blind>|<curtain>|<door>|<garage>|<gate>|<shade>|<shutter>|<window>)"
   # lock specific

--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -410,7 +410,7 @@ expansion_rules:
   window: "(raam|ramen)"
   # device/entity types
   lamp: "[de|het|een] (lamp[en]|licht[en]|verlichting)"
-  ventilator: "[de|een] (ventilator[s|en]|fan[s])"
+  ventilator: "[de |een ](ventilator[s|en]|fan[s])"
   schakelaar: "[de|een] (schakelaar[s]|switch[es]|plug[gen])"
   afdekking: "[de|het] (<awning>|<blind>|<curtain>|<door>|<garage>|<gate>|<shade>|<shutter>|<window>)"
   # lock specific

--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -380,6 +380,7 @@ expansion_rules:
   floor: "[de |het ]{floor}"
   in: "[in|op|van|bij]"
   met: "(door|met|bij)"
+  hier: "(hier|in deze (kamer|ruimte))"
   name_area: >
     (
       [[<in> de|het|een] {area}][ ]<name>

--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -375,8 +375,9 @@ lists:
 
 expansion_rules:
   # generic expansion rules for sentences
-  name: "[de|het] {name}"
-  area: "[de|het] {area}"
+  name: "[de |het ]{name}"
+  area: "[de |het ]{area}"
+  floor: "[de |het ]{floor}"
   in: "[in|op|van|bij]"
   met: "(door|met|bij)"
   name_area: >

--- a/sentences/nl/cover_HassTurnOff.yaml
+++ b/sentences/nl/cover_HassTurnOff.yaml
@@ -4,7 +4,7 @@ intents:
     data:
       - sentences:
           - "sluit <name>[[ ]<afdekking>]"
-          - "<name>[[ ]<afdekking>] sluiten"
+          - "<name>[[ ]<afdekking>] (sluiten|dicht doen)"
           - "[<doe>] <name>[[ ]<afdekking>] <dicht>"
         response: "cover"
         requires_context:
@@ -12,7 +12,7 @@ intents:
 
       - sentences:
           - "sluit [de] garage[ ][deur]"
-          - "[de] garage[ ][deur] sluiten"
+          - "[de] garage[ ][deur] (sluiten|dicht doen)"
           - "[<doe>] [de] garage[ ][deur] <dicht>"
         response: "cover_device_class"
         slots:
@@ -21,7 +21,7 @@ intents:
 
       - sentences:
           - "sluit (<name>[[ ]<afdekking>];<in> (<area>|<floor>))"
-          - "(<name>[[ ]<afdekking>];<in> (<area>|<floor>)) sluiten"
+          - "(<name>[[ ]<afdekking>];<in> (<area>|<floor>)) (sluiten|dicht doen)"
           - "[<doe>] <in> (<area>|<floor>) <name>[[ ]<afdekking>] <dicht>"
           - "[<doe>] <name>[[ ]<afdekking>] (<dicht>;<in> (<area>|<floor>))"
         response: "cover"
@@ -35,7 +35,7 @@ intents:
 
       - sentences:
           - "sluit ([de |het ]<curtain>;<in> (<area>|<floor>))"
-          - "([de |het ]<curtain>;<in> (<area>|<floor>)) sluiten"
+          - "([de |het ]<curtain>;<in> (<area>|<floor>)) (sluiten|dicht doen)"
           - "[<doe>] <in> (<area>|<floor>) [de |het ]<curtain> <dicht>"
           - "[<doe> ][de |het ]<curtain> (<dicht>;<in> (<area>|<floor>))"
         response: "cover"
@@ -44,8 +44,8 @@ intents:
           domain: "cover"
 
       - sentences:
-          - "sluit [de|het ](<blind>|<shutter>|<shade>) <in> (<area>|<floor>)"
-          - "([de |het ](<blind>|<shutter>|<shade>);<in> (<area>|<floor>)) sluiten"
+          - "sluit [de |het ](<blind>|<shutter>|<shade>) <in> (<area>|<floor>)"
+          - "([de |het ](<blind>|<shutter>|<shade>);<in> (<area>|<floor>)) (sluiten|dicht doen)"
           - "[<doe> ] <in> (<area>|<floor>) [de |het ](<blind>|<shutter>|<shade>) <dicht>"
           - "[<doe> ][de |het ](<blind>|<shutter>|<shade>) (<dicht>;<in> (<area>|<floor>))"
         response: "cover"
@@ -59,8 +59,8 @@ intents:
       - sentences:
           - "sluit [de |het ]<curtain>"
           - "sluit ([de |het ]<curtain>;hier)"
-          - "[de |het ]<curtain> sluiten"
-          - "([de |het ]<curtain>;hier) sluiten"
+          - "[de |het ]<curtain> (sluiten|dicht doen)"
+          - "([de |het ]<curtain>;hier) (sluiten|dicht doen)"
           - "[<doe> ][de |het ]<curtain> [hier ]<dicht>"
           - "[<doe> ]([de |het ]<curtain> <dicht>;hier)"
         response: "cover"
@@ -74,8 +74,8 @@ intents:
       - sentences:
           - "sluit [de |het ](<blind>|<shutter>|<shade>)"
           - "sluit ([de |het ](<blind>|<shutter>|<shade>);hier)"
-          - "[de |het ](<blind>|<shutter>|<shade>) sluiten"
-          - "([de |het ](<blind>|<shutter>|<shade>);hier) sluiten"
+          - "[de |het ](<blind>|<shutter>|<shade>) (sluiten|dicht doen)"
+          - "([de |het ](<blind>|<shutter>|<shade>);hier) (sluiten|dicht doen)"
           - "[<doe> ][de |het ](<blind>|<shutter>|<shade>) [hier ]<dicht>"
           - "[<doe> ]([de |het ](<blind>|<shutter>|<shade>) <dicht>;hier)"
         response: "cover"

--- a/sentences/nl/cover_HassTurnOff.yaml
+++ b/sentences/nl/cover_HassTurnOff.yaml
@@ -20,10 +20,10 @@ intents:
           domain: "cover"
 
       - sentences:
-          - "sluit (<name>[[ ]<afdekking>];<in> <area>)"
-          - "(<name>[[ ]<afdekking>];<in> <area>) sluiten"
-          - "[<doe>] <in> <area> <name>[[ ]<afdekking>] <dicht>"
-          - "[<doe>] <name>[[ ]<afdekking>] (<dicht>;<in> <area>)"
+          - "sluit (<name>[[ ]<afdekking>];<in> (<area>|<floor>))"
+          - "(<name>[[ ]<afdekking>];<in> (<area>|<floor>)) sluiten"
+          - "[<doe>] <in> (<area>|<floor>) <name>[[ ]<afdekking>] <dicht>"
+          - "[<doe>] <name>[[ ]<afdekking>] (<dicht>;<in> (<area>|<floor>))"
         response: "cover"
         requires_context:
           device_class:
@@ -34,20 +34,20 @@ intents:
           domain: "cover"
 
       - sentences:
-          - "sluit ([de |het ]<curtain>;<in> <area>)"
-          - "([de |het ]<curtain>;<in> <area>) sluiten"
-          - "[<doe>] <in> <area> [de |het ]<curtain> <dicht>"
-          - "[<doe> ][de |het ]<curtain> (<dicht>;<in> <area>)"
+          - "sluit ([de |het ]<curtain>;<in> (<area>|<floor>))"
+          - "([de |het ]<curtain>;<in> (<area>|<floor>)) sluiten"
+          - "[<doe>] <in> (<area>|<floor>) [de |het ]<curtain> <dicht>"
+          - "[<doe> ][de |het ]<curtain> (<dicht>;<in> (<area>|<floor>))"
         response: "cover"
         slots:
           device_class: "curtain"
           domain: "cover"
 
       - sentences:
-          - "sluit [de|het ](<blind>|<shutter>|<shade>) <in> <area>"
-          - "([de |het ](<blind>|<shutter>|<shade>);<in> <area>) sluiten"
-          - "[<doe> ] <in> <area> [de |het ](<blind>|<shutter>|<shade>) <dicht>"
-          - "[<doe> ][de |het ](<blind>|<shutter>|<shade>) (<dicht>;<in> <area>)"
+          - "sluit [de|het ](<blind>|<shutter>|<shade>) <in> (<area>|<floor>)"
+          - "([de |het ](<blind>|<shutter>|<shade>);<in> (<area>|<floor>)) sluiten"
+          - "[<doe> ] <in> (<area>|<floor>) [de |het ](<blind>|<shutter>|<shade>) <dicht>"
+          - "[<doe> ][de |het ](<blind>|<shutter>|<shade>) (<dicht>;<in> (<area>|<floor>))"
         response: "cover"
         slots:
           device_class:

--- a/sentences/nl/cover_HassTurnOff.yaml
+++ b/sentences/nl/cover_HassTurnOff.yaml
@@ -34,20 +34,20 @@ intents:
           domain: "cover"
 
       - sentences:
-          - "sluit ([de |het ]<curtain>;<in> (<area>|<floor>))"
-          - "([de |het ]<curtain>;<in> (<area>|<floor>)) (sluiten|dicht doen)"
-          - "[<doe>] <in> (<area>|<floor>) [de |het ]<curtain> <dicht>"
-          - "[<doe> ][de |het ]<curtain> (<dicht>;<in> (<area>|<floor>))"
+          - "sluit ([de|het] <curtain>;<in> (<area>|<floor>))"
+          - "([de|het] <curtain>;<in> (<area>|<floor>)) (sluiten|dicht doen)"
+          - "[<doe>] <in> (<area>|<floor>) [de|het] <curtain> <dicht>"
+          - "[<doe>] [de|het] <curtain> (<dicht>;<in> (<area>|<floor>))"
         response: "cover"
         slots:
           device_class: "curtain"
           domain: "cover"
 
       - sentences:
-          - "sluit [de |het ](<blind>|<shutter>|<shade>) <in> (<area>|<floor>)"
-          - "([de |het ](<blind>|<shutter>|<shade>);<in> (<area>|<floor>)) (sluiten|dicht doen)"
-          - "[<doe> ] <in> (<area>|<floor>) [de |het ](<blind>|<shutter>|<shade>) <dicht>"
-          - "[<doe> ][de |het ](<blind>|<shutter>|<shade>) (<dicht>;<in> (<area>|<floor>))"
+          - "sluit [de|het] (<blind>|<shutter>|<shade>) <in> (<area>|<floor>)"
+          - "([de|het] (<blind>|<shutter>|<shade>);<in> (<area>|<floor>)) (sluiten|dicht doen)"
+          - "[<doe>]  <in> (<area>|<floor>) [de|het] (<blind>|<shutter>|<shade>) <dicht>"
+          - "[<doe>] [de|het] (<blind>|<shutter>|<shade>) (<dicht>;<in> (<area>|<floor>))"
         response: "cover"
         slots:
           device_class:
@@ -57,12 +57,12 @@ intents:
           domain: "cover"
 
       - sentences:
-          - "sluit [de |het ]<curtain>"
-          - "sluit ([de |het ]<curtain>;<hier>)"
-          - "[de |het ]<curtain> (sluiten|dicht doen)"
-          - "([de |het ]<curtain>;<hier>) (sluiten|dicht doen)"
-          - "[<doe> ][de |het ]<curtain> [<hier> ]<dicht>"
-          - "[<doe> ]([de |het ]<curtain> <dicht>;<hier>)"
+          - "sluit [de|het] <curtain>"
+          - "sluit ([de|het] <curtain>;<hier>)"
+          - "[de|het] <curtain> (sluiten|dicht doen)"
+          - "([de|het] <curtain>;<hier>) (sluiten|dicht doen)"
+          - "[<doe>] [de|het] <curtain> [<hier>] <dicht>"
+          - "[<doe>] ([de|het] <curtain> <dicht>;<hier>)"
         response: "cover"
         slots:
           device_class: "curtain"
@@ -72,12 +72,12 @@ intents:
             slot: true
 
       - sentences:
-          - "sluit [de |het ](<blind>|<shutter>|<shade>)"
-          - "sluit ([de |het ](<blind>|<shutter>|<shade>);<hier>)"
-          - "[de |het ](<blind>|<shutter>|<shade>) (sluiten|dicht doen)"
-          - "([de |het ](<blind>|<shutter>|<shade>);<hier>) (sluiten|dicht doen)"
-          - "[<doe> ][de |het ](<blind>|<shutter>|<shade>) [<hier> ]<dicht>"
-          - "[<doe> ]([de |het ](<blind>|<shutter>|<shade>) <dicht>;<hier>)"
+          - "sluit [de|het] (<blind>|<shutter>|<shade>)"
+          - "sluit ([de|het] (<blind>|<shutter>|<shade>);<hier>)"
+          - "[de|het] (<blind>|<shutter>|<shade>) (sluiten|dicht doen)"
+          - "([de|het] (<blind>|<shutter>|<shade>);<hier>) (sluiten|dicht doen)"
+          - "[<doe>] [de|het] (<blind>|<shutter>|<shade>) [<hier>] <dicht>"
+          - "[<doe>] ([de|het] (<blind>|<shutter>|<shade>) <dicht>;<hier>)"
         response: "cover"
         slots:
           device_class:

--- a/sentences/nl/cover_HassTurnOff.yaml
+++ b/sentences/nl/cover_HassTurnOff.yaml
@@ -3,11 +3,9 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "sluit <name>"
-          - "<name> sluiten"
-          - "[<doe>] <name> <dicht>"
-          - "<zou> <name> ((<dicht> willen | <dicht> kunnen | <dicht>[ ])<doe>|sluiten)"
-          - "<zou> <name> (willen|kunnen) [<dicht>[ ]<doe>|sluiten]"
+          - "sluit <name>[[ ]<afdekking>]"
+          - "<name>[[ ]<afdekking>] sluiten"
+          - "[<doe>] <name>[[ ]<afdekking>] <dicht>"
         response: "cover"
         requires_context:
           domain: cover
@@ -16,21 +14,16 @@ intents:
           - "sluit [de] garage[ ][deur]"
           - "[de] garage[ ][deur] sluiten"
           - "[<doe>] [de] garage[ ][deur] <dicht>"
-          - "<zou> [de] garage[ ][deur] ((<dicht> willen | <dicht> kunnen | <dicht>[ ])<doe>|sluiten)"
-          - "<zou> [de] garage[ ][deur] (kunnen|willen) [<dicht>[ ]<doe>|sluiten]"
         response: "cover_device_class"
         slots:
           device_class: "garage"
           domain: "cover"
 
       - sentences:
-          - sluit <name> <in> <area>
-          - <name> <in> <area> sluiten
-          - "[<doe>] <name> (<dicht> <in> <area>|<in> <area> <dicht>)"
-          - "<zou> <name> <in> <area> ((<dicht> willen | <dicht> kunnen | <dicht>[ ])<doe>|sluiten)"
-          - "<zou> <name> ((<dicht> willen | <dicht> kunnen | <dicht>[ ])<doe>|sluiten) <in> <area>"
-          - "<zou> <name> <in> <area> (willen|kunnen) [<dicht>[ ]<doe>|sluiten]"
-          - "<zou> <name> (willen|kunnen) [<dicht>[ ]<doe>|sluiten] <in> <area>"
+          - "sluit (<name>[[ ]<afdekking>];<in> <area>)"
+          - "(<name>[[ ]<afdekking>];<in> <area>) sluiten"
+          - "[<doe>] <in> <area> <name>[[ ]<afdekking>] <dicht>"
+          - "[<doe>] <name>[[ ]<afdekking>] (<dicht>;<in> <area>)"
         response: "cover"
         requires_context:
           device_class:
@@ -41,25 +34,20 @@ intents:
           domain: "cover"
 
       - sentences:
-          - sluit [de|het] <curtain> <in> <area>
-          - "[de|het] <curtain> <in> <area> sluiten"
-          - "[<doe>] [de|het] <curtain> (<dicht> <in> <area>|<in> <area> <dicht>)"
-          - "<zou> [de|het] <curtain> <in> <area> ((<dicht> willen | <dicht> kunnen | <dicht>[ ])<doe>|sluiten)"
-          - "<zou> [de|het] <curtain> ((<dicht> willen | <dicht> kunnen | <dicht>[ ])<doe>|sluiten) <in> <area>"
-          - "<zou> [de|het] <curtain> <in> <area> (willen|kunnen) [<dicht>[ ]<doe>|sluiten]"
-          - "<zou> [de|het] <curtain> (willen|kunnen) [<dicht>[ ]<doe>|sluiten] <in> <area>"
+          - "sluit ([de |het ]<curtain>;<in> <area>)"
+          - "([de |het ]<curtain>;<in> <area>) sluiten"
+          - "[<doe>] <in> <area> [de |het ]<curtain> <dicht>"
+          - "[<doe> ][de |het ]<curtain> (<dicht>;<in> <area>)"
         response: "cover"
         slots:
           device_class: "curtain"
           domain: "cover"
 
       - sentences:
-          - sluit [de|het] (<blind>|<shutter>|<shade>) <in> <area>
-          - "[<doe>] [de|het] (<blind>|<shutter>|<shade>) (<dicht> <in> <area>|<in> <area> <dicht>)"
-          - "<zou> [de|het] (<blind>|<shutter>|<shade>) <in> <area> ((<dicht> willen | <dicht> kunnen | <dicht>[ ])<doe>|sluiten)"
-          - "<zou> [de|het] (<blind>|<shutter>|<shade>) ((<dicht> willen | <dicht> kunnen | <dicht>[ ])<doe>|sluiten) <in> <area>"
-          - "<zou> [de|het] (<blind>|<shutter>|<shade>) <in> <area> (willen|kunnen) [<dicht>[ ]<doe>|sluiten]"
-          - "<zou> [de|het] (<blind>|<shutter>|<shade>) (willen|kunnen) [<dicht>[ ]<doe>|sluiten] <in> <area>"
+          - "sluit [de|het ](<blind>|<shutter>|<shade>) <in> <area>"
+          - "([de |het ](<blind>|<shutter>|<shade>);<in> <area>) sluiten"
+          - "[<doe> ] <in> <area> [de |het ](<blind>|<shutter>|<shade>) <dicht>"
+          - "[<doe> ][de |het ](<blind>|<shutter>|<shade>) (<dicht>;<in> <area>)"
         response: "cover"
         slots:
           device_class:
@@ -67,3 +55,36 @@ intents:
             - "shutter"
             - "shade"
           domain: "cover"
+
+      - sentences:
+          - "sluit [de |het ]<curtain>"
+          - "sluit ([de |het ]<curtain>;hier)"
+          - "[de |het ]<curtain> sluiten"
+          - "([de |het ]<curtain>;hier) sluiten"
+          - "[<doe> ][de |het ]<curtain> [hier ]<dicht>"
+          - "[<doe> ]([de |het ]<curtain> <dicht>;hier)"
+        response: "cover"
+        slots:
+          device_class: "curtain"
+          domain: "cover"
+        requires_context:
+          area:
+            slot: true
+
+      - sentences:
+          - "sluit [de |het ](<blind>|<shutter>|<shade>)"
+          - "sluit ([de |het ](<blind>|<shutter>|<shade>);hier)"
+          - "[de |het ](<blind>|<shutter>|<shade>) sluiten"
+          - "([de |het ](<blind>|<shutter>|<shade>);hier) sluiten"
+          - "[<doe> ][de |het ](<blind>|<shutter>|<shade>) [hier ]<dicht>"
+          - "[<doe> ]([de |het ](<blind>|<shutter>|<shade>) <dicht>;hier)"
+        response: "cover"
+        slots:
+          device_class:
+            - "blind"
+            - "shutter"
+            - "shade"
+          domain: "cover"
+        requires_context:
+          area:
+            slot: true

--- a/sentences/nl/cover_HassTurnOff.yaml
+++ b/sentences/nl/cover_HassTurnOff.yaml
@@ -46,7 +46,7 @@ intents:
       - sentences:
           - "sluit [de|het] (<blind>|<shutter>|<shade>) <in> (<area>|<floor>)"
           - "([de|het] (<blind>|<shutter>|<shade>);<in> (<area>|<floor>)) (sluiten|dicht doen)"
-          - "[<doe>]  <in> (<area>|<floor>) [de|het] (<blind>|<shutter>|<shade>) <dicht>"
+          - "[<doe>] <in> (<area>|<floor>) [de|het] (<blind>|<shutter>|<shade>) <dicht>"
           - "[<doe>] [de|het] (<blind>|<shutter>|<shade>) (<dicht>;<in> (<area>|<floor>))"
         response: "cover"
         slots:

--- a/sentences/nl/cover_HassTurnOff.yaml
+++ b/sentences/nl/cover_HassTurnOff.yaml
@@ -58,11 +58,11 @@ intents:
 
       - sentences:
           - "sluit [de |het ]<curtain>"
-          - "sluit ([de |het ]<curtain>;hier)"
+          - "sluit ([de |het ]<curtain>;<hier>)"
           - "[de |het ]<curtain> (sluiten|dicht doen)"
-          - "([de |het ]<curtain>;hier) (sluiten|dicht doen)"
-          - "[<doe> ][de |het ]<curtain> [hier ]<dicht>"
-          - "[<doe> ]([de |het ]<curtain> <dicht>;hier)"
+          - "([de |het ]<curtain>;<hier>) (sluiten|dicht doen)"
+          - "[<doe> ][de |het ]<curtain> [<hier> ]<dicht>"
+          - "[<doe> ]([de |het ]<curtain> <dicht>;<hier>)"
         response: "cover"
         slots:
           device_class: "curtain"
@@ -73,11 +73,11 @@ intents:
 
       - sentences:
           - "sluit [de |het ](<blind>|<shutter>|<shade>)"
-          - "sluit ([de |het ](<blind>|<shutter>|<shade>);hier)"
+          - "sluit ([de |het ](<blind>|<shutter>|<shade>);<hier>)"
           - "[de |het ](<blind>|<shutter>|<shade>) (sluiten|dicht doen)"
-          - "([de |het ](<blind>|<shutter>|<shade>);hier) (sluiten|dicht doen)"
-          - "[<doe> ][de |het ](<blind>|<shutter>|<shade>) [hier ]<dicht>"
-          - "[<doe> ]([de |het ](<blind>|<shutter>|<shade>) <dicht>;hier)"
+          - "([de |het ](<blind>|<shutter>|<shade>);<hier>) (sluiten|dicht doen)"
+          - "[<doe> ][de |het ](<blind>|<shutter>|<shade>) [<hier> ]<dicht>"
+          - "[<doe> ]([de |het ](<blind>|<shutter>|<shade>) <dicht>;<hier>)"
         response: "cover"
         slots:
           device_class:

--- a/sentences/nl/cover_HassTurnOn.yaml
+++ b/sentences/nl/cover_HassTurnOn.yaml
@@ -3,34 +3,27 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "open <name>"
-          - "<name> openen"
-          - "[<doe>] <name> <open>"
-          - "<zou> <name> ((<open> willen | <open> kunnen | <open>[ ])<doe>|openen)"
-          - "<zou> <name> (willen|kunnen) [<open>[ ]<doe>|openen]"
+          - "open <name>[[ ]<afdekking>]"
+          - "<name>[[ ]<afdekking>] (openen|open doen)"
+          - "[<doe>] <name>[[ ]<afdekking>] <open>"
         response: "cover"
         requires_context:
           domain: cover
 
       - sentences:
           - "open [de] garage[ ][deur]"
-          - "[de] garage[ ][deur] openen"
+          - "[de] garage[ ][deur] (openen|open doen)"
           - "[<doe>] [de] garage[ ][deur] <open>"
-          - "<zou> [de] garage[ ][deur] ((<open> willen | <open> kunnen | <open>[ ])<doe>|openen)"
-          - "<zou> [de] garage[ ][deur] (kunnen|willen) [<open>[ ]<doe>|openen]"
         response: "cover_device_class"
         slots:
           device_class: "garage"
           domain: "cover"
 
       - sentences:
-          - open <name> <in> <area>
-          - <name> <in> <area> openen
-          - "[<doe>] <name> (<open> <in> <area>|<in> <area> <open>)"
-          - "<zou> <name> <in> <area> ((<open> willen | <open> kunnen | <open>[ ])<doe>|openen)"
-          - "<zou> <name> ((<open> willen | <open> kunnen | <open>[ ])<doe>|openen) <in> <area>"
-          - "<zou> <name> <in> <area> (willen|kunnen) [<open>[ ]<doe>|openen]"
-          - "<zou> <name> (willen|kunnen) [<open>[ ]<doe>|openen] <in> <area>"
+          - "open (<name>[[ ]<afdekking>];<in> (<area>|<floor>))"
+          - "(<name>[[ ]<afdekking>];<in> (<area>|<floor>)) (openen|open doen)"
+          - "[<doe>] <in> (<area>|<floor>) <name>[[ ]<afdekking>] <open>"
+          - "[<doe>] <name>[[ ]<afdekking>] (<open>;<in> (<area>|<floor>))"
         response: "cover"
         requires_context:
           device_class:
@@ -41,25 +34,20 @@ intents:
           domain: "cover"
 
       - sentences:
-          - open [de|het] <curtain> <in> <area>
-          - "[de|het] <curtain> <in> <area> openen"
-          - "[<doe>] [de|het] <curtain> (<open> <in> <area>|<in> <area> <open>)"
-          - "<zou> [de|het] <curtain> <in> <area> ((<open> willen | <open> kunnen | <open>[ ])<doe>|openen)"
-          - "<zou> [de|het] <curtain> ((<open> willen | <open> kunnen | <open>[ ])<doe>|openen) <in> <area>"
-          - "<zou> [de|het] <curtain> <in> <area> (willen|kunnen) [<open>[ ]<doe>|openen]"
-          - "<zou> [de|het] <curtain> (willen|kunnen) [<open>[ ]<doe>|openen] <in> <area>"
+          - "open ([de |het ]<curtain>;<in> (<area>|<floor>))"
+          - "([de |het ]<curtain>;<in> (<area>|<floor>)) (openen|open doen)"
+          - "[<doe>] <in> (<area>|<floor>) [de |het ]<curtain> <open>"
+          - "[<doe> ][de |het ]<curtain> (<open>;<in> (<area>|<floor>))"
         response: "cover"
         slots:
           device_class: "curtain"
           domain: "cover"
 
       - sentences:
-          - open [de|het] (<blind>|<shutter>|<shade>) <in> <area>
-          - "[<doe>] [de|het] (<blind>|<shutter>|<shade>) (<open> <in> <area>|<in> <area> <open>)"
-          - "<zou> [de|het] (<blind>|<shutter>|<shade>) <in> <area> ((<open> willen | <open> kunnen | <open>[ ])<doe>|openen)"
-          - "<zou> [de|het] (<blind>|<shutter>|<shade>) ((<open> willen | <open> kunnen | <open>[ ])<doe>|openen) <in> <area>"
-          - "<zou> [de|het] (<blind>|<shutter>|<shade>) <in> <area> (willen|kunnen) [<open>[ ]<doe>|openen]"
-          - "<zou> [de|het] (<blind>|<shutter>|<shade>) (willen|kunnen) [<open>[ ]<doe>|openen] <in> <area>"
+          - "open [de |het ](<blind>|<shutter>|<shade>) <in> (<area>|<floor>)"
+          - "([de |het ](<blind>|<shutter>|<shade>);<in> (<area>|<floor>)) (openen|open doen)"
+          - "[<doe> ] <in> (<area>|<floor>) [de |het ](<blind>|<shutter>|<shade>) <open>"
+          - "[<doe> ][de |het ](<blind>|<shutter>|<shade>) (<open>;<in> (<area>|<floor>))"
         response: "cover"
         slots:
           device_class:
@@ -67,3 +55,36 @@ intents:
             - "shutter"
             - "shade"
           domain: "cover"
+
+      - sentences:
+          - "open [de |het ]<curtain>"
+          - "open ([de |het ]<curtain>;hier)"
+          - "[de |het ]<curtain> (openen|open doen)"
+          - "([de |het ]<curtain>;hier) (openen|open doen)"
+          - "[<doe> ][de |het ]<curtain> [hier ]<open>"
+          - "[<doe> ]([de |het ]<curtain> <open>;hier)"
+        response: "cover"
+        slots:
+          device_class: "curtain"
+          domain: "cover"
+        requires_context:
+          area:
+            slot: true
+
+      - sentences:
+          - "open [de |het ](<blind>|<shutter>|<shade>)"
+          - "open ([de |het ](<blind>|<shutter>|<shade>);hier)"
+          - "[de |het ](<blind>|<shutter>|<shade>) (openen|open doen)"
+          - "([de |het ](<blind>|<shutter>|<shade>);hier) (openen|open doen)"
+          - "[<doe> ][de |het ](<blind>|<shutter>|<shade>) [hier ]<open>"
+          - "[<doe> ]([de |het ](<blind>|<shutter>|<shade>) <open>;hier)"
+        response: "cover"
+        slots:
+          device_class:
+            - "blind"
+            - "shutter"
+            - "shade"
+          domain: "cover"
+        requires_context:
+          area:
+            slot: true

--- a/sentences/nl/cover_HassTurnOn.yaml
+++ b/sentences/nl/cover_HassTurnOn.yaml
@@ -46,7 +46,7 @@ intents:
       - sentences:
           - "open [de|het] (<blind>|<shutter>|<shade>) <in> (<area>|<floor>)"
           - "([de|het] (<blind>|<shutter>|<shade>);<in> (<area>|<floor>)) (openen|open doen)"
-          - "[<doe>]  <in> (<area>|<floor>) [de|het] (<blind>|<shutter>|<shade>) <open>"
+          - "[<doe>] <in> (<area>|<floor>) [de|het] (<blind>|<shutter>|<shade>) <open>"
           - "[<doe>] [de|het] (<blind>|<shutter>|<shade>) (<open>;<in> (<area>|<floor>))"
         response: "cover"
         slots:

--- a/sentences/nl/cover_HassTurnOn.yaml
+++ b/sentences/nl/cover_HassTurnOn.yaml
@@ -58,11 +58,11 @@ intents:
 
       - sentences:
           - "open [de |het ]<curtain>"
-          - "open ([de |het ]<curtain>;hier)"
+          - "open ([de |het ]<curtain>;<hier>)"
           - "[de |het ]<curtain> (openen|open doen)"
-          - "([de |het ]<curtain>;hier) (openen|open doen)"
-          - "[<doe> ][de |het ]<curtain> [hier ]<open>"
-          - "[<doe> ]([de |het ]<curtain> <open>;hier)"
+          - "([de |het ]<curtain>;<hier>) (openen|open doen)"
+          - "[<doe> ][de |het ]<curtain> [<hier> ]<open>"
+          - "[<doe> ]([de |het ]<curtain> <open>;<hier>)"
         response: "cover"
         slots:
           device_class: "curtain"
@@ -73,11 +73,11 @@ intents:
 
       - sentences:
           - "open [de |het ](<blind>|<shutter>|<shade>)"
-          - "open ([de |het ](<blind>|<shutter>|<shade>);hier)"
+          - "open ([de |het ](<blind>|<shutter>|<shade>);<hier>)"
           - "[de |het ](<blind>|<shutter>|<shade>) (openen|open doen)"
-          - "([de |het ](<blind>|<shutter>|<shade>);hier) (openen|open doen)"
-          - "[<doe> ][de |het ](<blind>|<shutter>|<shade>) [hier ]<open>"
-          - "[<doe> ]([de |het ](<blind>|<shutter>|<shade>) <open>;hier)"
+          - "([de |het ](<blind>|<shutter>|<shade>);<hier>) (openen|open doen)"
+          - "[<doe> ][de |het ](<blind>|<shutter>|<shade>) [<hier> ]<open>"
+          - "[<doe> ]([de |het ](<blind>|<shutter>|<shade>) <open>;<hier>)"
         response: "cover"
         slots:
           device_class:

--- a/sentences/nl/cover_HassTurnOn.yaml
+++ b/sentences/nl/cover_HassTurnOn.yaml
@@ -34,20 +34,20 @@ intents:
           domain: "cover"
 
       - sentences:
-          - "open ([de |het ]<curtain>;<in> (<area>|<floor>))"
-          - "([de |het ]<curtain>;<in> (<area>|<floor>)) (openen|open doen)"
-          - "[<doe>] <in> (<area>|<floor>) [de |het ]<curtain> <open>"
-          - "[<doe> ][de |het ]<curtain> (<open>;<in> (<area>|<floor>))"
+          - "open ([de|het] <curtain>;<in> (<area>|<floor>))"
+          - "([de|het] <curtain>;<in> (<area>|<floor>)) (openen|open doen)"
+          - "[<doe>] <in> (<area>|<floor>) [de|het] <curtain> <open>"
+          - "[<doe>] [de|het] <curtain> (<open>;<in> (<area>|<floor>))"
         response: "cover"
         slots:
           device_class: "curtain"
           domain: "cover"
 
       - sentences:
-          - "open [de |het ](<blind>|<shutter>|<shade>) <in> (<area>|<floor>)"
-          - "([de |het ](<blind>|<shutter>|<shade>);<in> (<area>|<floor>)) (openen|open doen)"
-          - "[<doe> ] <in> (<area>|<floor>) [de |het ](<blind>|<shutter>|<shade>) <open>"
-          - "[<doe> ][de |het ](<blind>|<shutter>|<shade>) (<open>;<in> (<area>|<floor>))"
+          - "open [de|het] (<blind>|<shutter>|<shade>) <in> (<area>|<floor>)"
+          - "([de|het] (<blind>|<shutter>|<shade>);<in> (<area>|<floor>)) (openen|open doen)"
+          - "[<doe>]  <in> (<area>|<floor>) [de|het] (<blind>|<shutter>|<shade>) <open>"
+          - "[<doe>] [de|het] (<blind>|<shutter>|<shade>) (<open>;<in> (<area>|<floor>))"
         response: "cover"
         slots:
           device_class:
@@ -57,12 +57,12 @@ intents:
           domain: "cover"
 
       - sentences:
-          - "open [de |het ]<curtain>"
-          - "open ([de |het ]<curtain>;<hier>)"
-          - "[de |het ]<curtain> (openen|open doen)"
-          - "([de |het ]<curtain>;<hier>) (openen|open doen)"
-          - "[<doe> ][de |het ]<curtain> [<hier> ]<open>"
-          - "[<doe> ]([de |het ]<curtain> <open>;<hier>)"
+          - "open [de|het] <curtain>"
+          - "open ([de|het] <curtain>;<hier>)"
+          - "[de|het] <curtain> (openen|open doen)"
+          - "([de|het] <curtain>;<hier>) (openen|open doen)"
+          - "[<doe>] [de|het] <curtain> [<hier>] <open>"
+          - "[<doe>] ([de|het] <curtain> <open>;<hier>)"
         response: "cover"
         slots:
           device_class: "curtain"
@@ -72,12 +72,12 @@ intents:
             slot: true
 
       - sentences:
-          - "open [de |het ](<blind>|<shutter>|<shade>)"
-          - "open ([de |het ](<blind>|<shutter>|<shade>);<hier>)"
-          - "[de |het ](<blind>|<shutter>|<shade>) (openen|open doen)"
-          - "([de |het ](<blind>|<shutter>|<shade>);<hier>) (openen|open doen)"
-          - "[<doe> ][de |het ](<blind>|<shutter>|<shade>) [<hier> ]<open>"
-          - "[<doe> ]([de |het ](<blind>|<shutter>|<shade>) <open>;<hier>)"
+          - "open [de|het] (<blind>|<shutter>|<shade>)"
+          - "open ([de|het] (<blind>|<shutter>|<shade>);<hier>)"
+          - "[de|het] (<blind>|<shutter>|<shade>) (openen|open doen)"
+          - "([de|het] (<blind>|<shutter>|<shade>);<hier>) (openen|open doen)"
+          - "[<doe>] [de|het] (<blind>|<shutter>|<shade>) [<hier>] <open>"
+          - "[<doe>] ([de|het] (<blind>|<shutter>|<shade>) <open>;<hier>)"
         response: "cover"
         slots:
           device_class:

--- a/sentences/nl/fan_HassTurnOff.yaml
+++ b/sentences/nl/fan_HassTurnOff.yaml
@@ -3,12 +3,12 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "[<doe>] [<alle>] <ventilator> ([<naar>] uit;<in> <area>)"
-          - "[<doe>] [<alle>] <ventilator> (<in> <area>;[<naar>] uit)"
-          - "[<doe>] [(<alle>|<in>)] <area>[ ]<ventilator> [<naar>] uit"
-          - "[<alle>] <area>[ ]<ventilator> (uit[ ](zetten|doen)|uitschakelen)"
-          - "([<in>] <area>;[<alle>] <ventilator>) (uit[ ](zetten|doen)|uitschakelen)"
-          - "[<alle>] <ventilator> [<in>] <area> (uit[ ](zetten|doen)|uitschakelen)"
+          - "[<doe>] [<alle>] <ventilator> ([<naar>] uit;<in> (<area>|<floor>))"
+          - "[<doe>] [<alle>] <ventilator> (<in> (<area>|<floor>);[<naar>] uit)"
+          - "[<doe>] [(<alle>|<in>)] (<area>|<floor>)[ ]<ventilator> [<naar>] uit"
+          - "[<alle>] (<area>|<floor>)[ ]<ventilator> (uit[ ](zetten|doen)|uitschakelen)"
+          - "([<in>] (<area>|<floor>);[<alle>] <ventilator>) (uit[ ](zetten|doen)|uitschakelen)"
+          - "[<alle>] <ventilator> [<in>] (<area>|<floor>) (uit[ ](zetten|doen)|uitschakelen)"
         response: fans_area
         slots:
           domain: "fan"

--- a/sentences/nl/fan_HassTurnOff.yaml
+++ b/sentences/nl/fan_HassTurnOff.yaml
@@ -6,9 +6,9 @@ intents:
           - "[<doe>] [<alle>] <ventilator> ([<naar>] uit;<in> <area>)"
           - "[<doe>] [<alle>] <ventilator> (<in> <area>;[<naar>] uit)"
           - "[<doe>] [(<alle>|<in>)] <area>[ ]<ventilator> [<naar>] uit"
-          - "[<alle> ]<area>[ ]<ventilator> (uit[ ](zetten|doen)|uitschakelen)"
-          - "([<in>] <area>;[<alle> ]<ventilator>) (uit[ ](zetten|doen)|uitschakelen)"
-          - "[<alle> ]<ventilator> [<in> ]<area> (uit[ ](zetten|doen)|uitschakelen)"
+          - "[<alle>] <area>[ ]<ventilator> (uit[ ](zetten|doen)|uitschakelen)"
+          - "([<in>] <area>;[<alle>] <ventilator>) (uit[ ](zetten|doen)|uitschakelen)"
+          - "[<alle>] <ventilator> [<in>] <area> (uit[ ](zetten|doen)|uitschakelen)"
         response: fans_area
         slots:
           domain: "fan"
@@ -21,11 +21,11 @@ intents:
           domain: "fan"
 
       - sentences:
-          - "[<doe> ]<ventilator> [<naar> ]uit"
-          - "[<doe> ](<hier>;[alle ]<ventilator>) [<naar> ]uit"
-          - "[<doe> ][alle ]<ventilator> [<naar> ]uit <hier>"
-          - "[alle ]<ventilator> (<hier>;(uit[ ](zetten|doen)|uitschakelen))"
-          - "<hier> [alle ]<ventilator> (uit[ ](zetten|doen)|uitschakelen)"
+          - "[<doe>] <ventilator> [<naar>] uit"
+          - "[<doe>] (<hier>;[alle] <ventilator>) [<naar>] uit"
+          - "[<doe>] [alle] <ventilator> [<naar>] uit <hier>"
+          - "[alle] <ventilator> (<hier>;(uit[ ](zetten|doen)|uitschakelen))"
+          - "<hier> [alle] <ventilator> (uit[ ](zetten|doen)|uitschakelen)"
           - "<ventilator> (uit[ ](zetten|doen)|uitschakelen)"
         response: "fans_area"
         slots:

--- a/sentences/nl/fan_HassTurnOff.yaml
+++ b/sentences/nl/fan_HassTurnOff.yaml
@@ -3,25 +3,33 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "[<doe>] [<alle>] <ventilator> [<naar>] uit <in> <area>"
-          - "<zou> [<alle>] <ventilator> [<naar>] (uit willen |uit kunnen |uit[ ])<doe> <in> <area>"
-          - "[<doe>] [<alle>] <ventilator> <in> <area> [<naar>] uit"
-          - "<zou> [<alle>] <ventilator> <in> <area> [<naar>] (uit willen |uit kunnen |uit[ ])<doe>"
+          - "[<doe>] [<alle>] <ventilator> ([<naar>] uit;<in> <area>)"
+          - "[<doe>] [<alle>] <ventilator> (<in> <area>;[<naar>] uit)"
           - "[<doe>] [(<alle>|<in>)] <area>[ ]<ventilator> [<naar>] uit"
-          - "<zou> [(<alle>|<in>)] <area>[ ]<ventilator> [<naar>] (uit willen |uit kunnen |uit[ ])<doe>"
-          - "<zou> [(<alle>|<in>)] [<area>[ ]]<ventilator> [<in> <area>] [willen|kunnen] (uit[ ](zetten|doen)|uitschakelen)"
-          - "[(<alle>|<in>)] [<area>[ ]]<ventilator> [<in> <area>] (uit[ ](zetten|doen)|uitschakelen)"
+          - "[<alle> ]<area>[ ]<ventilator> (uit[ ](zetten|doen)|uitschakelen)"
+          - "([<in>] <area>;[<alle> ]<ventilator>) (uit[ ](zetten|doen)|uitschakelen)"
+          - "[<alle> ]<ventilator> [<in> ]<area> (uit[ ](zetten|doen)|uitschakelen)"
         response: fans_area
         slots:
           domain: "fan"
-          name: "all"
 
       - sentences:
           - "[<doe>] ((overal|<alle>) <ventilator>|<ventilator> overal) uit"
-          - "<zou> ((overal|<alle>) <ventilator>|<ventilator> overal) (uit willen |uit kunnen |uit[ ])<doe>"
-          - "<zou> ((overal|<alle>) <ventilator>|<ventilator> overal) [willen|kunnen] (uit[ ](zetten|doen)|uitschakelen)"
           - "((overal|<alle>) <ventilator>|<ventilator> overal) (uit[ ](zetten|doen)|uitschakelen)"
         response: "fan_all"
         slots:
           domain: "fan"
-          name: "all"
+
+      - sentences:
+          - "[<doe> ]<ventilator> [<naar> ]uit"
+          - "[<doe> ](<hier>;[alle ]<ventilator>) [<naar> ]uit"
+          - "[<doe> ][alle ]<ventilator> [<naar> ]uit <hier>"
+          - "[alle ]<ventilator> (<hier>;(uit[ ](zetten|doen)|uitschakelen))"
+          - "<hier> [alle ]<ventilator> (uit[ ](zetten|doen)|uitschakelen)"
+          - "<ventilator> (uit[ ](zetten|doen)|uitschakelen)"
+        response: "fans_area"
+        slots:
+          domain: fan
+        requires_context:
+          area:
+            slot: true

--- a/sentences/nl/fan_HassTurnOn.yaml
+++ b/sentences/nl/fan_HassTurnOn.yaml
@@ -3,15 +3,15 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "[<doe>] [<alle>] <ventilator> ([<naar>] aan;<in> <area>)"
-          - "Schakel [<alle>] <ventilator> ([<naar>] in;<in> <area>)"
-          - "[<doe>] [<alle>] <ventilator> (<in> <area>;[<naar>] aan)"
-          - "Schakel [<alle>] <ventilator> (<in> <area>;[<naar>] in)"
-          - "[<doe>] [(<alle>|<in>)] <area>[ ]<ventilator> [<naar>] aan"
-          - "Schakel [(<alle>|<in>)] <area>[ ]<ventilator> [<naar>] in"
-          - "[<alle>] <area>[ ]<ventilator> (aan[ ](zetten|doen)|inschakelen)"
-          - "([<in>] <area>;[<alle>] <ventilator>) (aan[ ](zetten|doen)|inschakelen)"
-          - "[<alle>] <ventilator> [<in>] <area> (aan[ ](zetten|doen)|inschakelen)"
+          - "[<doe>] [<alle>] <ventilator> ([<naar>] aan;<in> (<area>|<floor>))"
+          - "Schakel [<alle>] <ventilator> ([<naar>] in;<in> (<area>|<floor>))"
+          - "[<doe>] [<alle>] <ventilator> (<in> (<area>|<floor>);[<naar>] aan)"
+          - "Schakel [<alle>] <ventilator> (<in> (<area>|<floor>);[<naar>] in)"
+          - "[<doe>] [(<alle>|<in>)] (<area>|<floor>)[ ]<ventilator> [<naar>] aan"
+          - "Schakel [(<alle>|<in>)] (<area>|<floor>)[ ]<ventilator> [<naar>] in"
+          - "[<alle>] (<area>|<floor>)[ ]<ventilator> (aan[ ](zetten|doen)|inschakelen)"
+          - "([<in>] (<area>|<floor>);[<alle>] <ventilator>) (aan[ ](zetten|doen)|inschakelen)"
+          - "[<alle>] <ventilator> [<in>] (<area>|<floor>) (aan[ ](zetten|doen)|inschakelen)"
         response: fans_area
         slots:
           domain: "fan"

--- a/sentences/nl/fan_HassTurnOn.yaml
+++ b/sentences/nl/fan_HassTurnOn.yaml
@@ -3,17 +3,32 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "[<doe>] [<alle>] <ventilator> [<naar>] aan <in> <area>"
-          - "<zou> [<alle>] <ventilator> [<naar>] [[aan willen |aan kunnen |aan[ ]]<doe>] <in> <area>"
-          - "Schakel [<alle>] <ventilator> [<naar>] in <in> <area>"
-          - "[<doe>] [<alle>] <ventilator> <in> <area> [<naar>] aan"
-          - "<zou> [<alle>] <ventilator> <in> <area> [<naar>] [[aan willen |aan kunnen |aan[ ]]<doe>]"
-          - "Schakel [<alle>] <ventilator> <in> <area> [<naar>] in"
-          - "[<doe>] [(<alle>|<in>)] <area> <ventilator> [<naar>] aan"
-          - "<zou> [(<alle>|<in>)] <area> <ventilator> [<naar>] [[aan willen |aan kunnen |aan[ ]]<doe>]"
+          - "[<doe>] [<alle>] <ventilator> ([<naar>] aan;<in> <area>)"
+          - "Schakel [<alle>] <ventilator> ([<naar>] in;<in> <area>)"
+          - "[<doe>] [<alle>] <ventilator> (<in> <area>;[<naar>] aan)"
+          - "Schakel [<alle>] <ventilator> (<in> <area>;[<naar>] in)"
+          - "[<doe>] [(<alle>|<in>)] <area>[ ]<ventilator> [<naar>] aan"
           - "Schakel [(<alle>|<in>)] <area>[ ]<ventilator> [<naar>] in"
-          - "[<zou>] [(<alle>|<in>)] [<area>[ ]]<ventilator> [<in> <area>] [willen|kunnen] (aan[ ](zetten|doen)|inschakelen)"
+          - "[<alle> ]<area>[ ]<ventilator> (aan[ ](zetten|doen)|inschakelen)"
+          - "([<in>] <area>;[<alle> ]<ventilator>) (aan[ ](zetten|doen)|inschakelen)"
+          - "[<alle> ]<ventilator> [<in> ]<area> (aan[ ](zetten|doen)|inschakelen)"
         response: fans_area
         slots:
           domain: "fan"
-          name: "all"
+
+      - sentences:
+          - "[<doe> ]<ventilator> [<naar> ]aan"
+          - "schakel <ventilator> [<naar> ]in"
+          - "[<doe> ](<hier>;[alle ]<ventilator>) [<naar> ]aan"
+          - "schakel (<hier>;[alle ]<ventilator>) [<naar> ]in"
+          - "[<doe> ][alle ]<ventilator> [<naar> ]aan <hier>"
+          - "schakel [alle ]<ventilator> [<naar> ]in <hier>"
+          - "[alle ]<ventilator> (<hier>;(aan[ ](zetten|doen)|inschakelen))"
+          - "<hier> [alle ]<ventilator> (aan[ ](zetten|doen)|inschakelen)"
+          - "<ventilator> (aan[ ](zetten|doen)|inschakelen)"
+        response: "fans_area"
+        slots:
+          domain: fan
+        requires_context:
+          area:
+            slot: true

--- a/sentences/nl/fan_HassTurnOn.yaml
+++ b/sentences/nl/fan_HassTurnOn.yaml
@@ -9,22 +9,22 @@ intents:
           - "Schakel [<alle>] <ventilator> (<in> <area>;[<naar>] in)"
           - "[<doe>] [(<alle>|<in>)] <area>[ ]<ventilator> [<naar>] aan"
           - "Schakel [(<alle>|<in>)] <area>[ ]<ventilator> [<naar>] in"
-          - "[<alle> ]<area>[ ]<ventilator> (aan[ ](zetten|doen)|inschakelen)"
-          - "([<in>] <area>;[<alle> ]<ventilator>) (aan[ ](zetten|doen)|inschakelen)"
-          - "[<alle> ]<ventilator> [<in> ]<area> (aan[ ](zetten|doen)|inschakelen)"
+          - "[<alle>] <area>[ ]<ventilator> (aan[ ](zetten|doen)|inschakelen)"
+          - "([<in>] <area>;[<alle>] <ventilator>) (aan[ ](zetten|doen)|inschakelen)"
+          - "[<alle>] <ventilator> [<in>] <area> (aan[ ](zetten|doen)|inschakelen)"
         response: fans_area
         slots:
           domain: "fan"
 
       - sentences:
-          - "[<doe> ]<ventilator> [<naar> ]aan"
-          - "schakel <ventilator> [<naar> ]in"
-          - "[<doe> ](<hier>;[alle ]<ventilator>) [<naar> ]aan"
-          - "schakel (<hier>;[alle ]<ventilator>) [<naar> ]in"
-          - "[<doe> ][alle ]<ventilator> [<naar> ]aan <hier>"
-          - "schakel [alle ]<ventilator> [<naar> ]in <hier>"
-          - "[alle ]<ventilator> (<hier>;(aan[ ](zetten|doen)|inschakelen))"
-          - "<hier> [alle ]<ventilator> (aan[ ](zetten|doen)|inschakelen)"
+          - "[<doe>] <ventilator> [<naar>] aan"
+          - "schakel <ventilator> [<naar>] in"
+          - "[<doe>] (<hier>;[alle] <ventilator>) [<naar>] aan"
+          - "schakel (<hier>;[alle] <ventilator>) [<naar>] in"
+          - "[<doe>] [alle] <ventilator> [<naar>] aan <hier>"
+          - "schakel [alle] <ventilator> [<naar>] in <hier>"
+          - "[alle] <ventilator> (<hier>;(aan[ ](zetten|doen)|inschakelen))"
+          - "<hier> [alle] <ventilator> (aan[ ](zetten|doen)|inschakelen)"
           - "<ventilator> (aan[ ](zetten|doen)|inschakelen)"
         response: "fans_area"
         slots:

--- a/tests/nl/cover_HassTurnOff.yaml
+++ b/tests/nl/cover_HassTurnOff.yaml
@@ -4,8 +4,6 @@ tests:
       - Sluit het gordijn links
       - Doe het gordijn links dicht
       - Maak het gordijn links dicht
-      - Zal je het gordijn links dicht willen doen?
-      - Zou je het gordijn links willen dichtdoen?
     intent:
       name: HassTurnOff
       slots:
@@ -33,8 +31,6 @@ tests:
       - Sluit de garage
       - Doe de garage deur dicht
       - Garagedeur dicht
-      - Zou de garagedeur dicht mogen?
-      - Kun je de garagedeur sluiten?
     intent:
       name: HassTurnOff
       slots:
@@ -49,8 +45,6 @@ tests:
       - Gordijn links in woonkamer dicht
       - Gordijn links dicht in woonkamer
       - Sluit gordijn links woonkamer
-      - Zal je het gordijn links in de woonkamer dicht willen doen?
-      - Zal je het gordijn links in de woonkamer kunnen sluiten?
     intent:
       name: HassTurnOff
       slots:
@@ -67,7 +61,6 @@ tests:
       - Maak het rolluik achterdeur in keuken naar beneden
       - Rolluik achterdeur in keuken omlaag
       - Rolluik achterdeur keuken naar beneden
-      - Zal je het rolluik achterdeur in de keuken kunnen sluiten?
     intent:
       name: HassTurnOff
       slots:
@@ -80,7 +73,11 @@ tests:
 
   - sentences:
       - Sluit het gordijn in de woonkamer
-      - Mogen de gordijnen dicht in de woonkamer
+      - sluit in de woonkamer de gordijnen
+      - doe het gordijn in de woonkamer dicht
+      - doe in de woonkamer het gordijn dicht
+      - gordijn in de woonkamer sluiten
+      - in de woonkamer het gordijn sluiten
     intent:
       name: HassTurnOff
       slots:
@@ -91,17 +88,49 @@ tests:
 
   - sentences:
       - Mag de luxaflex dicht in de woonkamer
-      - Sluit de screens in de woonkamer
+      # - Sluit de screens in de woonkamer
       - Mag het screen in de woonkamer dicht?
       - Jaloezie woonkamer dicht
       - Rolluiken woonkamer omlaag
       - Doe de rolluiken in de woonkamer naar beneden
-      - Zal je de rolluiken in de woonkamer willen sluiten?
-      - Zou je de screens in de woonkamer kunnen sluiten?
     intent:
       name: HassTurnOff
       slots:
         area: Woonkamer
         device_class: blind
+        domain: cover
+    response: Gesloten
+
+  - sentences:
+      - Sluit het gordijn hier
+      - Doe hier de gordijnen dicht
+      - gordijnen hier sluiten
+      - hier de gordijnen sluiten
+      - doe de gordijnen hier dicht
+      - sluit hier het gordijn
+    intent:
+      name: HassTurnOff
+      context:
+        area: Woonkamer
+      slots:
+        device_class: curtain
+        area: Woonkamer
+        domain: cover
+    response: Gesloten
+
+  - sentences:
+      - Mag hier de luxaflex dicht
+      - Sluit de screens hier
+      - Mag het screen hier dicht?
+      - Jaloezie dicht
+      - Jaloezieën hier omlaag
+      - Doe hier de rolluiken naar beneden
+    intent:
+      name: HassTurnOff
+      context:
+        area: Woonkamer
+      slots:
+        device_class: blind
+        area: Woonkamer
         domain: cover
     response: Gesloten

--- a/tests/nl/cover_HassTurnOff.yaml
+++ b/tests/nl/cover_HassTurnOff.yaml
@@ -88,7 +88,7 @@ tests:
 
   - sentences:
       - Mag de luxaflex dicht in de woonkamer
-      # - Sluit de screens in de woonkamer
+      - Sluit de screens in de woonkamer
       - Mag het screen in de woonkamer dicht?
       - Jaloezie woonkamer dicht
       - Rolluiken woonkamer omlaag

--- a/tests/nl/cover_HassTurnOff.yaml
+++ b/tests/nl/cover_HassTurnOff.yaml
@@ -106,7 +106,7 @@ tests:
       - Doe hier de gordijnen dicht
       - gordijnen hier sluiten
       - hier de gordijnen sluiten
-      - doe de gordijnen hier dicht
+      - doe de gordijnen in deze kamer dicht
       - sluit hier het gordijn
     intent:
       name: HassTurnOff
@@ -123,7 +123,7 @@ tests:
       - Sluit de screens hier
       - Mag het screen hier dicht?
       - Jaloezie dicht
-      - Jaloezieën hier omlaag
+      - Jaloezieën in deze ruimte omlaag
       - Doe hier de rolluiken naar beneden
     intent:
       name: HassTurnOff

--- a/tests/nl/cover_HassTurnOn.yaml
+++ b/tests/nl/cover_HassTurnOn.yaml
@@ -104,7 +104,7 @@ tests:
     response: Geopend
 
   - sentences:
-      - Open het gordijn hier
+      - Open het gordijn in deze kamer
       - Doe hier de gordijnen open
       - gordijnen hier openen
       - hier de gordijnen openen
@@ -122,7 +122,7 @@ tests:
 
   - sentences:
       - Mag hier de luxaflex open
-      - Open de screens hier
+      - Open de screens in deze ruimte
       - Mag het screen hier open?
       - Jaloezie open
       - Jaloezieën hier omhoog

--- a/tests/nl/cover_HassTurnOn.yaml
+++ b/tests/nl/cover_HassTurnOn.yaml
@@ -18,7 +18,7 @@ tests:
       - Open gordijn links
       - Doe het gordijn links open
       - Maak gordijn links open
-      - Zal je het gordijn links open willen doen?
+      - Gordijn links open doen
     intent:
       name: HassTurnOn
       slots:
@@ -32,7 +32,7 @@ tests:
       - Open de garagedeur
       - Doe de garage open
       - Garage deur open
-      - Zou je de garagedeur open willen zetten
+      - Garagedeur open doen
     intent:
       name: HassTurnOn
       slots:
@@ -41,13 +41,12 @@ tests:
     response: Garage geopend
 
   - sentences:
-      - Open gordijn links in de woonkamer
-      - Doe gordijn links in de woonkamer open
-      - Maak het gordijn links in woonkamer open
+      - Open het gordijn links in de woonkamer
+      - Doe het gordijn links in de woonkamer open
+      - Maak het gordijn links in de woonkamer open
       - Gordijn links in woonkamer open
-      - Gordijn links woonkamer open
-      - Zal je het gordijn links in de woonkamer open willen doen?
-      - Zal je het gordijn links in de woonkamer kunnen openen?
+      - Gordijn links open in woonkamer
+      - Open gordijn links woonkamer
     intent:
       name: HassTurnOn
       slots:
@@ -62,8 +61,8 @@ tests:
       - Open rolluik achterdeur in de keuken
       - Doe rolluik achterdeur in de keuken omhoog
       - Maak het rolluik achterdeur in keuken naar boven
-      - Rolluik achterdeur keuken omhoog
-      - Zal je het rolluik achterdeur in de keuken kunnen openen?
+      - Rolluik achterdeur in keuken omhoog
+      - Rolluik achterdeur keuken naar boven
     intent:
       name: HassTurnOn
       slots:
@@ -76,9 +75,11 @@ tests:
 
   - sentences:
       - Open het gordijn in de woonkamer
-      - Vitrage woonkamer open
-      - Mogen de gordijnen open in de woonkamer
-      - Zal je het gordijn in de woonkamer willen openen?
+      - Open in de woonkamer de gordijnen
+      - doe het gordijn in de woonkamer open
+      - doe in de woonkamer het gordijn open
+      - gordijn in de woonkamer openen
+      - in de woonkamer het gordijn open doen
     intent:
       name: HassTurnOn
       slots:
@@ -90,10 +91,8 @@ tests:
   - sentences:
       - Mag de luxaflex open in de woonkamer
       - Open de screens in de woonkamer
-      - Open screens woonkamer
-      - Jaloezieën woonkamer open
-      - Rolluik omhoog in woonkamer
       - Mag het screen in de woonkamer open?
+      - Jaloezie woonkamer open
       - Rolluiken woonkamer omhoog
       - Doe de rolluiken in de woonkamer naar boven
     intent:
@@ -101,5 +100,39 @@ tests:
       slots:
         area: Woonkamer
         device_class: blind
+        domain: cover
+    response: Geopend
+
+  - sentences:
+      - Open het gordijn hier
+      - Doe hier de gordijnen open
+      - gordijnen hier openen
+      - hier de gordijnen openen
+      - doe de gordijnen hier open
+      - Open hier het gordijn
+    intent:
+      name: HassTurnOn
+      context:
+        area: Woonkamer
+      slots:
+        device_class: curtain
+        area: Woonkamer
+        domain: cover
+    response: Geopend
+
+  - sentences:
+      - Mag hier de luxaflex open
+      - Open de screens hier
+      - Mag het screen hier open?
+      - Jaloezie open
+      - Jaloezieën hier omhoog
+      - Doe hier de rolluiken naar boven
+    intent:
+      name: HassTurnOn
+      context:
+        area: Woonkamer
+      slots:
+        device_class: blind
+        area: Woonkamer
         domain: cover
     response: Geopend

--- a/tests/nl/fan_HassTurnOff.yaml
+++ b/tests/nl/fan_HassTurnOff.yaml
@@ -7,7 +7,7 @@ tests:
       - Doe de ventilatoren in de woonkamer uit
       - Zet de ventilator in het woonkamer op uit
       - Doe alle ventilatoren uit in de woonkamer
-      - Mogen de ventilators uit in de woonkamer?
+      - Mogen in de woonkamer de ventilators uit?
       - Zet alle ventilators in het woonkamer op uit
       - Zet alle woonkamer ventilatoren uit
       - Schakel in de woonkamer de ventilators uit
@@ -16,16 +16,13 @@ tests:
       - Mogen in de woonkamer de ventilatoren op uit?
       - Woonkamer ventilatoren uit
       - Ventilators woonkamer uit
-      - Zal je de ventilator in de woonkamer uit willen doen?
-      - Zal je de woonkamer ventilatoren uit willen doen?
       - Alle woonkamerventilators uitschakelen
-      - Zou u de ventilatoren in de woonkamer willen uitzetten?
     intent:
       name: HassTurnOff
       slots:
         area: Woonkamer
         domain: fan
-        name: all
+    response: Ventilatoren uitgezet
 
   - sentences:
       - Doe overal de ventilator uit
@@ -36,9 +33,27 @@ tests:
       - Schakel ventilatoren overal uit
       - Zet de ventilator overal uit
       - Mag de ventilator overal uit?
-      - Zal je alle ventilatoren uit willen doen?
     intent:
       name: HassTurnOff
       slots:
         domain: fan
-        name: all
+    response: Alle ventilatoren uitgezet
+
+  - sentences:
+      - Mag hier de ventilator uit
+      - Zet de ventilatoren in deze kamer uit
+      - Mag de ventilator uit in deze ruimte?
+      - Ventilator uit
+      - Ventilatoren in deze ruimte uit
+      - Doe hier de ventilator uit
+      - "hier de ventilatoren uitzetten"
+      - "ventilatoren uitschakelen"
+      - "ventilator uit doen hier"
+    intent:
+      name: HassTurnOff
+      context:
+        area: Woonkamer
+      slots:
+        area: Woonkamer
+        domain: fan
+    response: Ventilatoren uitgezet

--- a/tests/nl/fan_HassTurnOn.yaml
+++ b/tests/nl/fan_HassTurnOn.yaml
@@ -6,8 +6,8 @@ tests:
       - Doe de ventilator aan in de woonkamer
       - Doe de ventilator in de woonkamer aan
       - Zet de ventilatoren in woonkamer op aan
-      - Schakel de ventilators in de woonkamer in
-      - Doe de ventilators aan in de woonkamer
+      - Schakel in de woonkamer de ventilators in
+      - Doe de ventilators in de woonkamer aan
       - Schakel alle ventilatoren in de woonkamer in
       - Ventilatoren woonkamer aan
       - Doe alle woonkamer ventilators aan
@@ -17,13 +17,29 @@ tests:
       - Mogen in de woonkamer de ventilators aan?
       - Zet in de woonkamer de ventilator aan
       - Woonkamer ventilator aan
-      - Zal je de ventilator in de woonkamer aan willen doen?
-      - Zal je de woonkamer ventilatoren aan willen doen?
       - Alle woonkamerventilatoren inschakelen
-      - Zou u de ventilatoren in de woonkamer willen aan zetten?
     intent:
       name: HassTurnOn
       slots:
         area: Woonkamer
         domain: fan
-        name: all
+    response: Ventilatoren aangezet
+
+  - sentences:
+      - Mag hier de ventilator aan
+      - Zet de ventilatoren in deze kamer aan
+      - Mag de ventilator aan in deze ruimte?
+      - Ventilator aan
+      - Ventilatoren in deze ruimte aan
+      - Doe hier de ventilator aan
+      - "hier de ventilatoren aanzetten"
+      - "ventilatoren inschakelen"
+      - "ventilator aan doen hier"
+    intent:
+      name: HassTurnOn
+      context:
+        area: Woonkamer
+      slots:
+        area: Woonkamer
+        domain: fan
+    response: Ventilatoren aangezet


### PR DESCRIPTION
changes:
 * Add support for area aware intents
 * Added some additional combinations by allowing different word order
 * Some cleanup

Differences with EN
 * Add support for floors
 * The curtain intents are split off from the other device classes. If I look at my own situation, I have blinds for the sun, and curtains on the same window. I do not always want to close both, the blinds are closed on sunny days, while the curtains are closed after the sun has set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new expansion rule for "floor" and included "hier" as an option in generic expansion rules.

- **Enhancements**
  - Refined sentence structures for the `HassTurnOff` and `HassTurnOn` intents to improve the handling and control of covers like garage doors, curtains, blinds, shutters, and shades.

- **Tests**
  - Streamlined and enhanced test cases to cover new sentence variations for turning off and on various home devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->