### PR TITLE
Don't use strftime in date/time responses

### DIFF
--- a/responses/en/HassGetCurrentDate.yaml
+++ b/responses/en/HassGetCurrentDate.yaml
@@ -3,6 +3,20 @@ responses:
   intents:
     HassGetCurrentDate:
       default: >
+        {% set months = {
+           1: 'January',
+           2: 'February',
+           3: 'March',
+           4: 'April',
+           5: 'May',
+           6: 'June',
+           7: 'July',
+           8: 'August',
+           9: 'September',
+           10: 'October',
+           11: 'November',
+           12: 'December',
+        } %}
         {% set ordinal = {
            1: '1st',
            2: '2nd',
@@ -36,4 +50,4 @@ responses:
            30: '30th',
            31: '31st',
          } %}
-        {{ slots.date.strftime('%B') }} {{ ordinal[slots.date.day] }}, {{ slots.date.year }}
+        {{ months[slots.date.month] }} {{ ordinal[slots.date.day] }}, {{ slots.date.year }}

--- a/responses/en/HassGetCurrentTime.yaml
+++ b/responses/en/HassGetCurrentTime.yaml
@@ -3,9 +3,10 @@ responses:
   intents:
     HassGetCurrentTime:
       default: >
-        {% set time_str = slots.time.strftime('%I:%M %p') %}
-        {% if time_str.startswith('0'): -%}
-        {{ time_str[1:] }}
+        {% set minute_str = '{0:02d}'.format(slots.time.minute) %}
+
+        {% if slots.time.hour <= 12: %}
+        {{ slots.time.hour }}:{{ minute_str }} AM
         {% else: %}
-        {{ time_str }}
+        {{ slots.time.hour - 12 }}:{{ minute_str }} PM
         {% endif %}


### PR DESCRIPTION
`strftime` will use the machine's current locale, not the intent's language :man_facepalming: 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated date format to use a dictionary for month names, improving localization support.
  - Enhanced time formatting to correctly handle AM/PM times across different locales.
  
- **Bug Fixes**
  - Corrected time formatting logic to ensure accurate display of hours and minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->