### PR TITLE
[EN] Add "lock all doors"

### DIFF
--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -367,7 +367,7 @@ expansion_rules:
   area_floor: "(<area>|<floor>)"
   in_area_floor: "[<in> ]<area_floor>"
   what_is: "(what's|whats|what is|tell me)[ the]"
-  lockable: "[the ](lock|door|window|gate|garage door|shutter)[s]"
+  lockable: "[(the|my) ](lock|door|window|gate|garage door|shutter)[s]"
   where_is: "(where's|wheres|where is)"
   which: "(which|what)[ of the]"
   is: "(is|are)[ (there|the)]"

--- a/sentences/en/lock_HassTurnOn.yaml
+++ b/sentences/en/lock_HassTurnOn.yaml
@@ -11,7 +11,7 @@ intents:
       - sentences:
           - "lock[ all] <lockable>[ in] <area>"
           - "lock[ all] <area>[ <lockable>]"
+          - "lock all[ of] <lockable>"
         slots:
           domain: "lock"
-          name: "all"
         response: lock

--- a/tests/en/lock_HassTurnOn.yaml
+++ b/tests/en/lock_HassTurnOn.yaml
@@ -21,5 +21,4 @@ tests:
       slots:
         area: Kitchen
         domain: lock
-        name: all
     response: Locked


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error messages for lockable entities to include personalized ownership context.
	- Added a new sentence pattern for the locking action in the `HassTurnOn` intent, allowing users to say "lock all of [lockable]."

- **Bug Fixes**
	- Removed the "all" entry from the `name` slot in the `HassTurnOn` intent for improved clarity.
	- Corrected the structure and formatting of test cases related to the `HassTurnOn` intent for better functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->