### PR TITLE
[SL] Current Time fix for time format

### DIFF
--- a/responses/sl/HassGetCurrentTime.yaml
+++ b/responses/sl/HassGetCurrentTime.yaml
@@ -3,6 +3,5 @@ responses:
   intents:
     HassGetCurrentTime:
       default: >
-        {% set hour_str = '{0:02d}'.format(slots.time.hour) %}
         {% set minute_str = '{0:02d}'.format(slots.time.minute) %}
-        {{ hour_str }}:{{ minute_str }}
+        {{ slots.time.hour }}:{{ minute_str }}

--- a/tests/sl/homeassistant_HassGetCurrentTime.yaml
+++ b/tests/sl/homeassistant_HassGetCurrentTime.yaml
@@ -6,4 +6,4 @@ tests:
       - "trenuten čas"
     intent:
       name: HassGetCurrentTime
-    response: 01:02
+    response: "1:02"


### PR DESCRIPTION
Fix in response file for CurrentTime. Output time format '1:02' instead '01:02'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the time format in the `HassGetCurrentTime` intent response to display the hour without leading zeros.
  - Adjusted the corresponding test scenario to match the new time format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->