### PR TITLE
[SV] Add vacuum intents

### DIFF
--- a/responses/sv/HassVacuumReturnToBase.yaml
+++ b/responses/sv/HassVacuumReturnToBase.yaml
@@ -1,0 +1,5 @@
+language: sv
+responses:
+  intents:
+    HassVacuumReturnToBase:
+      default: "Återvänder"

--- a/responses/sv/HassVacuumStart.yaml
+++ b/responses/sv/HassVacuumStart.yaml
@@ -1,0 +1,5 @@
+language: sv
+responses:
+  intents:
+    HassVacuumStart:
+      default: "Startad"

--- a/sentences/sv/homeassistant_HassTurnOn.yaml
+++ b/sentences/sv/homeassistant_HassTurnOn.yaml
@@ -4,6 +4,8 @@ intents:
     data:
       - sentences:
           - <slå_på> <name>
+        excludes_context:
+          domain: vacuum
       - sentences:
           - <öppna_gardiner> <name>
         response: cover

--- a/sentences/sv/vacuum_HassVacuumReturnToBase.yaml
+++ b/sentences/sv/vacuum_HassVacuumReturnToBase.yaml
@@ -1,0 +1,10 @@
+language: sv
+intents:
+  HassVacuumReturnToBase:
+    data:
+      - sentences:
+          - "kör [tillbaka] <name> till (laddaren|basen|dockan)"
+          - "kör tillbaka <name>"
+          - "(docka|ladda) <name>"
+        requires_context:
+          domain: vacuum

--- a/sentences/sv/vacuum_HassVacuumStart.yaml
+++ b/sentences/sv/vacuum_HassVacuumStart.yaml
@@ -1,0 +1,10 @@
+language: sv
+intents:
+  HassVacuumStart:
+    data:
+      - sentences:
+          - "<slå_på> dammsugare[n] i <area>"
+      - sentences:
+          - "<slå_på> <name>"
+        requires_context:
+          domain: vacuum

--- a/tests/sv/_fixtures.yaml
+++ b/tests/sv/_fixtures.yaml
@@ -89,6 +89,9 @@ entities:
   - name: Sovrumsgardinen
     id: cover.bedroom_curtain
     area: bedroom
+  - name: Rover
+    id: vacuum.rover
+    area: livingroom
 
   - name: "Stockholm"
     id: "weather.stockholm"

--- a/tests/sv/vacuum_HassVacuumReturnToBase.yaml
+++ b/tests/sv/vacuum_HassVacuumReturnToBase.yaml
@@ -1,0 +1,14 @@
+language: sv
+tests:
+  - sentences:
+      - "Kör tillbaka Rover till dockan"
+      - "Kör tillbaka Rover till basen"
+      - "Kör tillbaka Rover"
+      - "Kör Rover till laddaren"
+      - "Ladda Rover"
+      - "Docka Rover"
+    intent:
+      name: HassVacuumReturnToBase
+      slots:
+        name: "Rover"
+    response: "Återvänder"

--- a/tests/sv/vacuum_HassVacuumStart.yaml
+++ b/tests/sv/vacuum_HassVacuumStart.yaml
@@ -1,0 +1,18 @@
+language: sv
+tests:
+  - sentences:
+      - "starta dammsugaren i sovrummet"
+      - "slå på dammsugaren i sovrummet"
+    intent:
+      name: HassVacuumStart
+      slots:
+        area: "Sovrum"
+    response: "Startad"
+  - sentences:
+      - "starta rover"
+      - "slå på rover"
+    intent:
+      name: HassVacuumStart
+      slots:
+        name: "Rover"
+    response: "Startad"


### PR DESCRIPTION
Add Swedish for returning vacuum to dock, and for starting a vacuum.
Also add some tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Swedish language support for vacuum control with responses for starting and returning to base.
  - Introduced intent definitions for recognizing commands related to vacuum operations in Swedish.
  
- **Tests**
  - Created comprehensive test cases for Swedish language commands for vacuum operations, ensuring accurate recognition and responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->