### PR TITLE
[SL] Added MediaPrevious

### DIFF
--- a/responses/sl/HassMediaPrevious.yaml
+++ b/responses/sl/HassMediaPrevious.yaml
@@ -1,0 +1,5 @@
+language: sl
+responses:
+  intents:
+    HassMediaPrevious:
+      default: "Predvajam prejšnjo"

--- a/sentences/sl/media_player_HassMediaNext.yaml
+++ b/sentences/sl/media_player_HassMediaNext.yaml
@@ -3,7 +3,7 @@ intents:
   HassMediaNext:
     data:
       - sentences:
-          - "[predvajajo] naslednj(o|i|e) [pesem|skladno|oddajo|element|posnetek|epizodo|komad] [na] <name>"
+          - "[predvajaj] naslednj(o|i|e) [pesem|skladbo|oddajo|element|posnetek|epizodo|komad] [na] <name>"
           - "(preskoči [na naslednj(i|o|a|o)] [pesem|skladbo|komad|štiklc|epizodo] ;[na ]<name>)"
         requires_context:
           domain: media_player

--- a/sentences/sl/media_player_HassMediaPrevious.yaml
+++ b/sentences/sl/media_player_HassMediaPrevious.yaml
@@ -1,0 +1,25 @@
+language: sl
+intents:
+  HassMediaPrevious:
+    data:
+      - sentences:
+          - "[predvajaj] (prejšnj(o|i|e)| zadnj(o|i|e)) [pesem|skladbo|oddajo|element|posnetek|epizodo|komad]; [na] <name>"
+          - "vrni [se na] (prejšnj(o|i|e)| zadnj(o|i|e)) [pesem|skladbo|oddajo|element|posnetek|epizodo|komad]; [na] <name>"
+          - "ponovi (prejšnj(o|i|e) | zadnj(o|i|e)) [pesem|skladbo|oddajo|element|posnetek|epizodo|komad] [na] <name>"
+          - "<name> [ponovno] (predvajaj|ponovi|vrni se) [na] (prejšnj(o|i|e)| zadnj(o|i|e)) [pesem|skladbo|oddajo|element|posnetek|epizodo|komad]"
+        requires_context:
+          domain: media_player
+
+      - sentences:
+          - "pojdi nazaj [[na] (prejšnj(o|i|e)| zadnj(o|i|e)) [pesem|skladbo|oddajo|element|posnetek|epizodo|komad]]"
+          - "ponovi (prejšnj(o|i|e) | zadnj(o|i|e)) [pesem|skladbo|oddajo|element|posnetek|epizodo|komad]"
+          - "ponov(i|no) (predvajaj|zavrti) (prejšnj(o|i|e)| zadnj(o|i|e)) [pesem|skladbo|oddajo|element|posnetek|epizodo|komad]"
+          - "(ponovitev|ponovi)"
+        requires_context:
+          area:
+            slot: true
+      - sentences:
+          - "pojdi nazaj [na] [(prejšnj(o|i|e) | zadnj(o|i|e)) [pesem|skladbo|oddajo|element|posnetek|epizodo|komad]] [v|na ] <area>"
+          - "(ponov(i|no) [(predvajaj|zavrti)] [(prejšnj(o|i|e) | zadnj(o|i|e))] [pesem|skladbo|oddajo|element|posnetek|epizodo|komad]; [v|na ] <area>)"
+          - "((predvajaj|zavrti) (prejšnj(o|i|e) | zadnj(o|i|e)) [pesem|skladbo|oddajo|element|posnetek|epizodo|komad] [ponovno];[v|na ] <area>)"
+          - "[v|na ] <area> [ponov(i|no)] (predvajaj|zavrti) (prejšnj(o|i|e) | zadnj(o|i|e)) [pesem|skladbo|oddajo|element|posnetek|epizodo|komad]"

--- a/tests/sl/media_player_HassMediaPrevious.yaml
+++ b/tests/sl/media_player_HassMediaPrevious.yaml
@@ -1,0 +1,46 @@
+language: sl
+tests:
+  - sentences:
+      - "predvajaj prejšnji element na TV"
+      - "vrni se na prejšnjo skladbo na TV"
+      - "ponovi zadnjo skladbo na TV"
+      - "TV predvajaj prejšnji element"
+      - "TV vrni se na prejšnjo skladbo"
+      - "TV prejšnjo skladbo"
+      - "TV predvajaj prejšnjo skladbo"
+      - "TV ponovno predvajaj prejšnjo skladbo"
+      - "TV ponovi zadnjo skladbo"
+    intent:
+      name: HassMediaPrevious
+      slots:
+        name: "TV"
+    response: "Predvajam prejšnjo"
+
+  - sentences:
+      - "pojdi nazaj"
+      - "pojdi nazaj na prejšnjo skladbo"
+      - "pojdi nazaj na zadnjo skladbo"
+      - "ponovi zadnjo"
+      - "ponovno predvajaj zadnjo skladbo"
+      - "ponovitev"
+    intent:
+      name: HassMediaPrevious
+      slots:
+        area: "Living Room"
+      context:
+        area: Living Room
+    response: "Predvajam prejšnjo"
+
+  - sentences:
+      - "pojdi nazaj v dnevni sobi"
+      - "pojdi nazaj na prejšnjo skladbo v dnevni sobi"
+      - "pojdi nazaj na zadnjo skladbo v dnevni sobi"
+      - "ponovi zadnjo skladbo v dnevni sobi"
+      - "v dnevni sobi ponovno zavrti zadnjo skladbo"
+    intent:
+      name: HassMediaPrevious
+      slots:
+        area: "dnevni sobi"
+      context:
+        area: Living Room
+    response: "Predvajam prejšnjo"


### PR DESCRIPTION
Added Slovenian translation for media_player_HassMediaPrevious

Fixed typo in media_player_HassMediaNext

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Slovenian language support for the `HassMediaPrevious` intent to handle commands for playing the previous media item.
  - Introduced new test cases in Slovenian for media player controls.

- **Improvements**
  - Refined sentence patterns in Slovenian for the `HassMediaNext` intent to enhance command recognition for playing the next media item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->