### PR TITLE
[SL] Added HassStartTimer

### DIFF
--- a/responses/sl/HassStartTimer.yaml
+++ b/responses/sl/HassStartTimer.yaml
@@ -1,0 +1,7 @@
+---
+language: sl
+responses:
+  intents:
+    HassStartTimer:
+      default: "Časovnik začet"
+      command: "Ukaz prejet"

--- a/sentences/sl/_common.yaml
+++ b/sentences/sl/_common.yaml
@@ -356,7 +356,7 @@ lists:
       to: 100
   timer_half:
     values:
-      - in: "[in] pol"
+      - in: "pol"
         out: 30
       - in: "1/2"
         out: 30
@@ -401,16 +401,18 @@ expansion_rules:
   luč: "luč[i|ke|ko|ki|k]|svetil[a|i|o]|razsvetljav[e|o|a]|svetilk[e|o|a]"
   position: "{position}[[ ]%| odstotkov|procentov]"
   volume: "{volume:volume_level}[[ ]%| (procent(a|ov)|odsotk(a|ov))]"
-
+  pol: "30 (minut|sekund)"
   # Questions
   kaksna_je_vrednost_senzorja: "((kakšna je) [vrednost [senzorja]] [za] <class> [v|na|za] [senzor[ju|ja]] <name> [[v|na] <area>] | (kakšna je) [vrednost [senzorja]] [za] <name> [[v|na] <area>] | (kakšen je|kakšna je) [vrednost] [napolnjenost|koncentracija|stopnja] [<class>] [v|na|za] [senzor[ju|ja]] <name> [[v|na] <area>] | kateri <class> [je|bo|bil] <name> )"
 
   # Timers
-  timer_set: "(zaženi|sproži|začni|nastavi|ustvari|kreiraj|štartaj|start)"
+  timer_set: "(zaženi|sproži|začni|nastavi|ustvari|kreiraj|štartaj|start|startaj)"
   timer_cancel: "(prekliči|ustavi|stop|štop)"
   timer_duration_seconds: "{timer_seconds:seconds} sekund[a|i|e]"
-  timer_duration_minutes: "{timer_minutes:minutes} minut[ [in ]{timer_seconds:seconds} sekund[a|i|e]]"
-  timer_duration_hours: "{timer_hours:hours} ur[a|i|e][ [in ]{timer_minutes:minutes} minut[a|i|e]][ [in ]{timer_seconds:seconds} sekund[a|i|e]]"
+  #timer_duration_minutes: "{timer_minutes:minutes} minut[ [in ]{timer_seconds:seconds} sekund[a|i|e]]"
+  timer_duration_minutes: "({timer_minutes:minutes} minut[e|i|o|a][ [in ]{timer_seconds:seconds} sekund[e|o|i|a]])|({timer_minutes:minutes} minut[e|o|i|a] in {timer_half:seconds})|({timer_half:seconds} minut[e|o|i|a])"
+  timer_duration_hours: "{timer_hours:hours} ur[a|i|e|o][ [in ]{timer_minutes:minutes} minut[a|i|e]][ [in ]{timer_seconds:seconds} sekund[a|i|e]]|({timer_hours:hours} [ur[i|o|a|e]] [in ] {timer_half:minutes} [ur[e|o|a|i]])|({timer_half:minutes} ur[e])"
+  #timer_duration_hours: "({timer_hours:hours} hour[s][ [and ]{timer_minutes:minutes} minute[s]][ [and ]{timer_seconds:seconds} second[s]])
   timer_duration: "<timer_duration_seconds>|<timer_duration_minutes>|<timer_duration_hours>"
 
   timer_start_seconds: "{timer_seconds:start_seconds} sekund[a|i|e|ni]"

--- a/sentences/sl/homeassistant_HassStartTimer.yaml
+++ b/sentences/sl/homeassistant_HassStartTimer.yaml
@@ -1,0 +1,21 @@
+---
+language: "sl"
+intents:
+  HassStartTimer:
+    data:
+      - sentences:
+          - "(<timer_duration> (časovnik|timer|tajmer|štoparica|odštevalnik) | (časovnik|timer|tajmer|štoparica|odštevalnik) <timer_duration>)"
+          - "(časovnik|timer|tajmer|štoparica|odštevalnik) za <timer_duration>"
+          - "[<timer_set>] <timer_duration>[ni|o] (časovnik|timer|tajmer|štoparica|odštevalnik)"
+          - "<timer_set> (časovnik|timer|tajmer|štoparica|odštevalnik) [za] <timer_duration>[o]"
+          - "[<timer_set>] (časovnik|timer|tajmer|štoparica|odštevalnik) [za] <timer_duration>[e|o|i|a]"
+          - "<timer_set> (časovnik|timer|tajmer|štoparica|odštevalnik) [za] <timer_duration>[o|e|i]"
+          - "[<timer_set>] <timer_duration>ni (časovnik|timer|tajmer|štoparica|odštevalnik)"
+          - "(časovnik|timer|tajmer|štoparica|odštevalnik) [za] <timer_duration>[ni|a|o|e|i]"
+          - "[<timer_set>] <timer_duration>[ni|a|o|e|i] (časovnik|timer|tajmer|štoparica|odštevalnik) (imenovan|po imenu|z imenom|poimenovan|za) {timer_name:name}"
+          - "[<timer_set>] (časovnik|timer|tajmer|štoparica|odštevalnik) (imenovan|po imenu|z imenom|poimenovan|za) {timer_name:name} [za] <timer_duration>"
+          - "[<timer_set>] (časovnik|timer|tajmer|štoparica|odštevalnik) [za] <timer_duration> (imenovan|po imenu|z imenom|poimenovan|za) {timer_name:name}"
+      - sentences:
+          - "{timer_command:conversation_command} (čez|v|po) <timer_duration>[ah|i]"
+          - "(čez|v|po) <timer_duration> {timer_command:conversation_command}"
+        response: command

--- a/tests/sl/homeassistant_HassStartTimer.yaml
+++ b/tests/sl/homeassistant_HassStartTimer.yaml
@@ -1,0 +1,180 @@
+---
+language: sl
+tests:
+  - sentences:
+      - "časovnik 10 minut"
+      - "10 minut tajmer"
+      - "timer za 10 minut"
+    intent:
+      name: HassStartTimer
+      slots:
+        minutes: 10
+    response: Časovnik začet
+
+  - sentences:
+      - "začni 1 urni časovnik"
+      - "nastavi timer za 1 uro"
+      - "startaj 1 urni timer"
+      - "1 urni tajmer"
+      - "timer za 1 uro"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        hours: 1
+    response: Časovnik začet
+
+  - sentences:
+      - "nastavi timer za 5 minut in 30 sekund"
+      - "nastavi timer za 5 minut in pol"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        minutes: 5
+        seconds: 30
+    response: Časovnik začet
+
+  - sentences:
+      - "nastavi timer za 1/2 minut"
+      - "nastavi časovnik za pol minute"
+      - "timer za 1/2 minute"
+      - "timer za pol minute"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        seconds: 30
+    response: Časovnik začet
+
+  - sentences:
+      - "nastavi timer za 1 uro in pol"
+      - "nastavi timer za 1 uro in 1/2"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        hours: 1
+        minutes: 30
+    response: Časovnik začet
+
+  - sentences:
+      - "nastavi timer za pol ure"
+      - "nastavi timer za 1/2 ure"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        minutes: 30
+    response: Časovnik začet
+
+  - sentences:
+      - "nastavi časovnik za 1 uro in 15 minut"
+      - "nastavi timer za 1 uro in  15 minut"
+      - "1 ura in 15 minut časovnik"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        hours: 1
+        minutes: 15
+    response: Časovnik začet
+
+  - sentences:
+      - "nastavi časovnik za 1 uro in 30 sekund"
+      - "timer 1 ura in 30 sekund"
+      - "1 ura in 30 sekund časovnik"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        hours: 1
+        seconds: 30
+    response: Časovnik začet
+
+  - sentences:
+      - "nastavi časovnik za 1 uro 15 minut in 30 sekund"
+      - "1 ura 15 minut 30 sekund timer"
+      - "nastavi timer 1 ura, 15 minut, 30 sekund"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        hours: 1
+        minutes: 15
+        seconds: 30
+    response: Časovnik začet
+
+  - sentences:
+      - "začni 5 minutni timer"
+      - "5 minutni timer"
+      - "timer za 5 minut"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        minutes: 5
+    response: Časovnik začet
+
+  - sentences:
+      - "nastavi 5 minutni timer po imenu pizza"
+      - "5 minutni časovnik za pizzo"
+      - "nastavi timer po imenu pizza za 5 minut"
+      - "timer za 5 minut po imenu pizza"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        minutes: 5
+        name:
+          - "pizza "
+          - "pizza"
+          - "pizzo"
+    response: Časovnik začet
+
+  - sentences:
+      - "nastavi 5 minut in 10 sekund timer"
+      - "timer za 5 minut in 10 sekund"
+      - "5 minut 10 sekund timer"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        minutes: 5
+        seconds: 10
+    response: Časovnik začet
+
+  - sentences:
+      - "nastavi 45 sekundni timer"
+      - "timer za 45 sekund"
+      - "45 sekundni timer"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        seconds: 45
+    response: Časovnik začet
+
+  - sentences:
+      - "odpri garažna vrata čez 5 minut"
+      - "čez 5 minut odpri garažna vrata"
+    intent:
+      name: HassStartTimer
+      slots:
+        minutes: 5
+        conversation_command:
+          - "odpri garažna vrata"
+          - "odpri garažna vrata "
+    response: Ukaz prejet


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Slovenian language support for timer-related intents, including the ability to start timers with various durations and names in Home Assistant.
  - Enhanced flexibility in specifying timer durations (minutes, hours, seconds) with different expressions.

- **Improvements**
  - Refined timer duration expressions for better clarity and usability.
  - Improved slot extraction for more accurate timer configurations.

- **Tests**
  - Introduced comprehensive test cases for the `HassStartTimer` intent in Slovenian, validating timer settings and durations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->