### PR TITLE
[FR] Time and Date intents

### DIFF
--- a/responses/fr/HassGetCurrentDate.yaml
+++ b/responses/fr/HassGetCurrentDate.yaml
@@ -1,0 +1,27 @@
+language: fr
+responses:
+  intents:
+    HassGetCurrentDate:
+      default: >
+        {% set months = {
+           1: 'janvier',
+           2: 'février',
+           3: 'mars',
+           4: 'avril',
+           5: 'mai',
+           6: 'juin',
+           7: 'juillet',
+           8: 'août',
+           9: 'septembre',
+           10: 'octobre',
+           11: 'novembre',
+           12: 'décembre',
+        } %}
+
+        Nous sommes le
+        {% if slots.date.day == 1 -%}
+          premier
+        {%- else -%}
+          {{slots.date.day}}
+        {%- endif %}
+         {{ months[slots.date.month] }} {{ slots.date.year }}

--- a/responses/fr/HassGetCurrentTime.yaml
+++ b/responses/fr/HassGetCurrentTime.yaml
@@ -1,0 +1,8 @@
+language: fr
+responses:
+  intents:
+    HassGetCurrentTime:
+      default: >
+        {% set minute_str = '{0:02d}'.format(slots.time.minute) %}
+        {% set hour_str = '{0:02d}'.format(slots.time.hour) %}
+        Il est {{ hour_str }}:{{ minute_str }}

--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -678,7 +678,7 @@ expansion_rules:
   diminue: "(diminue|diminuer|baisse|baisser)"
   eclaire: "(éclaire|éclairer|illumine|illuminer)"
   eteins: "(éteint|eteint|éteins|eteins|éteindre|eteindre|désactive|désactiver|stoppe|stopper|arrête|arrêter|coupe|couper|<eteins_dirty>)"
-  ferme: "(ferme|fermer|baisse|baisser)"
+  ferme: "(ferme|fermer|baisse|baisser|<ferme_dirty>)"
   lis: "(lis|lire)"
   mets: "(mets|mettre|passe|passer|<mets_dirty>)"
   ouvre: "(ouvre|ouvrir|monte|monter)"
@@ -695,6 +695,8 @@ expansion_rules:
   eteins_dirty: "(étant|étends|étend|étendre|état|et tant|et teins|et teint|et teints|et t'as|été|étais|était)"
   # Mets
   mets_dirty: "(mais|maître)"
+  # ferme
+  ferme_dirty: "faire"
 
   # Domains and Things
   lumiere: "(lumière|lampe|ampoule)"

--- a/sentences/fr/homeassistant_HassGetCurrentDate.yaml
+++ b/sentences/fr/homeassistant_HassGetCurrentDate.yaml
@@ -1,0 +1,16 @@
+language: fr
+intents:
+  HassGetCurrentDate:
+    data:
+      - sentences:
+          - "Quel jour sommes-nous[ aujourd'hui]"
+          - "Quelle est la date[ d'aujourd'hui]"
+          - "Quelle est la date aujourd'hui"
+          - "Quelle est la date du jour"
+          - "On est quel jour[ aujourd'hui]"
+          - "On est le combien[ aujourd'hui]"
+          - "Nous sommes le combien[ aujourd'hui]"
+          - "C'est quoi la date[ aujourd'hui]"
+          - "C'est quoi la date du jour"
+          - "Quel jour est-il"
+          - "Quel jour est il"

--- a/sentences/fr/homeassistant_HassGetCurrentTime.yaml
+++ b/sentences/fr/homeassistant_HassGetCurrentTime.yaml
@@ -1,0 +1,8 @@
+language: fr
+intents:
+  HassGetCurrentTime:
+    data:
+      - sentences:
+          - "Quelle heure est-il[ maintenant]"
+          - "Quelle heure est il[ maintenant]"
+          - "Il est quelle heure[ maintenant]"

--- a/tests/fr/homeassistant_HassGetCurrentDate.yaml
+++ b/tests/fr/homeassistant_HassGetCurrentDate.yaml
@@ -1,0 +1,19 @@
+language: fr
+tests:
+  - sentences:
+      - "Quel jour sommes-nous?"
+      - "Quel jour sommes-nous aujourd'hui?"
+      - "Quelle est la date?"
+      - "Quelle est la date aujourd'hui?"
+      - "Quelle est la date du jour?"
+      - "On est le combien?"
+      - "On est le combien aujourd'hui?"
+      - "Nous sommes le combien?"
+      - "Nous sommes le combien aujourd'hui?"
+      - "C'est quoi la date?"
+      - "C'est quoi la date du jour?"
+      - "Quel jour est-il?"
+      - "Quel jour est il?"
+    intent:
+      name: HassGetCurrentDate
+    response: Nous sommes le 17 septembre 2013

--- a/tests/fr/homeassistant_HassGetCurrentTime.yaml
+++ b/tests/fr/homeassistant_HassGetCurrentTime.yaml
@@ -1,0 +1,10 @@
+language: fr
+tests:
+  - sentences:
+      - "Quelle heure est-il?"
+      - "Quelle heure est-il maintenant?"
+      - "Quelle heure est il?"
+      - "Il est quelle heure?"
+    intent:
+      name: HassGetCurrentTime
+    response: Il est 01:02


### PR DESCRIPTION
## Date
Added intent for getting the current date.
- Months are correctly translated
- I am using the ordinal form for the first day of the month (`Premier janvier` vs `2 janvier`)
- I decided to go with the response `Nous sommes le <date>`

## Time
Added intent for getting the current time.
- I kept the answer very simple: `Il est 12:45` 

Note: I tested the speech synthesis on both HA Cloud and Piper for that `XX:XX` format.
Both are generating understandable answers!

_It is still to be noted that HA Cloud provides better results for a few special cases_
Here are a few examples:
- The "hour sharp" case: `13:00`
  - HA Cloud: `Il est treize heures`
  - Piper: `Il est treize heures zéro zéro` 
- The "midnight" case: `00:15`
  - HA Cloud: `Il est minuit quize`
  - Piper: `Il est zéro heure quize`

## Others
I added one more "dirty" transcription that I keep hitting over and over again at home: 
`Ferme les volets` is almost always translated to `Faire les volets`... 
So now this form works too.

_I am so looking forward to a fuzzy matching logic at some point..._