### PR TITLE
[SL] added Current Date and Current Time

### DIFF
--- a/responses/sl/HassGetCurrentDate.yaml
+++ b/responses/sl/HassGetCurrentDate.yaml
@@ -1,0 +1,53 @@
+language: sl
+responses:
+  intents:
+    HassGetCurrentDate:
+      default: >
+        {% set months = {
+           1: 'januar',
+           2: 'februar',
+           3: 'marec',
+           4: 'april',
+           5: 'maj',
+           6: 'junij',
+           7: 'julij',
+           8: 'avgust',
+           9: 'september',
+           10: 'oktober',
+           11: 'november',
+           12: 'december',
+        } %}
+        {% set ordinal = {
+           1: '1.',
+           2: '2.',
+           3: '3.',
+           4: '4.',
+           5: '5.',
+           6: '6.',
+           7: '7.',
+           8: '8.',
+           9: '9.',
+           10: '10.',
+           11: '11.',
+           12: '12.',
+           13: '13.',
+           14: '14.',
+           15: '15.',
+           16: '16.',
+           17: '17.',
+           18: '18.',
+           19: '19.',
+           20: '20.',
+           21: '21.',
+           22: '22.',
+           23: '23.',
+           24: '24.',
+           25: '25.',
+           26: '26.',
+           27: '27.',
+           28: '28.',
+           29: '29.',
+           30: '30.',
+           31: '31.',
+         } %}
+         {{ slots.date.day }}. {{ months[slots.date.month] }} {{ slots.date.year }}

--- a/responses/sl/HassGetCurrentTime.yaml
+++ b/responses/sl/HassGetCurrentTime.yaml
@@ -1,0 +1,16 @@
+language: sl
+responses:
+  intents:
+    HassGetCurrentTime:
+      default: >
+        {% set hour_str = '{0:02d}'.format(slots.time.hour) %}
+        {% set minute_str = '{0:02d}'.format(slots.time.minute) %}
+        {{ hour_str }}:{{ minute_str }}
+      # default: >
+      #   # {% set minute_str = '{0:02d}'.format(slots.time.minute) %}
+
+      #   # {% if slots.time.hour <= 12: %}
+      #   # {{ slots.time.hour }}:{{ minute_str }} AM
+      #   # {% else: %}
+      #   # {{ slots.time.hour - 12 }}:{{ minute_str }} PM
+      #   # {% endif %}

--- a/sentences/sl/homeassistant_HassGetCurrentDate.yaml
+++ b/sentences/sl/homeassistant_HassGetCurrentDate.yaml
@@ -1,0 +1,10 @@
+language: sl
+intents:
+  HassGetCurrentDate:
+    data:
+      - sentences:
+          - "([povej [mi]] kateri|katerega) [smo] [dan je] danes"
+          - "([povej [mi]] današnji datum)"
+          - "([povej [mi]] kateri dan je [danes])"
+          - "([povej [mi]] kateri je danes)"
+          - "([povej [mi]] kirega smo [danes])"

--- a/sentences/sl/homeassistant_HassGetCurrentTime.yaml
+++ b/sentences/sl/homeassistant_HassGetCurrentTime.yaml
@@ -1,0 +1,8 @@
+language: sl
+intents:
+  HassGetCurrentTime:
+    data:
+      - sentences:
+          - "([povej [mi]]) koliko je ura"
+          - "trenutna ura"
+          - "([povej [mi]]) trenuten čas"

--- a/tests/sl/homeassistant_HassGetCurrentDate.yaml
+++ b/tests/sl/homeassistant_HassGetCurrentDate.yaml
@@ -1,0 +1,12 @@
+language: sl
+tests:
+  - sentences:
+      - "kateri dan je danes"
+      - "katerega smo danes"
+      - "povej mi današnji datum"
+      - "današnji datum"
+      - "kateri je danes"
+      - "kirega smo danes" #for slovenian speaking folks: se opravičujem, narečna varianta stavka in testa dodani na posebno zahtevo :)
+    intent:
+      name: HassGetCurrentDate
+    response: 17. september 2013

--- a/tests/sl/homeassistant_HassGetCurrentTime.yaml
+++ b/tests/sl/homeassistant_HassGetCurrentTime.yaml
@@ -1,0 +1,12 @@
+language: sl
+tests:
+  - sentences:
+      - "koliko je ura"
+      - "trenutna ura"
+      - "trenuten čas"
+      # - "what time is it"
+      # - "what time is it right now"
+      # - "tell me the time"
+    intent:
+      name: HassGetCurrentTime
+    response: 01:02


### PR DESCRIPTION
Added Slovenian translation for HassCurrentDate and HassCurrentTime

Response for current time maybe not correct or perfect for Slovenian time format...needs change. Example: **0**1:02 - > 1:02
TODO: modify response file for CurrentTime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced Slovenian language support for querying the current date (`HassGetCurrentDate`) and current time (`HassGetCurrentTime`) in Home Assistant.

- **Tests**
  - Added test cases for Slovenian language intents to ensure accurate responses for current date and time queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->