### PR TITLE
HassVacuumReturnToBase

### DIFF
--- a/responses/zh-hk/HassVacuumReturnToBase.yaml
+++ b/responses/zh-hk/HassVacuumReturnToBase.yaml
@@ -1,0 +1,5 @@
+language: zh-hk
+responses:
+  intents:
+    HassVacuumReturnToBase:
+      default: "開始返回"

--- a/responses/zh-hk/HassVacuumStart.yaml
+++ b/responses/zh-hk/HassVacuumStart.yaml
@@ -2,4 +2,4 @@ language: zh-hk
 responses:
   intents:
     HassVacuumStart:
-      default: "Started"
+      default: "開始"

--- a/sentences/zh-hk/_common.yaml
+++ b/sentences/zh-hk/_common.yaml
@@ -142,4 +142,5 @@ expansion_rules:
   numeric_value_set: "(調整|set|change|turn|increase|decrease|make)"
   position: "{position}[[ ]%| percent]"
   start: "(開始|開動)"
+  return: "(返回)"
 skip_words: []

--- a/sentences/zh-hk/vacuum_HassVacuumReturnToBase.yaml
+++ b/sentences/zh-hk/vacuum_HassVacuumReturnToBase.yaml
@@ -1,0 +1,9 @@
+language: zh-hk
+intents:
+  HassVacuumReturnToBase:
+    data:
+      - sentences:
+          - "<return> <name>"
+          - "<return> <name>[<to>基地]"
+        requires_context:
+          domain: vacuum

--- a/tests/zh-hk/vacuum_HassVacuumReturnToBase.yaml
+++ b/tests/zh-hk/vacuum_HassVacuumReturnToBase.yaml
@@ -1,0 +1,10 @@
+language: zh-hk
+tests:
+  - sentences:
+      - "返回 rover"
+      - "返回 rover 到 基地"
+    intent:
+      name: HassVacuumReturnToBase
+      slots:
+        name: "Rover"
+    response: "開始返回"

--- a/tests/zh-hk/vacuum_HassVacuumStart.yaml
+++ b/tests/zh-hk/vacuum_HassVacuumStart.yaml
@@ -6,4 +6,4 @@ tests:
       name: HassVacuumStart
       slots:
         name: "Rover"
-    response: "Started"
+    response: "開始"


### PR DESCRIPTION
zh-hk - HassVacuumReturnToBase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for the `HassVacuumReturnToBase` intent in Chinese (Hong Kong), including a default message "開始返回" ("Start returning").
	- Introduced a new keyword "return" to enhance action vocabulary in Chinese (Hong Kong).

- **Bug Fixes**
	- Updated the response for the `HassVacuumStart` intent to "開始" in Chinese (Hong Kong).

- **Tests**
	- Added test cases for the `HassVacuumReturnToBase` intent in Chinese (Hong Kong).
	- Updated test cases for `HassVacuumStart` intent to reflect the new response "開始".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->