### PR TITLE
HassSetPosition

### DIFF
--- a/responses/zh-hk/HassSetPosition.yaml
+++ b/responses/zh-hk/HassSetPosition.yaml
@@ -1,0 +1,5 @@
+language: zh-hk
+responses:
+  intents:
+    HassSetPosition:
+      default: "Position set"

--- a/sentences/zh-hk/_common.yaml
+++ b/sentences/zh-hk/_common.yaml
@@ -3,12 +3,16 @@ settings:
   ignore_whitespace: true
 responses:
   errors:
+    # General errors
     no_intent: "對唔住，我聽不明白"
+    handle_error: "處理時發生意外錯誤"
+
+    # Errors for when user is not logged in
     no_area: "沒有區域名叫 {{ area }}"
     no_domain_in_area: "區域名 {{ area }} 不包含 {{ domain }}"
     no_device_class_in_area: "區域名 {{ area }} 不包含 {{ device_class }}"
     no_entity: "無設備或實體叫 {{ entity }}"
-    handle_error: "處理時發生意外錯誤"
+
 lists:
   color:
     values:
@@ -96,12 +100,19 @@ lists:
         out: shutter
       - in: "窗戶"
         out: window
+
   lock_states:
     values:
       - in: "(已上鎖|鎖著|鎖上|鎖了|鎖咗)[的|嘅]"
         out: locked
       - in: "(已解鎖|沒[有][上]鎖|無[上]鎖)[的|嘅]"
         out: unlocked
+
+  position:
+    range:
+      type: "percentage"
+      from: 0
+      to: 100
 
 expansion_rules:
   name: "{name}[的|嘅]"
@@ -123,9 +134,11 @@ expansion_rules:
   set_to: "(設置|設定|調節|調)(為|到|至)"
   turn_on: "(打開|開啟|開|着)"
   turn_off: "(關閉|關掉|關了|關|閂)"
-  open: "(打開|開)"
+  open: "(打開|開|開大|開放|擴大)"
   close: "(關閉|關掉|關了|關|閂)"
   light: "(燈|吸頂燈|筒燈|射燈|檯燈|台燈|床頭燈|燈光)[的|嘅]"
   temp: "溫度"
   temperature: "{temperature} [{temperature_unit}]"
+  numeric_value_set: "(調整|set|change|turn|increase|decrease|make)"
+  position: "{position}[[ ]%| percent]"
 skip_words: []

--- a/sentences/zh-hk/cover_HassSetPosition.yaml
+++ b/sentences/zh-hk/cover_HassSetPosition.yaml
@@ -1,0 +1,15 @@
+language: zh-hk
+intents:
+  HassSetPosition:
+    data:
+      - sentences:
+          - "(<numeric_value_set>|<open>|<close>) <name> [position ] <to> <position>"
+        requires_context:
+          domain: cover
+        slots:
+          domain: cover
+
+      - sentences:
+          - "(<numeric_value_set>|<open>|<close>)<area>{cover_classes:device_class}[ position] <to> <position>"
+        slots:
+          domain: cover

--- a/sentences/zh-hk/valve_HassSetPosition.yaml
+++ b/sentences/zh-hk/valve_HassSetPosition.yaml
@@ -1,0 +1,10 @@
+language: zh-hk
+intents:
+  HassSetPosition:
+    data:
+      - sentences:
+          - "(<numeric_value_set>|<open>|<close>) <name> [position ] <to> <position>"
+        requires_context:
+          domain: valve
+        slots:
+          domain: valve

--- a/tests/zh-hk/_fixtures.yaml
+++ b/tests/zh-hk/_fixtures.yaml
@@ -2,14 +2,29 @@ language: zh-hk
 areas:
   - name: "廚房"
     id: kitchen
+    # prepositional floor
+    floor: "First Floor"
+
   - name: "客廳"
     id: living_room
+    floor: "First Floor"
+
   - name: "睡房"
     id: bedroom
+    floor: "Second Floor"
+
   - name: "車房"
     id: garage
+    floor: "First Floor"
+
   - name: "玄關"
     id: entrance
+    floor: "First Floor"
+
+  - name: "辦公室"
+    id: office
+    floor: "Basement"
+
 entities:
   - name: "廚房開關制"
     id: switch.kitchen
@@ -48,6 +63,7 @@ entities:
       out: "closed"
     attributes:
       device_class: curtain
+      #position: "0"
 
   - name: "走廊恆溫器"
     id: climate.thermostat_hallway
@@ -116,3 +132,11 @@ entities:
     attributes:
       temperature: "76"
       temperature_unit: "°F"
+
+  - name: "主活門"
+    id: "valve.main_valve"
+    state:
+      in: "打開"
+      out: "open"
+    attributes:
+      position: "100"

--- a/tests/zh-hk/cover_HassSetPosition.yaml
+++ b/tests/zh-hk/cover_HassSetPosition.yaml
@@ -1,0 +1,24 @@
+language: zh-hk
+tests:
+  - sentences:
+      - "調整睡房窗簾到50%"
+      - "打開睡房窗簾到50%"
+      - "關閉睡房窗簾到50%"
+    intent:
+      name: HassSetPosition
+      slots:
+        domain: cover
+        name: "睡房窗簾"
+        position: 50
+    response: "Position set"
+
+  - sentences:
+      - "調整睡房的窗簾到50%"
+    intent:
+      name: HassSetPosition
+      slots:
+        domain: cover
+        device_class: "curtain"
+        area: "睡房"
+        position: 50
+    response: "Position set"

--- a/tests/zh-hk/valve_HassSetPosition.yaml
+++ b/tests/zh-hk/valve_HassSetPosition.yaml
@@ -1,0 +1,12 @@
+language: zh-hk
+tests:
+  - sentences:
+      - "調整 主活門 到 100"
+      - "開大 主活門 到 100"
+    intent:
+      name: HassSetPosition
+      slots:
+        domain: valve
+        name: "主活門"
+        position: 100
+    response: "Position set"


### PR DESCRIPTION
This change is for HassSetPosition (zh-hk)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for setting positions of covers and valves in home automation using Chinese (Hong Kong) language intents.
  - Introduced new error messages and updated existing ones for improved error handling.
  - Enhanced synonym recognition and numeric value handling for a better user experience.
  
- **Tests**
  - Added comprehensive test cases for cover and valve position setting intents in Chinese (Hong Kong) language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->