### PR TITLE
lb-CurrentDate-CurrentTime

### DIFF
--- a/responses/lb/HassGetCurrentDate.yaml
+++ b/responses/lb/HassGetCurrentDate.yaml
@@ -1,0 +1,29 @@
+language: lb
+responses:
+  intents:
+    HassGetCurrentDate:
+      default: >
+        {% set months = {
+           1: 'Januar',
+           2: 'Februar',
+           3: 'März',
+           4: 'Abrëll',
+           5: 'Mee',
+           6: 'Juni',
+           7: 'Juli',
+           8: 'August',
+           9: 'September',
+           10: 'Oktober',
+           11: 'November',
+           12: 'Dezember',
+        } %}
+        {% set weekday = [
+          'Méindeg',
+          'Dënschdeg',
+          'Mëttwoch',
+          'Donneschdeg',
+          'Freideg',
+          'Samsdeg',
+          'Sonndeg'
+        ] %}
+        Haut ass {{ weekday[slots.date.weekday()] }}, den {{ slots.date.day }}. {{ months[slots.date.month] }} {{ slots.date.year }}

--- a/responses/lb/HassGetCurrentTime.yaml
+++ b/responses/lb/HassGetCurrentTime.yaml
@@ -1,0 +1,11 @@
+language: lb
+responses:
+  intents:
+    HassGetCurrentTime:
+      # return both hours and minutes with padded zeros so it is pronounced correctly by TTS
+      # "Es ist 1:02" results in spoken "Es ist eins null zwei"
+      # "Es ist 01:02" results in spoken "Es ist ein Uhr zwei"
+      default: >
+        {% set hour_str = '{0:02d}'.format(slots.time.hour) %}
+        {% set minute_str = '{0:02d}'.format(slots.time.minute) %}
+        Et ass {{ hour_str }}:{{ minute_str }}

--- a/sentences/lb/_common.yaml
+++ b/sentences/lb/_common.yaml
@@ -112,6 +112,7 @@ expansion_rules:
   brightness: "{brightness}[%| Prozent]"
   light: "([d']Luut[en] | [d']Luucht[en] | [d']Beliichtung)"
   switch: "([d']Schalteren | [d']Steckdous[en] | [de] Schalter)"
+
 skip_words:
   - "wannechgelift"
   - "merci"

--- a/sentences/lb/homeassistant_HassGetCurrentDate.yaml
+++ b/sentences/lb/homeassistant_HassGetCurrentDate.yaml
@@ -1,0 +1,7 @@
+language: lb
+intents:
+  HassGetCurrentDate:
+    data:
+      - sentences:
+          - "Wéien Dag ass haut"
+          - "De wéivillte[n] si mer [haut]"

--- a/sentences/lb/homeassistant_HassGetCurrentTime.yaml
+++ b/sentences/lb/homeassistant_HassGetCurrentTime.yaml
@@ -1,0 +1,7 @@
+language: lb
+intents:
+  HassGetCurrentTime:
+    data:
+      - sentences:
+          - "Wéi vill Auer ass et [elo]"
+          - "Wéi spéit ass et [elo]"

--- a/tests/lb/homeassistant_HassGetCurrentDate.yaml
+++ b/tests/lb/homeassistant_HassGetCurrentDate.yaml
@@ -1,0 +1,8 @@
+language: lb
+tests:
+  - sentences:
+      - "Wéien Dag ass haut"
+      - "De wéivillte si mer"
+    intent:
+      name: HassGetCurrentDate
+    response: Haut ass Dënschdeg, den 17. September 2013

--- a/tests/lb/homeassistant_HassGetCurrentTime.yaml
+++ b/tests/lb/homeassistant_HassGetCurrentTime.yaml
@@ -1,0 +1,8 @@
+language: lb
+tests:
+  - sentences:
+      - "Wéi vill Auer ass et elo"
+      - "Wéi spéit ass et"
+    intent:
+      name: HassGetCurrentTime
+    response: Et ass 01:02


### PR DESCRIPTION
Current date and time intents in Luxembourgish

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving and formatting the current date in Luxembourgish.
  - Added support for retrieving and formatting the current time in Luxembourgish.
  - Expanded vocabulary in Luxembourgish for Home Assistant, including translation for "switch" and new skip words.

- **Tests**
  - Introduced test cases for validating date and time queries in Luxembourgish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->