### PR TITLE
HassPauseTimer

### DIFF
--- a/responses/zh-hk/HassPauseTimer.yaml
+++ b/responses/zh-hk/HassPauseTimer.yaml
@@ -1,0 +1,5 @@
+language: zh-hk
+responses:
+  intents:
+    HassPauseTimer:
+      default: "計時器暫停"

--- a/sentences/zh-hk/_common.yaml
+++ b/sentences/zh-hk/_common.yaml
@@ -189,6 +189,7 @@ expansion_rules:
   my: "(我的|我個)"
   how much: "(幾多)"
   left: "([還|重]剩)"
+  pause: "(暫停)"
   hour: "(小時|個鐘|鐘頭|個鐘頭)"
   minute: "(分鐘)"
   second: "(秒)"

--- a/sentences/zh-hk/homeassistant_HassPauseTimer.yaml
+++ b/sentences/zh-hk/homeassistant_HassPauseTimer.yaml
@@ -1,0 +1,9 @@
+language: zh-hk
+intents:
+  HassPauseTimer:
+    data:
+      - sentences:
+          - "<pause>[<my>] <timer>"
+          - "<pause><timer_start> <timer>"
+          - "<pause> {area} <timer>"
+          - "<pause> {timer_name:name} <timer>"

--- a/tests/zh-hk/homeassistant_HassPauseTimer.yaml
+++ b/tests/zh-hk/homeassistant_HassPauseTimer.yaml
@@ -1,0 +1,33 @@
+language: zh-hk
+tests:
+  - sentences:
+      - "暫停 計時器"
+      - "暫停 我 個 計時器"
+    intent:
+      name: HassPauseTimer
+    response: 計時器暫停
+
+  - sentences:
+      - "暫停 1 小時 計時器"
+    intent:
+      name: HassPauseTimer
+      slots:
+        start_hours: 1
+    response: 計時器暫停
+
+  - sentences:
+      - "暫停 廚房 計時器"
+    intent:
+      name: HassPauseTimer
+      slots:
+        area: 廚房
+    response: 計時器暫停
+
+  - sentences:
+      - "暫停 pizza 計時器"
+    intent:
+      name: HassPauseTimer
+      slots:
+        name:
+          - "pizza"
+    response: 計時器暫停


### PR DESCRIPTION
zh-hk - HassPauseTimer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for pausing timers in Traditional Chinese (Hong Kong) for Home Assistant.
  - Added various sentence structures for pausing timers in Chinese (Hong Kong).
  - Implemented test cases for pausing timers covering multiple scenarios in Traditional Chinese (Hong Kong).
  
- **Localization**
  - Added the term "pause" with the translation "(暫停)" to the expansion rules for Chinese (Hong Kong).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->