### PR TITLE
[DE] add variants to HassMediaPrevious

### DIFF
--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -337,7 +337,7 @@ expansion_rules:
   naechster: "nächste[r|s|n]"
   vorheriger_letzter: "(vorherige|letzte)[r|s|n]"
   starte: (starte|spiele)
-  wiederhole: (wiederhole|zurück <zu_dem>)
+  wiederhole: (wiederhole[ <artikel_bestimmt>]|zurück <zu_dem>)
   song: "(Titel|Lied|Song|Track|Stück)"
   media_type: "(musik|[fernseh]sendung|gerät[e])"
 

--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -273,6 +273,7 @@ expansion_rules:
   auf: "(auf|hoch|rauf|nach oben)"
   zu: "(zu|[he]runter|nach unten)"
   von_dem: "(von[ dem]|vom)"
+  zu_dem: "(zu[ dem]|zum)"
   alle: "((alle|sämtliche)[r]|jede[r|s|n]|<artikel> (ganze|komplette|sämtliche)[n])[ der]"
   schliessen: "(schlie(ß|ss)[e|en]|zumachen|zu machen)"
   öffnen: "(öffne[n]|aufmachen|auf machen)"
@@ -336,6 +337,7 @@ expansion_rules:
   naechster: "nächste[r|s|n]"
   vorheriger_letzter: "(vorherige|letzte)[r|s|n]"
   starte: (starte|spiele)
+  wiederhole: (wiederhole|zurück <zu_dem>)
   song: "(Titel|Lied|Song|Track|Stück)"
   media_type: "(musik|[fernseh]sendung|gerät[e])"
 

--- a/sentences/de/media_player_HassMediaPrevious.yaml
+++ b/sentences/de/media_player_HassMediaPrevious.yaml
@@ -3,13 +3,13 @@ intents:
   HassMediaPrevious:
     data:
       - sentences:
-          - "[<starte> ]<vorheriger_letzter>[ <song>][ (<an>|am)][ <artikel_bestimmt>] <name>"
+          - "[(<starte>|<wiederhole>) ]<vorheriger_letzter>[ <song>][ (<an>|am)][ <artikel_bestimmt>] <name>"
         requires_context:
           domain: media_player
       - sentences:
-          - "[<starte> ]<vorheriger_letzter>[ <song>]"
+          - "[(<starte>|<wiederhole>) ]<vorheriger_letzter>[ <song>]"
         requires_context:
           area:
             slot: true
       - sentences:
-          - "[<starte> ]<vorheriger_letzter>[ <song>] <area>"
+          - "[(<starte>|<wiederhole>) ]<vorheriger_letzter>[ <song>] <area>"

--- a/tests/de/media_player_HassMediaPrevious.yaml
+++ b/tests/de/media_player_HassMediaPrevious.yaml
@@ -1,6 +1,16 @@
 language: de
 tests:
   - sentences:
+      - "Wiederhole letzten Titel auf TV"
+      - "Wiederhole letzten Titel am TV"
+      - "Wiederhole letzten Song auf TV"
+      - "Wiederhole letzten Song am TV"
+      - "Wiederhole letzten Song auf dem TV"
+      - "Zurück zum letzten Titel auf TV"
+      - "Zurück zum letzten Titel am TV"
+      - "Zurück zum letzten Song auf TV"
+      - "Zurück zum letzten Song am TV"
+      - "Zurück zum letzten Song auf dem TV"
       - "Vorheriger Titel auf TV"
       - "Vorheriger Titel am TV"
       - "Starte vorherigen Titel am TV"
@@ -21,6 +31,10 @@ tests:
         name: "TV"
     response: "Spiele vorheriges"
   - sentences:
+      - "Wiederhole letzten Titel im Wohnzimmer"
+      - "Wiederhole letzten Song im Wohnzimmer"
+      - "Zurück zum letzten Titel im Wohnzimmer"
+      - "Zurück zum letzten Song im Wohnzimmer"
       - "Vorheriger Titel im Wohnzimmer"
       - "Starte vorherigen Titel im Wohnzimmer"
       - "Starte vorherigen Song im Wohnzimmer"
@@ -39,6 +53,10 @@ tests:
         area: Wohnzimmer
     response: "Spiele vorheriges"
   - sentences:
+      - "Wiederhole letzten Titel"
+      - "Wiederhole letzten Song"
+      - "Zurück zum letzten Titel"
+      - "Zurück zum letzten Song"
       - "Vorheriger Titel"
       - "Starte vorherigen Titel"
       - "Starte vorherigen Song"

--- a/tests/de/media_player_HassMediaPrevious.yaml
+++ b/tests/de/media_player_HassMediaPrevious.yaml
@@ -2,6 +2,7 @@ language: de
 tests:
   - sentences:
       - "Wiederhole letzten Titel auf TV"
+      - "Wiederhole den letzten Titel auf TV"
       - "Wiederhole letzten Titel am TV"
       - "Wiederhole letzten Song auf TV"
       - "Wiederhole letzten Song am TV"
@@ -32,6 +33,7 @@ tests:
     response: "Spiele vorheriges"
   - sentences:
       - "Wiederhole letzten Titel im Wohnzimmer"
+      - "Wiederhole den letzten Titel im Wohnzimmer"
       - "Wiederhole letzten Song im Wohnzimmer"
       - "Zurück zum letzten Titel im Wohnzimmer"
       - "Zurück zum letzten Song im Wohnzimmer"
@@ -54,6 +56,7 @@ tests:
     response: "Spiele vorheriges"
   - sentences:
       - "Wiederhole letzten Titel"
+      - "Wiederhole den letzten Titel"
       - "Wiederhole letzten Song"
       - "Zurück zum letzten Titel"
       - "Zurück zum letzten Song"


### PR DESCRIPTION
added more variants as proposed in https://github.com/home-assistant/intents/pull/2254#pullrequestreview-2142758441

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced German language processing with refined directional phrases and commands.
	- Introduced the command "wiederhole" for repeating actions and expanded rule for "zu dem" as "zum".
	- Added flexibility in media playback control by allowing the option to start or repeat the previous song.

- **Tests**
	- Updated test scenarios to include new phrases for repeating and returning to the last title or song across different contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->