### PR TITLE
[FI] added HassMediaPrevious

### DIFF
--- a/responses/fi/HassMediaPrevious.yaml
+++ b/responses/fi/HassMediaPrevious.yaml
@@ -1,0 +1,5 @@
+language: fi
+responses:
+  intents:
+    HassMediaPrevious:
+      default: "Toistetaan edellinen"

--- a/sentences/fi/media_player_HassMediaPrevious.yaml
+++ b/sentences/fi/media_player_HassMediaPrevious.yaml
@@ -1,0 +1,8 @@
+language: fi
+intents:
+  HassMediaPrevious:
+    data:
+      - sentences:
+          - "edellinen [raita|biisi|kappale|jakso] [laitteelle|laitteella] <nimi>"
+        requires_context:
+          domain: media_player

--- a/tests/fi/media_player_HassMediaPrevious.yaml
+++ b/tests/fi/media_player_HassMediaPrevious.yaml
@@ -1,0 +1,10 @@
+language: fi
+tests:
+  - sentences:
+      - "edellinen jakso laitteella TV "
+      - "edellinen laitteella TV "
+    intent:
+      name: HassMediaPrevious
+      slots:
+        name: "TV"
+    response: "Toistetaan edellinen"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced Finnish language support for the "HassMediaPrevious" intent in the media player component.
  - Added default response text in Finnish for actions requesting the previous media item.
  
- **Tests**
  - Implemented test scenarios in Finnish for the "HassMediaPrevious" intent to ensure proper functionality and responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->