### PR TITLE
[SL] Added HassPauseTimer

### DIFF
--- a/responses/sl/HassPauseTimer.yaml
+++ b/responses/sl/HassPauseTimer.yaml
@@ -1,0 +1,6 @@
+---
+language: sl
+responses:
+  intents:
+    HassPauseTimer:
+      default: "Časovnik zaustavljen"

--- a/sentences/sl/_common.yaml
+++ b/sentences/sl/_common.yaml
@@ -417,7 +417,7 @@ expansion_rules:
 
   timer_start_seconds: "{timer_seconds:start_seconds} sekund[a|i|e|ni]"
   timer_start_minutes: "{timer_minutes:start_minutes} minut[a|i|e|ni][ [in ]{timer_seconds:start_seconds} sekund[a|i|e|ni]]"
-  timer_start_hours: "{timer_hours:start_hours}ur[a|i|e|ni][ [in ]{timer_minutes:start_minutes} minut[a|i|e|ni]][ [in ]{timer_seconds:start_seconds} sekund[a|i|e|ni]]"
+  timer_start_hours: "{timer_hours:start_hours}ur[a|i|e|ni|o][ [in ]{timer_minutes:start_minutes} minut[a|i|e|ni|o]][ [in ]{timer_seconds:start_seconds} sekund[a|i|e|ni|o]]"
   timer_start: "<timer_start_seconds>|<timer_start_minutes>|<timer_start_hours>"
 
 skip_words:

--- a/sentences/sl/homeassistant_HassPauseTimer.yaml
+++ b/sentences/sl/homeassistant_HassPauseTimer.yaml
@@ -1,0 +1,17 @@
+---
+language: "sl"
+intents:
+  HassPauseTimer:
+    data:
+      - sentences:
+          - "([daj na] (pavziraj|premor)) [moj] (časovnik|timer|tajmer|štoparico|odštevalnik)"
+          - "[daj] (časovnik|timer|tajmer|štoparico|odštevalnik) [na] (premor|pavzo)"
+          - "(pavziraj|[daj na] premor) [moj] <timer_start>ni (časovnik|timer|tajmer|štoparico|odštevalnik)"
+          - "(pavziraj|[daj na] premor) [moj] (časovnik|timer|tajmer|štoparico|odštevalnik) [za] <timer_start>"
+          - "(pavziraj|[daj na] premor) [moj] <timer_start>ni (časovnik|timer|tajmer|štoparico|odštevalnik)"
+          # - "pause[ the| my] {area} timer"
+          # - "pause[ the| my] timer in <area>"
+          - "(pavziraj|[daj na] premor)[moj] {timer_name:name} (časovnik|timer|tajmer|štoparico|odštevalnik)"
+          - "(daj [moj] {timer_name:name} (časovnik|timer|tajmer|štoparico|odštevalnik) na pavzo)"
+          - "(pavziraj|[daj na] premor|[[daj] na] pavzo) [moj] (časovnik|timer|tajmer|štoparico|odštevalnik) (poimenovan|po imenu|poimenovan) {timer_name:name}"
+          - "(daj [moj] (časovnik|timer|tajmer|štoparico|odštevalnik) (poimenovan|po imenu|poimenovan) {timer_name:name} na (pavzo|premor))"

--- a/tests/sl/homeassistant_HassPauseTimer.yaml
+++ b/tests/sl/homeassistant_HassPauseTimer.yaml
@@ -1,0 +1,43 @@
+---
+language: sl
+tests:
+  - sentences:
+      - "daj na premor timer"
+      - "daj timer na premor"
+      - "timer premor"
+    intent:
+      name: HassPauseTimer
+    response: Časovnik zaustavljen
+
+  - sentences:
+      - "pavziraj 1 urni timer"
+      - "pavziraj časovnik za 1 uro"
+      - "daj na premor časovnik za 1 uro"
+      - "daj na premor 1 urni časovnik"
+    intent:
+      name: HassPauseTimer
+      slots:
+        start_hours: 1
+    response: Časovnik zaustavljen
+
+  - sentences:
+      - "pavziraj pizza timer"
+      - "daj pizza timer na pavzo"
+      - "pavziraj moj časovnik poimenovan pizza"
+      - "daj moj časovnik po imenu pizza na pavzo"
+    intent:
+      name: HassPauseTimer
+      slots:
+        name:
+          - "pizza "
+          - "pizza"
+    response: Časovnik zaustavljen
+
+  # - sentences:
+  #     - "pause kitchen timer"
+  #     - "pause timer in kitchen"
+  #   intent:
+  #     name: HassPauseTimer
+  #     slots:
+  #       area: Kitchen
+  #   response: Timer paused


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced Slovenian language support for pausing timers with the `HassPauseTimer` intent in Home Assistant.
  
- **Enhancements**
  - Expanded the range of expressions for timer start phrases in Slovenian, allowing for more diverse and detailed commands.

- **Tests**
  - Added Slovenian test cases for pausing timers in Home Assistant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->