### PR TITLE
HassVacuumStart

### DIFF
--- a/responses/zh-hk/HassVacuumStart.yaml
+++ b/responses/zh-hk/HassVacuumStart.yaml
@@ -1,0 +1,5 @@
+language: zh-hk
+responses:
+  intents:
+    HassVacuumStart:
+      default: "Started"

--- a/sentences/zh-hk/_common.yaml
+++ b/sentences/zh-hk/_common.yaml
@@ -141,4 +141,5 @@ expansion_rules:
   temperature: "{temperature} [{temperature_unit}]"
   numeric_value_set: "(調整|set|change|turn|increase|decrease|make)"
   position: "{position}[[ ]%| percent]"
+  start: "(開始|開動)"
 skip_words: []

--- a/sentences/zh-hk/vacuum_HassVacuumStart.yaml
+++ b/sentences/zh-hk/vacuum_HassVacuumStart.yaml
@@ -1,0 +1,8 @@
+language: zh-hk
+intents:
+  HassVacuumStart:
+    data:
+      - sentences:
+          - "開始 <name>"
+        requires_context:
+          domain: vacuum

--- a/tests/zh-hk/_fixtures.yaml
+++ b/tests/zh-hk/_fixtures.yaml
@@ -140,3 +140,7 @@ entities:
       out: "open"
     attributes:
       position: "100"
+
+  - name: "Rover"
+    id: "vacuum.rover"
+    state: "idle"

--- a/tests/zh-hk/vacuum_HassVacuumStart.yaml
+++ b/tests/zh-hk/vacuum_HassVacuumStart.yaml
@@ -1,0 +1,9 @@
+language: zh-hk
+tests:
+  - sentences:
+      - "開始 rover"
+    intent:
+      name: HassVacuumStart
+      slots:
+        name: "Rover"
+    response: "Started"


### PR DESCRIPTION
zh-hk - HassVacuumStart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `HassVacuumStart` intent in Chinese (Hong Kong), allowing users to start their vacuum with specific commands in the language.
  - Implemented a new response in Chinese (Hong Kong) for the `HassVacuumStart` intent, providing the default reply "Started."
  - Introduced expansion rules for the word "start" in Chinese (Hong Kong) with translations "開始" and "開動."
  
- **Tests**
  - Added a test case for the `HassVacuumStart` intent in Chinese (Hong Kong), verifying the functionality with the command "開始 rover."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->