### PR TITLE
[NL] Remove area slot for start timer intent

### DIFF
--- a/sentences/nl/homeassistant_HassStartTimer.yaml
+++ b/sentences/nl/homeassistant_HassStartTimer.yaml
@@ -13,6 +13,3 @@ intents:
           - "<timer_set>[ een] <timer_duration> timer (genaamd|met de naam|voor) {timer_name:name}"
           - "<timer_set>[ een] timer (genaamd|met de naam|voor) {timer_name:name} (van|voor) <timer_duration>"
           - "<timer_set>[ een] timer (van|voor) <timer_duration> (genaamd|met de naam|voor) {timer_name:name}"
-        requires_context:
-          area:
-            slot: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Timer intents can now be invoked without needing to specify an area context, enhancing flexibility and simplifying user interactions. 

- **Bug Fixes**
	- Removed unnecessary constraints on timer commands, improving usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->