### PR TITLE
HassUnpauseTimer

### DIFF
--- a/responses/zh-hk/HassUnpauseTimer.yaml
+++ b/responses/zh-hk/HassUnpauseTimer.yaml
@@ -1,0 +1,5 @@
+language: zh-hk
+responses:
+  intents:
+    HassUnpauseTimer:
+      default: "計時器恢復"

--- a/sentences/zh-hk/_common.yaml
+++ b/sentences/zh-hk/_common.yaml
@@ -190,6 +190,7 @@ expansion_rules:
   how much: "(幾多)"
   left: "([還|重]剩)"
   pause: "(暫停)"
+  resume: "(恢復|繼續)"
   hour: "(小時|個鐘|鐘頭|個鐘頭)"
   minute: "(分鐘)"
   second: "(秒)"

--- a/sentences/zh-hk/homeassistant_HassUnpauseTimer.yaml
+++ b/sentences/zh-hk/homeassistant_HassUnpauseTimer.yaml
@@ -1,0 +1,9 @@
+language: zh-hk
+intents:
+  HassUnpauseTimer:
+    data:
+      - sentences:
+          - "<resume>[<my>] <timer>"
+          - "<resume>[<my>] <timer_start> <timer>"
+          - "<resume>[<my>] {area} <timer>"
+          - "<resume>[<my>] {timer_name:name} <timer>"

--- a/tests/zh-hk/homeassistant_HassUnpauseTimer.yaml
+++ b/tests/zh-hk/homeassistant_HassUnpauseTimer.yaml
@@ -1,0 +1,33 @@
+language: zh-hk
+tests:
+  - sentences:
+      - "恢復 計時器"
+      - "繼續 我 個 計時器"
+    intent:
+      name: HassUnpauseTimer
+    response: 計時器恢復
+
+  - sentences:
+      - "恢復 1 小時 倒數器"
+    intent:
+      name: HassUnpauseTimer
+      slots:
+        start_hours: 1
+    response: 計時器恢復
+
+  - sentences:
+      - "恢復 廚房 倒數器"
+    intent:
+      name: HassUnpauseTimer
+      slots:
+        area: 廚房
+    response: 計時器恢復
+
+  - sentences:
+      - "繼續 pizza 計時器"
+    intent:
+      name: HassUnpauseTimer
+      slots:
+        name:
+          - "pizza"
+    response: 計時器恢復


### PR DESCRIPTION
zh-hk - HassUnpauseTimer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Chinese (Hong Kong) language support for the Home Assistant skill related to unpausing timers.
  - Introduced semantic expansion rules for the term "resume" in Chinese (Hong Kong).
- **Tests**
  - Added test cases in Chinese (Hong Kong) for the intent to resume timers in Home Assistant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->