### PR TITLE
[zh-hk] HassMediaNext

### DIFF
--- a/responses/zh-hk/HassMediaNext.yaml
+++ b/responses/zh-hk/HassMediaNext.yaml
@@ -1,0 +1,5 @@
+language: zh-hk
+responses:
+  intents:
+    HassMediaNext:
+      default: "播放下一個單元"

--- a/sentences/zh-hk/_common.yaml
+++ b/sentences/zh-hk/_common.yaml
@@ -231,6 +231,8 @@ expansion_rules:
   down: "(低)"
   pause: "(暫停)"
   unpause: "(取消暫停|恢復|繼續)"
+  next: "(跳|轉)[到](下一)(個|首)"
+  item: "(台|曲|曲目|歌)"
 
   # Timers
   timer_set: "(開始|放置|撥|set)"

--- a/sentences/zh-hk/media_player_HassMediaNext.yaml
+++ b/sentences/zh-hk/media_player_HassMediaNext.yaml
@@ -1,0 +1,17 @@
+language: zh-hk
+intents:
+  HassMediaNext:
+    data:
+      - sentences:
+          - "<name> <next> [<item>] "
+        requires_context:
+          domain: media_player
+
+      - sentences:
+          - "<next> [<item>] "
+        requires_context:
+          area:
+            slot: true
+
+      - sentences:
+          - "<area> <next> [<item>]"

--- a/tests/zh-hk/media_player_HassMediaNext.yaml
+++ b/tests/zh-hk/media_player_HassMediaNext.yaml
@@ -1,0 +1,33 @@
+language: zh-hk
+tests:
+  - sentences:
+      - "TV 轉下一個 台 "
+      - "TV 跳到下一首 歌 "
+    intent:
+      name: HassMediaNext
+      slots:
+        name: "TV"
+    response: "播放下一個單元"
+
+  - sentences:
+      - "轉下一個 台 "
+      - "跳到下一首 歌 "
+      - "跳下一首 歌 "
+    intent:
+      name: HassMediaNext
+      slots:
+        area: "Living Room"
+      context:
+        area: Living Room
+    response: "播放下一個單元"
+
+  - sentences:
+      - "客廳 轉下一個 台 "
+      - "客廳 跳到下一首 歌 "
+    intent:
+      name: HassMediaNext
+      slots:
+        area: "客廳"
+      context:
+        area: Living Room
+    response: "播放下一個單元"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced Traditional Chinese (zh-hk) language support for media control commands in Home Assistant, including commands for playing the next item.
  
- **Enhancements**
  - Added new phrase expansion rules for better understanding of navigation-related terms in sequences and lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->