### PR TITLE
[HU] Create homeassistant_HassGetCurrentTime.yaml

### DIFF
--- a/responses/hu/HassCancelTimer.yaml
+++ b/responses/hu/HassCancelTimer.yaml
@@ -1,0 +1,6 @@
+---
+language: hu
+responses:
+  intents:
+    HassCancelTimer:
+      default: "Időzítő törölve"

--- a/responses/hu/HassGetCurrentTime.yaml
+++ b/responses/hu/HassGetCurrentTime.yaml
@@ -1,0 +1,8 @@
+language: hu
+responses:
+  intents:
+    HassGetCurrentTime:
+      default: >
+        {% set minute_str = '{0:02d}'.format(slots.time.minute) %}
+
+        {{ slots.time.hour }}:{{ minute_str }}

--- a/responses/hu/HassPauseTimer.yaml
+++ b/responses/hu/HassPauseTimer.yaml
@@ -1,0 +1,6 @@
+---
+language: hu
+responses:
+  intents:
+    HassPauseTimer:
+      default: "Időzítő szünetel"

--- a/responses/hu/HassStartTimer.yaml
+++ b/responses/hu/HassStartTimer.yaml
@@ -1,0 +1,7 @@
+---
+language: hu
+responses:
+  intents:
+    HassStartTimer:
+      default: "Időzítő fut"
+      command: "Vettem"

--- a/responses/hu/HassTimerStatus.yaml
+++ b/responses/hu/HassTimerStatus.yaml
@@ -1,0 +1,91 @@
+---
+language: hu
+responses:
+  intents:
+    HassTimerStatus:
+      default: |
+        {% set num_timers = slots.timers | length %}
+        {% set active_timers = slots.timers | selectattr('is_active') | list %}
+        {% set num_active_timers = active_timers | length %}
+        {% set paused_timers = slots.timers | rejectattr('is_active') | list %}
+        {% set num_paused_timers = paused_timers | length %}
+        {% set next_timer = None %}
+
+        {% if num_timers == 0: %}
+          Nincsenek időzítők.
+        {% elif num_active_timers == 0: %}
+          {# No active timers #}
+          {% if num_paused_timers == 1: %}
+            {% set next_timer = paused_timers[0] %}
+            Az időzítő szünetel.
+          {% else: %}
+            {{ num_paused_timers }} szünetelő időzítő.
+          {% endif %}
+        {% else: %}
+          {# At least one active timer #}
+          {% if num_active_timers == 1: %}
+            {% set next_timer = active_timers[0] %}
+          {% else: %}
+            {# Get active timer that will finish soonest #}
+            {% set sorted_timers = active_timers | sort(attribute='total_seconds_left') %}
+            {% set next_timer = sorted_timers[0] %}
+            {{ num_active_timers }} időzítő fut.
+          {% endif %}
+
+          {% if num_paused_timers == 1: %}
+            1 időzítő szünetel.
+          {% elif num_paused_timers > 0: %}
+            {{ num_paused_timers }} időzítő szünetel.
+          {% endif %}
+        {% endif %}
+
+        {% if next_timer: %}
+          {# At least one active timer #}
+          {% if (next_timer.rounded_hours_left == 1) and (next_timer.rounded_minutes_left > 0): %}
+            1 óra {{ next_timer.rounded_minutes_left }} perc
+          {% elif (next_timer.rounded_hours_left == 1): %}
+            1 óra
+          {% elif (next_timer.rounded_hours_left > 1) and (next_timer.rounded_minutes_left > 0): %}
+            {{ next_timer.rounded_hours_left }} óra {{ next_timer.rounded_minutes_left }} perc
+          {% elif (next_timer.rounded_hours_left > 1): %}
+            {{ next_timer.rounded_hours_left }} óra
+          {% elif (next_timer.rounded_minutes_left == 1) and (next_timer.rounded_seconds_left > 0): %}
+            1 perc {{ next_timer.rounded_seconds_left }} másodperc
+          {% elif (next_timer.rounded_minutes_left == 1): %}
+            1 perc
+          {% elif (next_timer.rounded_minutes_left > 1) and (next_timer.rounded_seconds_left > 0): %}
+            {{ next_timer.rounded_minutes_left }} perc  {{ next_timer.rounded_seconds_left }} másodperc
+          {% elif (next_timer.rounded_minutes_left > 1): %}
+            {{ next_timer.rounded_minutes_left }} perc
+          {% elif (next_timer.rounded_seconds_left == 1): %}
+            1 másodperc
+          {% elif (next_timer.rounded_seconds_left > 1): %}
+            {{ next_timer.rounded_seconds_left }} másodperc
+          {% endif %}
+
+          {% if num_timers > 1: %}
+            {# Give some extra information to disambiguate #}
+            vam hátra a
+            {% if (next_timer.start_hours > 0) and (next_timer.start_minutes > 0): %}
+              {{ next_timer.start_hours }} óra {{ next_timer.start_minutes }} perces
+            {% elif (next_timer.start_hours > 0): %}
+              {{ next_timer.start_hours }} órás
+            {% elif (next_timer.start_minutes > 0) and (next_timer.start_seconds > 0): %}
+              {{ next_timer.start_minutes }} perc {{ next_timer.start_seconds }} másodperces
+            {% elif (next_timer.start_minutes > 0): %}
+              {{ next_timer.start_minutes }} perces
+            {% elif (next_timer.start_seconds > 0): %}
+              {{ next_timer.start_seconds }} másodperces
+            {% endif %}
+
+            {% if next_timer.name: %}
+              {{ next_timer.name }}
+            {% elif next_timer.area: %}
+              {{ next_timer.area }}
+            {% endif %}
+
+            időzítőből.
+          {% else: %}
+            van hátra.
+          {% endif %}
+        {% endif %}

--- a/responses/hu/HassUnpauseTimer.yaml
+++ b/responses/hu/HassUnpauseTimer.yaml
@@ -1,0 +1,6 @@
+---
+language: hu
+responses:
+  intents:
+    HassUnpauseTimer:
+      default: "Időzítő újraindult"

--- a/sentences/hu/_common.yaml
+++ b/sentences/hu/_common.yaml
@@ -648,6 +648,12 @@ expansion_rules:
   #kérédések
   what_is_the_class_of_name: "(<what_is> <class> [amit] <name>[a|e|n(a|e)k] [szenzor[a|nak|on]|érzékelő[je|nek|n]|eszköz[e|nek|ön]|esemény[nek]] [mér[t]|mutat[ott]] [<area>]|<what_is> (<name> [szenzor[a|on]|érzékelő[je|n]|eszköz[ön]] [által] [mért|mutatott] <class> [értéke]; [<area>]))"
 
+  # időzítő
+  timer_duration_seconds: "{timer_seconds:seconds} másodperc[re|et]"
+  timer_duration_minutes: "{timer_minutes:minutes} perc[re|et][ [és ]{timer_seconds:seconds} másodperc[re|et]]"
+  timer_duration_hours: "{timer_hours:hours} órá[t|ra][ [és ]{timer_minutes:minutes} perc[re|et]][ [és ]{timer_seconds:seconds} másodperc[re|et]]"
+  timer_duration: "<timer_duration_seconds>|<timer_duration_minutes>|<timer_duration_hours>"
+
 skip_words:
   - "kérem [szépen]"
   - "kérlek [szépen]"

--- a/sentences/hu/_common.yaml
+++ b/sentences/hu/_common.yaml
@@ -596,6 +596,30 @@ lists:
       - in: "Távol"
         out: "not_home"
 
+  # timer
+  timer_seconds:
+    range:
+      from: 1
+      to: 100
+  timer_minutes:
+    range:
+      from: 1
+      to: 100
+  timer_hours:
+    range:
+      from: 1
+      to: 100
+  timer_half:
+    values:
+      - in: "fél"
+        out: 30
+      - in: "1/2"
+        out: 30
+  timer_name:
+    wildcard: true
+  timer_command:
+    wildcard: true
+
 expansion_rules:
   name: "[a |az ]{name}[<name_ragok>| <name_szavak>]"
   name_ragok: "(n(a|e)k|[o|e]t|r(a|e)|[o|e|ö]n)"
@@ -653,6 +677,7 @@ expansion_rules:
   timer_duration_minutes: "{timer_minutes:minutes} perc[re|et][ [és ]{timer_seconds:seconds} másodperc[re|et]]"
   timer_duration_hours: "{timer_hours:hours} órá[t|ra][ [és ]{timer_minutes:minutes} perc[re|et]][ [és ]{timer_seconds:seconds} másodperc[re|et]]"
   timer_duration: "<timer_duration_seconds>|<timer_duration_minutes>|<timer_duration_hours>"
+  timer_cancel: "[állítsd le|töröld]"
 
 skip_words:
   - "kérem [szépen]"

--- a/sentences/hu/homeassistant_HassCancelTimer.yaml
+++ b/sentences/hu/homeassistant_HassCancelTimer.yaml
@@ -1,5 +1,5 @@
 ---
-language: "en"
+language: "hu"
 intents:
   HassCancelTimer:
     data:

--- a/sentences/hu/homeassistant_HassCancelTimer.yaml
+++ b/sentences/hu/homeassistant_HassCancelTimer.yaml
@@ -6,5 +6,5 @@ intents:
       - sentences:
           - "<timer_cancel> az időzítőt"
           - "<timer_cancel> a visszaszámlálást"
-          - "<timer_cancel> a[z] {timer_name:name} [nevű ]visszaszámlálást"
-          - "<timer_cancel> a[z] {timer_name:name} [nevű ]időzítőt"
+          - "<timer_cancel> a[z] {timer_name:name} [nevű ]visszaszámlálás[t]"
+          - "<timer_cancel> a[z] {timer_name:name} [nevű ]időzítő[t]"

--- a/sentences/hu/homeassistant_HassCancelTimer.yaml
+++ b/sentences/hu/homeassistant_HassCancelTimer.yaml
@@ -8,4 +8,3 @@ intents:
           - "<timer_cancel> a visszaszámlálást"
           - "<timer_cancel> a[z] {timer_name:name} [nevű ]visszaszámlálást"
           - "<timer_cancel> a[z] {timer_name:name} [nevű ]időzítőt"
-          

--- a/sentences/hu/homeassistant_HassCancelTimer.yaml
+++ b/sentences/hu/homeassistant_HassCancelTimer.yaml
@@ -1,0 +1,11 @@
+---
+language: "en"
+intents:
+  HassCancelTimer:
+    data:
+      - sentences:
+          - "<timer_cancel> az időzítőt"
+          - "<timer_cancel> a visszaszámlálást"
+          - "<timer_cancel> a[z] {timer_name:name} [nevű ]visszaszámlálást"
+          - "<timer_cancel> a[z] {timer_name:name} [nevű ]időzítőt"
+          

--- a/sentences/hu/homeassistant_HassGetCurrentTime.yaml
+++ b/sentences/hu/homeassistant_HassGetCurrentTime.yaml
@@ -1,0 +1,7 @@
+language: hu
+intents:
+  HassGetCurrentTime:
+    data:
+      - sentences:
+          - "[mondd meg ]mennyi[ most] a pontos idő[ most]"
+          - "[mondd meg ]mennyi[ most] az idő[ most]"

--- a/sentences/hu/homeassistant_HassGetCurrentTime.yaml
+++ b/sentences/hu/homeassistant_HassGetCurrentTime.yaml
@@ -3,5 +3,5 @@ intents:
   HassGetCurrentTime:
     data:
       - sentences:
-          - "[mondd meg ]mennyi[ most] a pontos idő[ most]"
-          - "[mondd meg ]mennyi[ most] az idő[ most]"
+          - "mennyi[ most] a pontos idő"
+          - "mennyi[ most] az idő"

--- a/sentences/hu/homeassistant_HassPauseTimer.yaml
+++ b/sentences/hu/homeassistant_HassPauseTimer.yaml
@@ -1,0 +1,10 @@
+---
+language: "en"
+intents:
+  HassPauseTimer:
+    data:
+      - sentences:
+          - "[szüneteljen | álljon meg ]a visszaszámlálás"
+          - "[szüneteltesd | állítsd meg ]a visszaszámlálást"
+          - "[szüneteljen | álljon meg ]a[z] {timer_name:name}[ nevű] visszaszámlálás"
+          - "[szüneteltesd | állítsd meg ]a[z] {timer_name:name}[ nevű] visszaszámlálást"

--- a/sentences/hu/homeassistant_HassPauseTimer.yaml
+++ b/sentences/hu/homeassistant_HassPauseTimer.yaml
@@ -4,7 +4,7 @@ intents:
   HassPauseTimer:
     data:
       - sentences:
-          - "[szüneteljen | álljon meg ]a visszaszámlálás"
-          - "[szüneteltesd | állítsd meg ]a visszaszámlálást"
-          - "[szüneteljen | álljon meg ]a[z] {timer_name:name}[ nevű] visszaszámlálás"
-          - "[szüneteltesd | állítsd meg ]a[z] {timer_name:name}[ nevű] visszaszámlálást"
+          - "szüneteljen a visszaszámlálás"
+          - "szüneteltesd a visszaszámlálást"
+          - "szüneteljen a[z] {timer_name:name}[ nevű] visszaszámlálás"
+          - "szüneteltesd a[z] {timer_name:name}[ nevű] visszaszámlálást"

--- a/sentences/hu/homeassistant_HassPauseTimer.yaml
+++ b/sentences/hu/homeassistant_HassPauseTimer.yaml
@@ -1,5 +1,5 @@
 ---
-language: "en"
+language: "hu"
 intents:
   HassPauseTimer:
     data:

--- a/sentences/hu/homeassistant_HassStartTimer.yaml
+++ b/sentences/hu/homeassistant_HassStartTimer.yaml
@@ -1,0 +1,9 @@
+---
+language: "en"
+intents:
+  HassStartTimer:
+    data:
+      - sentences:
+          - "<timer_duration> időzítő[t]"
+          - "időzítő <timer_duration>"
+          - "<timer_duration> időzítő {timer_name:name}"

--- a/sentences/hu/homeassistant_HassStartTimer.yaml
+++ b/sentences/hu/homeassistant_HassStartTimer.yaml
@@ -4,7 +4,8 @@ intents:
   HassStartTimer:
     data:
       - sentences:
-          - "állíts [be ][egy ] időzítő[t] <timer_duration>"
-          - "állíts [be ][egy ] {timer_name:name} időzítő[t] <timer_duration>"
+          - "állíts [be ][egy ] időzítőt <timer_duration>"
+          - "állíts [be ][egy ] {timer_name:name} időzítőt <timer_duration>"
           - "számolj vissza <timer_duration>"
           - "értesíts <timer_duration> múlva"
+        response: command

--- a/sentences/hu/homeassistant_HassStartTimer.yaml
+++ b/sentences/hu/homeassistant_HassStartTimer.yaml
@@ -1,9 +1,10 @@
 ---
-language: "en"
+language: "hu"
 intents:
   HassStartTimer:
     data:
       - sentences:
-          - "<timer_duration> időzítő[t]"
-          - "időzítő <timer_duration>"
-          - "<timer_duration> időzítő {timer_name:name}"
+          - "állíts [be ][egy ] időzítő[t] <timer_duration>"
+          - "állíts [be ][egy ] {timer_name:name} időzítő[t] <timer_duration>"
+          - "számolj vissza <timer_duration>"
+          - "értesíts <timer_duration> múlva"

--- a/sentences/hu/homeassistant_HassTimerStatus.yaml
+++ b/sentences/hu/homeassistant_HassTimerStatus.yaml
@@ -1,0 +1,8 @@
+---
+language: "en"
+intents:
+  HassTimerStatus:
+    data:
+      - sentences:
+          - "időzítő(k) állapota"
+          - "mennyi idő van még[ hátra| vissza]"

--- a/sentences/hu/homeassistant_HassTimerStatus.yaml
+++ b/sentences/hu/homeassistant_HassTimerStatus.yaml
@@ -1,5 +1,5 @@
 ---
-language: "en"
+language: "hu"
 intents:
   HassTimerStatus:
     data:

--- a/sentences/hu/homeassistant_HassUnpauseTimer.yaml
+++ b/sentences/hu/homeassistant_HassUnpauseTimer.yaml
@@ -5,5 +5,4 @@ intents:
     data:
       - sentences:
           - "folytasd a visszaszámlálást"
-          - "folytasd az időzítőt"
           - "folytasd[ a| az] {timer_name:name}[ nevű][ időzítőt| visszaszámlálást]"

--- a/sentences/hu/homeassistant_HassUnpauseTimer.yaml
+++ b/sentences/hu/homeassistant_HassUnpauseTimer.yaml
@@ -1,5 +1,5 @@
 ---
-language: "en"
+language: "hu"
 intents:
   HassUnpauseTimer:
     data:

--- a/sentences/hu/homeassistant_HassUnpauseTimer.yaml
+++ b/sentences/hu/homeassistant_HassUnpauseTimer.yaml
@@ -1,0 +1,9 @@
+---
+language: "en"
+intents:
+  HassUnpauseTimer:
+    data:
+      - sentences:
+          - "folytasd a visszaszámlálást"
+          - "folytasd az időzítőt"
+          - "folytasd[ a| az] {timer_name:name}[ nevű][ időzítőt| visszaszámlálást]"

--- a/tests/hu/_fixtures.yaml
+++ b/tests/hu/_fixtures.yaml
@@ -716,3 +716,23 @@ entities:
   - name: "consuela"
     id: "vacuum.consuela"
     state: "idle"
+
+timers:
+  - is_active: false
+    start_hours: 1
+    total_seconds_left: 100
+    rounded_hours_left: 0
+    rounded_minutes_left: 1
+    rounded_seconds_left: 40
+  - name: "főtt tojás"
+    start_minutes: 30
+    total_seconds_left: 1505
+    rounded_hours_left: 0
+    rounded_minutes_left: 25
+    rounded_seconds_left: 0
+  - area: "ebédlő"
+    start_minutes: 5
+    total_seconds_left: 190
+    rounded_hours_left: 0
+    rounded_minutes_left: 3
+    rounded_seconds_left: 0

--- a/tests/hu/homeassistant_HassCancelTimer.yaml
+++ b/tests/hu/homeassistant_HassCancelTimer.yaml
@@ -1,0 +1,12 @@
+language: hu
+tests:
+  - sentences:
+      - "állítsd le az időzítőt"
+      - "állítsd le a visszaszámlálást"
+      - "töröld az időzítőt"
+      - "töröld az visszaszámlálást"
+      - "állítsd le a főtt tojás nevű visszaszámlálást"
+      - "töröld a főtt tojás nevű időzítőt"
+    intent:
+      name: HassCancelTimer
+    response: Időzítő törölve

--- a/tests/hu/homeassistant_HassCancelTimer.yaml
+++ b/tests/hu/homeassistant_HassCancelTimer.yaml
@@ -4,9 +4,15 @@ tests:
       - "állítsd le az időzítőt"
       - "állítsd le a visszaszámlálást"
       - "töröld az időzítőt"
-      - "töröld az visszaszámlálást"
+      - "töröld a visszaszámlálást"
+    intent:
+      name: HassCancelTimer
+    response: Időzítő törölve
+  - sentences:
       - "állítsd le a főtt tojás nevű visszaszámlálást"
       - "töröld a főtt tojás nevű időzítőt"
     intent:
       name: HassCancelTimer
+      slots:
+        name: főtt tojás
     response: Időzítő törölve

--- a/tests/hu/homeassistant_HassGetCurrentTime.yaml
+++ b/tests/hu/homeassistant_HassGetCurrentTime.yaml
@@ -1,0 +1,13 @@
+language: hu
+tests:
+  - sentences:
+      - "mennyi az idő"
+      - "mennyi most az idő"
+      - "mennyi a pontos idő"
+      - "nem szóltam"
+      - "töröld"
+      - "töröld a kérést"
+      - "mindegy"
+    intent:
+      name: HassGetCurrentTime
+    response: 13:02

--- a/tests/hu/homeassistant_HassGetCurrentTime.yaml
+++ b/tests/hu/homeassistant_HassGetCurrentTime.yaml
@@ -4,10 +4,6 @@ tests:
       - "mennyi az idő"
       - "mennyi most az idő"
       - "mennyi a pontos idő"
-      - "nem szóltam"
-      - "töröld"
-      - "töröld a kérést"
-      - "mindegy"
     intent:
       name: HassGetCurrentTime
-    response: "13:02"
+    response: "1:02"

--- a/tests/hu/homeassistant_HassGetCurrentTime.yaml
+++ b/tests/hu/homeassistant_HassGetCurrentTime.yaml
@@ -10,4 +10,4 @@ tests:
       - "mindegy"
     intent:
       name: HassGetCurrentTime
-    response: 13:02
+    response: "13:02"

--- a/tests/hu/homeassistant_HassPauseTimer.yaml
+++ b/tests/hu/homeassistant_HassPauseTimer.yaml
@@ -1,0 +1,16 @@
+language: hu
+tests:
+  - sentences:
+      - "szüneteljen a visszaszámlálás"
+      - "szüneteltesd a visszaszámlálást"
+    intent:
+      name: HassPauseTimer
+    response: Időzítő szünetel
+  - sentences:
+      - "szüneteltesd a főtt tojás visszaszámlálást"
+      - "szüneteljen a főtt tojás nevű visszaszámlálás"
+    intent:
+      name: HassPauseTimer
+      slots:
+        name: főtt tojás
+    response: Időzítő szünetel

--- a/tests/hu/homeassistant_HassStartTimer.yaml
+++ b/tests/hu/homeassistant_HassStartTimer.yaml
@@ -1,0 +1,23 @@
+language: hu
+tests:
+  - sentences:
+      - "állíts időzítőt 2 percre"
+      - "állíts be időzítőt 2 percre"
+      - "állíts egy időzítőt 2 percre"
+      - "állíts be egy időzítőt 2 percre"
+      - "számolj vissza 2 percet"
+      - "számolj vissza 30 másodpercet"
+      - "értesíts 2 perc múlva"
+    intent:
+      name: HassStartTimer
+      slots:
+        minutes: 2
+    response: Vettem
+  - sentences:
+      - "állíts egy főtt tojás időzítőt 2 percre"
+    intent:
+      name: HassStartTimer
+      slots:
+        minutes: 2
+        name: főtt tojás
+    response: Vettem

--- a/tests/hu/homeassistant_HassTimerStatus.yaml
+++ b/tests/hu/homeassistant_HassTimerStatus.yaml
@@ -1,0 +1,11 @@
+language: hu
+tests:
+  - sentences:
+      - "időzítők állapota"
+      - "időzítő állapota"
+      - "mennyi idő van még vissza"
+      - "mennyi idő van még hátra"
+    intent:
+      name: HassTimerStatus
+    response: |
+      2 időzítő fut. 1 időzítő szünetel. 3 perc van hátra az 5 perces ebédlő időzítőből.

--- a/tests/hu/homeassistant_HassUnpauseTimer.yaml
+++ b/tests/hu/homeassistant_HassUnpauseTimer.yaml
@@ -1,0 +1,15 @@
+language: hu
+tests:
+  - sentences:
+      - "folytasd a visszaszámlálást"
+    intent:
+      name: HassUnpauseTimer
+    response: Időzítő újraindult
+  - sentences:
+      - "folytasd a főtt tojás nevű visszaszámlálást"
+      - "folytasd a főtt tojás nevű időzítőt"
+    intent:
+      name: HassUnpauseTimer
+      slots:
+        name: főtt tojás
+    response: Időzítő újraindult


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced localized intent sentences for Hungarian users in Home Assistant to query the current time, cancel timers, pause timers, start timers, check timer status, and unpause timers.
	- Enhanced multilingual capabilities with flexible sentence structures for natural user interactions across various timer functionalities.
	- Added response templates in Hungarian for each intent, improving user feedback consistency.
	- Expanded timer-related configurations to support a wider range of user inputs and commands in Hungarian.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->