### PR TITLE
[zh-hk] HassMediaUnpause

### DIFF
--- a/responses/zh-hk/HassMediaUnpause.yaml
+++ b/responses/zh-hk/HassMediaUnpause.yaml
@@ -1,0 +1,5 @@
+language: zh-hk
+responses:
+  intents:
+    HassMediaUnpause:
+      default: "繼續"

--- a/sentences/zh-hk/_common.yaml
+++ b/sentences/zh-hk/_common.yaml
@@ -222,7 +222,6 @@ expansion_rules:
   my: "(我的|我個|我嗰個|我嘅)"
   how much: "(幾多)"
   left: "([還|重]剩)"
-  pause: "(暫停)"
   resume: "(恢復|繼續)"
   for: "(到)"
   hour: "(小時|鐘|個|個鐘|鐘頭|個鐘頭|)"
@@ -230,6 +229,8 @@ expansion_rules:
   second: "(秒|)"
   up: "(高)"
   down: "(低)"
+  pause: "(暫停)"
+  unpause: "(取消暫停|恢復|繼續)"
 
   # Timers
   timer_set: "(開始|放置|撥|set)"

--- a/sentences/zh-hk/media_player_HassMediaUnpause.yaml
+++ b/sentences/zh-hk/media_player_HassMediaUnpause.yaml
@@ -1,17 +1,17 @@
 language: zh-hk
 intents:
-  HassMediaPause:
+  HassMediaUnpause:
     data:
       - sentences:
-          - "(<pause>;<name>)"
+          - "((<unpause>);<name>)"
         requires_context:
           domain: media_player
 
       - sentences:
-          - "<pause>"
+          - "<unpause>"
         requires_context:
           area:
             slot: true
 
       - sentences:
-          - "<pause> <area> [ [<the>| <my>](music|[tv ]show[s]|media[ player[s]]) ]"
+          - "<unpause> <area> [ [<the>| <my>](music|[tv ]show[s]|media[ player[s]]) ]"

--- a/tests/zh-hk/media_player_HassMediaPause.yaml
+++ b/tests/zh-hk/media_player_HassMediaPause.yaml
@@ -10,7 +10,7 @@ tests:
     response: "暫停完成"
 
   - sentences:
-      - "pause"
+      - "暫停"
     intent:
       name: HassMediaPause
       slots:

--- a/tests/zh-hk/media_player_HassMediaUnpause.yaml
+++ b/tests/zh-hk/media_player_HassMediaUnpause.yaml
@@ -1,0 +1,35 @@
+language: zh-hk
+tests:
+  - sentences:
+      - "繼續 TV"
+      - "TV 繼續"
+      - "恢復 TV"
+      - "TV 恢復"
+    intent:
+      name: HassMediaUnpause
+      slots:
+        name: "TV"
+    response: "繼續"
+
+  - sentences:
+      - "繼續"
+      - "恢復"
+    intent:
+      name: HassMediaUnpause
+      slots:
+        area: "Living Room"
+      context:
+        area: Living Room
+    response: "繼續"
+
+  - sentences:
+      - "繼續 客廳 music"
+      - "恢復 客廳 media player"
+      - "繼續 客廳 tv show"
+    intent:
+      name: HassMediaUnpause
+      slots:
+        area: "客廳"
+      context:
+        area: Living Room
+    response: "繼續"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `HassMediaUnpause` functionality in Chinese (Hong Kong) for resuming media playback with various scenarios and contexts.
  
- **Enhancements**
  - Improved language processing for pausing and unpausing actions by refining definitions and sentence structures in Chinese (Hong Kong).

- **Tests**
  - Added new test cases and updated existing ones to reflect changes in pausing and unpausing media actions in Chinese (Hong Kong).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->