### PR TITLE
[zh-hk] HassMediaPause

### DIFF
--- a/responses/zh-hk/HassMediaPause.yaml
+++ b/responses/zh-hk/HassMediaPause.yaml
@@ -1,0 +1,5 @@
+language: zh-hk
+responses:
+  intents:
+    HassMediaPause:
+      default: "暫停完成"

--- a/sentences/zh-hk/media_player_HassMediaPause.yaml
+++ b/sentences/zh-hk/media_player_HassMediaPause.yaml
@@ -1,0 +1,17 @@
+language: zh-hk
+intents:
+  HassMediaPause:
+    data:
+      - sentences:
+          - "(暫停;<name>)"
+        requires_context:
+          domain: media_player
+
+      - sentences:
+          - "pause"
+        requires_context:
+          area:
+            slot: true
+
+      - sentences:
+          - "暫停 <area> [ [<the>| <my>](music|[tv ]show[s]|media[ player[s]]) ]"

--- a/tests/zh-hk/media_player_HassMediaPause.yaml
+++ b/tests/zh-hk/media_player_HassMediaPause.yaml
@@ -1,0 +1,32 @@
+language: zh-hk
+tests:
+  - sentences:
+      - "暫停 TV"
+      - "TV 暫停"
+    intent:
+      name: HassMediaPause
+      slots:
+        name: "TV"
+    response: "暫停完成"
+
+  - sentences:
+      - "pause"
+    intent:
+      name: HassMediaPause
+      slots:
+        area: "Living Room"
+      context:
+        area: Living Room
+    response: "暫停完成"
+
+  - sentences:
+      - "暫停 客廳 music"
+      - "暫停 客廳 media player"
+      - "暫停 客廳 tv show"
+    intent:
+      name: HassMediaPause
+      slots:
+        area: "客廳"
+      context:
+        area: Living Room
+    response: "暫停完成"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `HassMediaPause` intent in Chinese (Hong Kong), including various ways to express pausing media playback.

- **Tests**
  - Introduced test cases for `HassMediaPause` in Chinese (Hong Kong), covering various contexts such as TV, living room, and specific media types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->