### PR TITLE
Add expansion rule for luz

### DIFF
--- a/sentences/pt/_common.yaml
+++ b/sentences/pt/_common.yaml
@@ -136,6 +136,7 @@ expansion_rules:
   qual: "(que|qual|qual é|quais)"
   temperatura: "{temperature}[°| graus] [{temperature_unit}]"
   zona: "[(o|os|a|as)] {area}"
+  luz: (luz | luzes | candeeiro | candeeiros)
 
 skip_words:
   - "por favor"

--- a/sentences/pt/light_HassTurnOff.yaml
+++ b/sentences/pt/light_HassTurnOff.yaml
@@ -3,14 +3,14 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "<desliga> [(todas | todos)] [(o | os | a | as)] (luz | luzes | candeeiro | candeeiros) <na_zona>"
+          - "<desliga> [(todas | todos)] [(o | os | a | as)] <luz> <na_zona>"
         slots:
           domain: "light"
 
       # Desligar luzes na mesma divisão que um dispositivo de voz
       - sentences:
-          - "<desliga> [(o | os | a | as)] (luz | luzes | candeeiro | candeeiros)"
-          - "<desliga> [(todas | todos)] [(o | os | a | as)] (luz | luzes | candeeiro | candeeiros) aqui"
+          - "<desliga> [(o | os | a | as)] <luz>"
+          - "<desliga> [(todas | todos)] [(o | os | a | as)] <luz> aqui"
         slots:
           domain: "light"
         requires_context:

--- a/sentences/pt/light_HassTurnOn.yaml
+++ b/sentences/pt/light_HassTurnOn.yaml
@@ -3,14 +3,14 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "<liga> [(todas | todos)] [(o | os | a | as)] (luz | luzes | candeeiro | candeeiros) <na_zona>"
+          - "<liga> [(todas | todos)] [(o | os | a | as)] <luz> <na_zona>"
         slots:
           domain: "light"
 
       # Ligar luzes na mesma divisão que um dispositivo de voz
       - sentences:
-          - "<liga> [(o | os | a | as)] (luz | luzes | candeeiro | candeeiros)"
-          - "<liga> [(todas | todos)] [(o | os | a | as)] (luz | luzes | candeeiro | candeeiros) aqui"
+          - "<liga> [(o | os | a | as)] <luz>"
+          - "<liga> [(todas | todos)] [(o | os | a | as)] <luz> aqui"
         slots:
           domain: "light"
         requires_context:


### PR DESCRIPTION
Simple addition on expansion rules to avoid using multiple times the same alternates for luz.