### PR TITLE
[he] added `nevermind` intent

### DIFF
--- a/sentences/he/homeassistant_HassNevermind.yaml
+++ b/sentences/he/homeassistant_HassNevermind.yaml
@@ -1,0 +1,9 @@
+language: he
+intents:
+  HassNevermind:
+    data:
+      - sentences:
+          - "לא משנה"
+          - "ביטול"
+          - "עצור|עצרי"
+          - "בטל[י]"

--- a/tests/he/homeassistant_HassNevermind.yaml
+++ b/tests/he/homeassistant_HassNevermind.yaml
@@ -1,0 +1,11 @@
+language: he
+tests:
+  - sentences:
+      - "לא משנה"
+      - "ביטול"
+      - "עצור"
+      - "עצרי"
+      - "בטל"
+      - "בטלי"
+    intent:
+      name: HassNevermind


### PR DESCRIPTION
Added `nevermind` intent,  which allows to cancel the flow on false invocations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Hebrew language support for the `HassNevermind` intent, allowing users to cancel commands with phrases like "לא משנה" and "ביטול".

- **Tests**
  - Introduced test cases in Hebrew for the `HassNevermind` intent to ensure accurate recognition and response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->