### PR TITLE
[EN] Rename CO2 binary sensor fixture

### DIFF
--- a/tests/en/_fixtures.yaml
+++ b/tests/en/_fixtures.yaml
@@ -174,8 +174,8 @@ entities:
     attributes:
       device_class: battery_charging
 
-  - name: "CO2"
-    id: "binary_sensor.co2"
+  - name: "CO"
+    id: "binary_sensor.co"
     area: "kitchen_id"
     state:
       in: "clear"

--- a/tests/en/binary_sensor_HassGetState.yaml
+++ b/tests/en/binary_sensor_HassGetState.yaml
@@ -106,13 +106,13 @@ tests:
 
   # Carbon monoxide
   - sentences:
-      - "is CO2 detected?"
+      - "is CO detected?"
     intent:
       name: HassGetState
       slots:
         domain: "binary_sensor"
         device_class: "carbon_monoxide"
-        name: "CO2"
+        name: "CO"
         state: "on"
     response: "No, clear"
 
@@ -146,7 +146,7 @@ tests:
         domain: binary_sensor
         device_class: carbon_monoxide
         state: "on"
-    response: "No, CO2 is not on"
+    response: "No, CO is not on"
 
   - sentences:
       - "which carbon monoxide sensors are on?"


### PR DESCRIPTION
Fix #2350

There was an improperly named `binary_sensor` with `device_class: carbon_monoxide` but named `CO2` (carbon **di**oxide).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated sensor naming and identifiers from "CO2" to "CO," reflecting a shift to carbon monoxide detection.
  
- **Bug Fixes**
	- Revised test cases to use consistent terminology for carbon monoxide, enhancing clarity and accuracy in testing outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->