### PR TITLE
[zh-hk] HassStartTimer

### DIFF
--- a/responses/zh-hk/HassStartTimer.yaml
+++ b/responses/zh-hk/HassStartTimer.yaml
@@ -1,0 +1,6 @@
+language: zh-hk
+responses:
+  intents:
+    HassStartTimer:
+      default: "Timer started"
+      command: "收到命令"

--- a/sentences/zh-hk/_common.yaml
+++ b/sentences/zh-hk/_common.yaml
@@ -145,10 +145,32 @@ lists:
       to: 100
   timer_half:
     values:
-      - in: "half"
+      - in: "半"
         out: 30
       - in: "1/2"
         out: 30
+  timer_5minute:
+    values:
+      - in: "一個字"
+        out: 5
+      - in: "兩個字"
+        out: 10
+      - in: "三個字"
+        out: 15
+      - in: "四個字"
+        out: 20
+      - in: "五個字"
+        out: 25
+      - in: "七個字"
+        out: 35
+      - in: "八個字"
+        out: 40
+      - in: "九個字"
+        out: 45
+      - in: "十個字"
+        out: 50
+      - in: "十一個字"
+        out: 55
   timer_name:
     wildcard: true
   timer_command:
@@ -191,16 +213,17 @@ expansion_rules:
   left: "([還|重]剩)"
   pause: "(暫停)"
   resume: "(恢復|繼續)"
-  hour: "(小時|個鐘|鐘頭|個鐘頭)"
-  minute: "(分鐘)"
-  second: "(秒)"
+  for: "(到)"
+  hour: "(小時|鐘|個|個鐘|鐘頭|個鐘頭|)"
+  minute: "(分鐘|分|)"
+  second: "(秒|)"
 
   # Timers
-  timer_set: "(start|set|create)"
+  timer_set: "(開始|放置|撥|set)"
   timer_cancel: "(cancel|stop)"
-  timer_duration_seconds: "{timer_seconds:seconds} second[s]"
-  timer_duration_minutes: "({timer_minutes:minutes} minute[s][ [and ]{timer_seconds:seconds} second[s]])|({timer_minutes:minutes} and[ a] {timer_half:seconds} minute[s])|({timer_half:seconds} a minute[s])"
-  timer_duration_hours: "({timer_hours:hours} hour[s][ [and ]{timer_minutes:minutes} minute[s]][ [and ]{timer_seconds:seconds} second[s]])|({timer_hours:hours} and[ a] {timer_half:minutes} hour[s])|({timer_half:minutes} an hour[s])"
+  timer_duration_seconds: "{timer_seconds:seconds} <second>"
+  timer_duration_minutes: "({timer_minutes:minutes} <minute>[ [and ]{timer_seconds:seconds} <second>])|({timer_minutes:minutes} [and[ a]] {timer_half:seconds}[<minute>])|({timer_half:seconds} <minute>)|({timer_5minute:minutes} [<minute>])"
+  timer_duration_hours: "({timer_hours:hours} <hour>[ [and ]{timer_minutes:minutes} <minute>][ [and ]{timer_seconds:seconds} <second>])|({timer_hours:hours}[<hour>] [and[ a]] {timer_half:minutes} [<hour>])|({timer_half:minutes} <hour>)"
   timer_duration: "<timer_duration_seconds>|<timer_duration_minutes>|<timer_duration_hours>"
 
   timer_start_seconds: "{timer_seconds:start_seconds} <second>"

--- a/sentences/zh-hk/homeassistant_HassStartTimer.yaml
+++ b/sentences/zh-hk/homeassistant_HassStartTimer.yaml
@@ -1,0 +1,12 @@
+language: zh-hk
+intents:
+  HassStartTimer:
+    data:
+      - sentences:
+          - "<timer_duration> <timer>"
+          - "<timer_set>[<my>] <timer_duration> <timer>"
+          - "<timer_set>[ a| the| my] <timer> <for> <timer_duration>"
+          - "<timer_set>[ a| the| my] {timer_name:name} <timer> <for> <timer_duration>"
+          - "{timer_command:conversation_command} in <timer_duration>"
+          - "<timer_duration> 後 {timer_command:conversation_command} "
+        response: command

--- a/tests/zh-hk/homeassistant_HassStartTimer.yaml
+++ b/tests/zh-hk/homeassistant_HassStartTimer.yaml
@@ -1,0 +1,256 @@
+language: zh-hk
+tests:
+  - sentences:
+      - "10 分鐘 倒數器"
+    intent:
+      name: HassStartTimer
+      slots:
+        minutes: 10
+    response: 收到命令
+
+  - sentences:
+      - "開始 1 小時 計時器"
+      - "撥 計時器 到 1 小時"
+      - "set 計時器 到 1 小時"
+      - "set 計時器 到 1 個鐘"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        hours: 1
+    response: 收到命令
+
+  - sentences:
+      - "撥 計時器 到 5 分鐘 30 秒"
+      - "撥 計時器 到 5 分 30 秒"
+      #- "撥 計時器 到 5 分 半"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        minutes: 5
+        seconds: 30
+    response: 收到命令
+
+  - sentences:
+      - "撥 計時器 到 半 分鐘"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        seconds: 30
+    response: 收到命令
+
+  - sentences:
+      - "撥 計時器 到 1 個鐘頭 30 分鐘"
+      - "撥 計時器 到 1 個鐘 半"
+      - "撥 計時器 到 1 個 半 鐘"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        hours: 1
+        minutes: 30
+    response: 收到命令
+
+  - sentences:
+      - "撥 計時器 到 半 個鐘"
+      - "撥 計時器 到 30 分鐘"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        minutes: 30
+    response: 收到命令
+
+  - sentences:
+      - "撥 計時器 到 1 個鐘頭 15 分鐘"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        hours: 1
+        minutes: 15
+    response: 收到命令
+
+  - sentences:
+      - "撥 計時器 到 1 個鐘頭 30 秒"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        hours: 1
+        seconds: 30
+    response: 收到命令
+
+  - sentences:
+      - "撥 計時器 到 1 個鐘頭 15 分 30 秒"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        hours: 1
+        minutes: 15
+        seconds: 30
+    response: 收到命令
+
+  - sentences:
+      - "撥 計時器 到 5 分鐘"
+      - "撥 計時器 到 一個字"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        minutes: 5
+    response: 收到命令
+
+  - sentences:
+      - "撥 計時器 到 10 分鐘"
+      - "撥 計時器 到 兩個字"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        minutes: 10
+    response: 收到命令
+
+  - sentences:
+      - "撥 計時器 到 15 分鐘"
+      - "撥 計時器 到 三個字"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        minutes: 15
+    response: 收到命令
+
+  - sentences:
+      - "撥 計時器 到 20 分鐘"
+      - "撥 計時器 到 四個字"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        minutes: 20
+    response: 收到命令
+
+  - sentences:
+      - "撥 計時器 到 25 分鐘"
+      - "撥 計時器 到 五個字"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        minutes: 25
+    response: 收到命令
+
+  - sentences:
+      - "撥 計時器 到 35 分鐘"
+      - "撥 計時器 到 七個字"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        minutes: 35
+    response: 收到命令
+
+  - sentences:
+      - "撥 計時器 到 40 分鐘"
+      - "撥 計時器 到 八個字"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        minutes: 40
+    response: 收到命令
+
+  - sentences:
+      - "撥 計時器 到 45 分鐘"
+      - "撥 計時器 到 九個字"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        minutes: 45
+    response: 收到命令
+
+  - sentences:
+      - "撥 計時器 到 50 分鐘"
+      - "撥 計時器 到 十個字"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        minutes: 50
+    response: 收到命令
+
+  - sentences:
+      - "撥 計時器 到 55 分鐘"
+      - "撥 計時器 到 十一個字"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        minutes: 55
+    response: 收到命令
+
+  - sentences:
+      - "set pizza 計時器 到 5 分鐘"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        minutes: 5
+        name:
+          - "pizza"
+    response: 收到命令
+
+  - sentences:
+      - "撥 計時器 到 5 分 10 秒"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        minutes: 5
+        seconds: 10
+    response: 收到命令
+
+  - sentences:
+      - "撥 計時器 到 45 秒"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Living Room
+      slots:
+        seconds: 45
+    response: 收到命令
+
+  - sentences:
+      - "12 分鐘 後 open the garage door "
+    intent:
+      name: HassStartTimer
+      slots:
+        minutes: 12
+        conversation_command:
+          - "openthegaragedoor"
+    response: 收到命令


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced responses and intents in Chinese (Hong Kong) for starting timers with the Home Assistant skill.
  - Added support for timer durations in Chinese characters for intervals ranging from 5 to 55 minutes.
  
- **Tests**
  - Added tests for starting timers using natural language in Chinese (Hong Kong), covering various timer durations and expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->