### PR TITLE
[FR&EN] Floor Support for HassLightSet

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -205,6 +205,9 @@ HassLightSet:
     area:
       description: "Name of an area"
       required: false
+    floor:
+      description: "Name of a floor"
+      required: false
     brightness:
       description: "Brightness percentage from 0 to 100"
       required: false

--- a/sentences/en/light_HassLightSet.yaml
+++ b/sentences/en/light_HassLightSet.yaml
@@ -67,12 +67,7 @@ intents:
 
       # Floor support for brightness
       - sentences:
-          - "[<numeric_value_set>] [the] brightness in <floor> to <brightness>"
-          - "[<numeric_value_set>] [the] brightness of <floor> to <brightness>"
           - "[<numeric_value_set>] <floor> brightness [to] <brightness>"
-          - "[<numeric_value_set>] <floor> [to] <brightness> brightness"
-          - "[<numeric_value_set>] <floor> [to] <brightness>"
-          - "[<numeric_value_set>] [all] [the] lights [<in>] <floor> to <brightness> [brightness]"
         response: "brightness"
 
       - sentences:
@@ -106,6 +101,5 @@ intents:
 
       # Floor support for color
       - sentences:
-          - "[<set>] [[the] color of] (<floor> | [all [the]] lights in <floor> | [all] <floor> lights) [to] {color}"
-          - "[<set>] (<floor> | [all] lights in <floor> | [all] <floor> lights) [color] [to] {color}"
+          - "[<set>] <floor> [color] [to] {color}"
         response: "color"

--- a/sentences/en/light_HassLightSet.yaml
+++ b/sentences/en/light_HassLightSet.yaml
@@ -23,14 +23,10 @@ intents:
           - "[<numeric_value_set>] <area> [to] <brightness> brightness"
           - "[<numeric_value_set>] <area> [to] <brightness>"
           - "[<numeric_value_set>] [all] [the] lights [<in>] <area> to <brightness> [brightness]"
-        slots:
-          name: "all"
         response: "brightness"
 
       - sentences:
           - "<numeric_value_set> <area> to <brightness>"
-        slots:
-          name: "all"
         response: "brightness"
 
       - sentences:
@@ -57,8 +53,6 @@ intents:
           - "[<numeric_value_set>] [the] brightness of <area> to [the] {brightness_level:brightness}"
           - "[<numeric_value_set>] <area> brightness to [the] {brightness_level:brightness}"
           - "[<numeric_value_set>] <area> [to] [the] {brightness_level:brightness} brightness"
-        slots:
-          name: "all"
         response: "brightness"
 
       - sentences:
@@ -71,6 +65,23 @@ intents:
           area:
             slot: true
 
+      # Floor support for brightness
+      - sentences:
+          - "[<numeric_value_set>] [the] brightness in <floor> to <brightness>"
+          - "[<numeric_value_set>] [the] brightness of <floor> to <brightness>"
+          - "[<numeric_value_set>] <floor> brightness [to] <brightness>"
+          - "[<numeric_value_set>] <floor> [to] <brightness> brightness"
+          - "[<numeric_value_set>] <floor> [to] <brightness>"
+          - "[<numeric_value_set>] [all] [the] lights [<in>] <floor> to <brightness> [brightness]"
+        response: "brightness"
+
+      - sentences:
+          - "[<numeric_value_set>] [the] brightness in <floor> to [the] {brightness_level:brightness}"
+          - "[<numeric_value_set>] [the] brightness of <floor> to [the] {brightness_level:brightness}"
+          - "[<numeric_value_set>] <floor> brightness to [the] {brightness_level:brightness}"
+          - "[<numeric_value_set>] <floor> [to] [the] {brightness_level:brightness} brightness"
+        response: "brightness"
+
       # color
       - sentences:
           - "[<set>] <name> [color] [to] {color}"
@@ -81,8 +92,6 @@ intents:
       - sentences:
           - "[<set>] [[the] color of] (<area> | [all [the]] lights in <area> | [all] <area> lights) [to] {color}"
           - "[<set>] (<area> | [all] lights in <area> | [all] <area> lights) [color] [to] {color}"
-        slots:
-          name: "all"
         response: "color"
 
       - sentences:
@@ -94,3 +103,9 @@ intents:
         requires_context:
           area:
             slot: true
+
+      # Floor support for color
+      - sentences:
+          - "[<set>] [[the] color of] (<floor> | [all [the]] lights in <floor> | [all] <floor> lights) [to] {color}"
+          - "[<set>] (<floor> | [all] lights in <floor> | [all] <floor> lights) [color] [to] {color}"
+        response: "color"

--- a/sentences/en/light_HassLightSet.yaml
+++ b/sentences/en/light_HassLightSet.yaml
@@ -70,13 +70,6 @@ intents:
           - "[<numeric_value_set>] <floor> brightness [to] <brightness>"
         response: "brightness"
 
-      - sentences:
-          - "[<numeric_value_set>] [the] brightness in <floor> to [the] {brightness_level:brightness}"
-          - "[<numeric_value_set>] [the] brightness of <floor> to [the] {brightness_level:brightness}"
-          - "[<numeric_value_set>] <floor> brightness to [the] {brightness_level:brightness}"
-          - "[<numeric_value_set>] <floor> [to] [the] {brightness_level:brightness} brightness"
-        response: "brightness"
-
       # color
       - sentences:
           - "[<set>] <name> [color] [to] {color}"

--- a/sentences/fr/light_HassLightSet.yaml
+++ b/sentences/fr/light_HassLightSet.yaml
@@ -87,7 +87,24 @@ intents:
       # To be done when it's supported in the slot_combinations
 
       # brightness (floor)
-      # To be done when it's supported in the slot_combinations
+      - sentences:
+          # Baisse la luminosité du rez-de-chaussée à 40%
+          - "(<regle>|<augmente>|<diminue>) [la] luminosité [<dans>] [<le>]{floor} [à] {brightness}<pourcent>"
+          # Allume la lumière du rez-de-chaussée à 70%
+          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>](<lumiere>|<lumieres>)  [<dans>] [<le>]{floor} [à] {brightness}<pourcent>"
+          # Règle le rez-de-chaussée à 50% de luminosité
+          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]{floor} [à] {brightness}<pourcent> [de] luminosité"
+          # Monte le rez-de-chaussée a 100%
+          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]{floor} [à] {brightness}<pourcent>"
+          # Luminosité dans rez-de-chaussée à 50%
+          - "luminosité [<dans>] [<le>]{floor} [à] {brightness}<pourcent>"
+          # Rez-de-chaussée luminosité 50%
+          - "[<le>]{floor} luminosité [à] {brightness}<pourcent>"
+          # Rez-de-chaussée à 50 de luminosité
+          - "[<le>]{floor} [à] {brightness}<pourcent> [de] luminosité"
+          # Règle les lumieres du rez-de-chaussée avec la luminosité à 50% (Too complex... We should think about removing that)
+          - "(<allume>|<regle>) [<tous>] [<le>][<lumieres>] [<de>] [<le>]{floor} [avec la luminosité|avec la lumière] [à] {brightness}<pourcent>"
+        response: brightness
 
       # color (name)
       - sentences:
@@ -138,4 +155,13 @@ intents:
       # To be done when it's supported in the slot_combinations
 
       # color (floor)
-      # To be done when it's supported in the slot_combinations
+      - sentences:
+          # Règle la couleur du rez-de-chaussée en vert
+          - "<regle> la couleur [<de>] [<le>]{floor} [en] {color}"
+          # Règle la couleur des lumières du rez-de-chaussée en vert
+          - "<regle> la couleur <de> [<tous>] [<le>](<lumiere>|<lumieres>) [<dans>] [<le>]{floor} [en] {color}"
+          # Allume les lumières du rez-de-chaussée en rouge
+          - "(<regle>|<allume>) [<tous>] [<le>](<lumiere>|<lumieres>) [<de>] [<le>]{floor} [avec la couleur | de couleur | en] {color}"
+          # Allume le rez-de-chaussée en rouge
+          - "(<regle>|<allume>) [<le>]{floor} [avec la couleur | de couleur | en] {color}"
+        response: color

--- a/tests/en/light_HassLightSet.yaml
+++ b/tests/en/light_HassLightSet.yaml
@@ -120,32 +120,6 @@ tests:
         floor: First Floor
     response: "Brightness set"
 
-  - sentences:
-      - "set the brightness in the first floor to max"
-      - "change the brightness of first floor to the highest"
-      - "set the first floor brightness to the max"
-      - "change the first floor to maximum brightness"
-      - "first floor to maximum brightness"
-      - "first floor maximum brightness"
-    intent:
-      name: HassLightSet
-      slots:
-        brightness: 100
-        floor: First Floor
-    response: "Brightness set"
-
-  - sentences:
-      - "set the brightness in the first floor to the lowest"
-      - "change the brightness of first floor to lowest"
-      - "set the first floor brightness to the minimum"
-      - "change the first floor to minimum brightness"
-    intent:
-      name: HassLightSet
-      slots:
-        brightness: 1
-        floor: First Floor
-    response: "Brightness set"
-
   # color
   - sentences:
       - "set the bedroom lamp color to red"

--- a/tests/en/light_HassLightSet.yaml
+++ b/tests/en/light_HassLightSet.yaml
@@ -112,16 +112,7 @@ tests:
     response: "Brightness set"
 
   - sentences:
-      - "set the brightness in the first floor to 50%"
-      - "change the brightness of first floor to 50 percent"
       - "set the first floor brightness to 50%"
-      - "change the first floor to 50% brightness"
-      - "set first floor to 50%"
-      - "first floor brightness 50%"
-      - "first floor 50%"
-      - "turn first floor to 50%"
-      - "set all the lights in the first floor to 50%"
-      - "set the lights of the first floor to 50% brightness"
     intent:
       name: HassLightSet
       slots:
@@ -199,10 +190,7 @@ tests:
 
   - sentences:
       - "set the first floor color to red"
-      - "change the color of the first floor to red"
-      - "first floor color red"
-      - "first floor red"
-      - "set the color of all the lights in the first floor to red"
+      - "set the first floor to red"
     intent:
       name: HassLightSet
       slots:

--- a/tests/en/light_HassLightSet.yaml
+++ b/tests/en/light_HassLightSet.yaml
@@ -33,7 +33,6 @@ tests:
       slots:
         brightness: 50
         area: Bedroom
-        name: all
     response: "Brightness set"
 
   - sentences:
@@ -74,7 +73,6 @@ tests:
       slots:
         brightness: 100
         area: Bedroom
-        name: all
     response: "Brightness set"
 
   - sentences:
@@ -98,7 +96,6 @@ tests:
       slots:
         brightness: 1
         area: Bedroom
-        name: all
     response: "Brightness set"
 
   - sentences:
@@ -112,6 +109,50 @@ tests:
       slots:
         brightness: 100
         area: Bedroom
+    response: "Brightness set"
+
+  - sentences:
+      - "set the brightness in the first floor to 50%"
+      - "change the brightness of first floor to 50 percent"
+      - "set the first floor brightness to 50%"
+      - "change the first floor to 50% brightness"
+      - "set first floor to 50%"
+      - "first floor brightness 50%"
+      - "first floor 50%"
+      - "turn first floor to 50%"
+      - "set all the lights in the first floor to 50%"
+      - "set the lights of the first floor to 50% brightness"
+    intent:
+      name: HassLightSet
+      slots:
+        brightness: 50
+        floor: First Floor
+    response: "Brightness set"
+
+  - sentences:
+      - "set the brightness in the first floor to max"
+      - "change the brightness of first floor to the highest"
+      - "set the first floor brightness to the max"
+      - "change the first floor to maximum brightness"
+      - "first floor to maximum brightness"
+      - "first floor maximum brightness"
+    intent:
+      name: HassLightSet
+      slots:
+        brightness: 100
+        floor: First Floor
+    response: "Brightness set"
+
+  - sentences:
+      - "set the brightness in the first floor to the lowest"
+      - "change the brightness of first floor to lowest"
+      - "set the first floor brightness to the minimum"
+      - "change the first floor to minimum brightness"
+    intent:
+      name: HassLightSet
+      slots:
+        brightness: 1
+        floor: First Floor
     response: "Brightness set"
 
   # color
@@ -141,7 +182,6 @@ tests:
       slots:
         color: red
         area: Bedroom
-        name: all
     response: "Color set"
 
   - sentences:
@@ -155,4 +195,17 @@ tests:
       slots:
         color: red
         area: Bedroom
+    response: "Color set"
+
+  - sentences:
+      - "set the first floor color to red"
+      - "change the color of the first floor to red"
+      - "first floor color red"
+      - "first floor red"
+      - "set the color of all the lights in the first floor to red"
+    intent:
+      name: HassLightSet
+      slots:
+        color: red
+        floor: First Floor
     response: "Color set"

--- a/tests/fr/light_HassLightSet.yaml
+++ b/tests/fr/light_HassLightSet.yaml
@@ -193,8 +193,8 @@ tests:
       - "règle le rez-de-chaussée en rouge"
       - "allume le rez-de-chaussée en rouge"
       - "régler le rez-de-chaussée en rouge"
-      - "règle les lumières de le rez-de-chaussée en rouge"
-      - "allume les lumières de le rez-de-chaussée en rouge"
+      - "règle les lumières du rez-de-chaussée en rouge"
+      - "allume les lumières du rez-de-chaussée en rouge"
     intent:
       name: HassLightSet
       slots:

--- a/tests/fr/light_HassLightSet.yaml
+++ b/tests/fr/light_HassLightSet.yaml
@@ -83,6 +83,27 @@ tests:
         area: chambre
     response: Luminosité réglée
 
+  # brightness (floor)
+  - sentences:
+      - "règle la luminosité du rez-de-chaussée à 50%"
+      - "règle la luminosité du rez-de-chaussée à 50 pourcent"
+      - "règle la luminosité dans le rez-de-chaussée à 50%"
+      - "changer luminosité rez-de-chaussée à 50%"
+      - "met le rez-de-chaussée à 50% de luminosité"
+      - "luminosité du rez-de-chaussée à 50%"
+      - "luminosité rez-de-chaussée 50%"
+      - "rez-de-chaussée 50% luminosité"
+      - "rez-de-chaussée luminosité 50%"
+      - "Augmente la lumière du rez-de-chaussée à 50%"
+      - "Monter le rez-de-chaussée à 50 %"
+      - "Baisser le rez-de-chaussée à 50 %"
+    intent:
+      name: HassLightSet
+      slots:
+        brightness: 50
+        floor: Rez-De-Chaussée
+    response: Luminosité réglée
+
   # color (name)
   - sentences:
       - "règle la lampe de chevet en rouge"
@@ -165,4 +186,18 @@ tests:
       slots:
         area: chambre
         color: red
+    response: Couleur réglée
+
+  # color (floor)
+  - sentences:
+      - "règle le rez-de-chaussée en rouge"
+      - "allume le rez-de-chaussée en rouge"
+      - "régler le rez-de-chaussée en rouge"
+      - "règle les lumières de le rez-de-chaussée en rouge"
+      - "allume les lumières de le rez-de-chaussée en rouge"
+    intent:
+      name: HassLightSet
+      slots:
+        color: red
+        floor: Rez-De-Chaussée
     response: Couleur réglée


### PR DESCRIPTION
## Context
We noticed that floors were supported for HassTurnOn and HassTurnOff but not for HAssSetLight.
This meant that light support was uneven 
- `Turn on the lights on the first floor` was working ✅
- `Set the lights of the first floor to 50%` was not ❌

 ## Scope
This PR fixes this.
We can now control brightness and color on a floor level (in addition to the area level that was already supported)

## Why English and French in the same PR?
As it is a brand new set of sentences, we also decided to provide a draft of the English sentences too.
~~They are derived from the area sentences.~~
@tetele rightfully pointed out that the `area` sentences way not be in the best of shape.
So I decided to add only a single sentence in English.
Up to English LL to take it from here.

## Anything else
Yes. We noticed a few `name: all` when targeting complete area in English.
This is not required anymore: When targeting n area (or floor), all entities of the area (or floor) are by default targeted.
Thus, we simplified this particular file.
_(Note: More `name: all` could exist in the English set, we only touched the file in scope of this PR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new optional field for specifying the floor in light settings.
  - Enhanced brightness and color control commands to allow adjustments for specific floors.

- **Bug Fixes**
  - Streamlined syntax by removing the "all" slot from brightness commands.

- **Tests**
  - Added new test cases for brightness and color control on specific floors in both English and French.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->