### PR TITLE
[SL] fixes for duplicate floors

### DIFF
--- a/responses/sl/HassGetState.yaml
+++ b/responses/sl/HassGetState.yaml
@@ -95,7 +95,7 @@ responses:
         {% else: %}
           {% set match = query.matched | map(attribute="name") | sort | list %}
           {% if match | length > 4 %}
-            {{ match[:3] | join(", ") }} and {{ (match | length - 3) }} more
+            {{ match[:3] | join(", ") }} in še {{ (match | length - 3) }} drugih.
           {% else %}
             {%- for name in match -%}
               {% if not loop.first and not loop.last %}, {% elif loop.last and not loop.first %} in {% endif -%}
@@ -112,7 +112,7 @@ responses:
         {% else: %}
           {% set match = query.matched | map(attribute="name") | sort | list %}
           {% if match | length > 4 %}
-            {{ match[:3] | join(", ") }} and {{ (match | length - 3) }} more
+            {{ match[:3] | join(", ") }} in še {{ (match | length - 3) }} drugih.
           {% else %}
             {%- for name in match -%}
               {% if not loop.first and not loop.last %}, {% elif loop.last and not loop.first %} in {% endif -%}
@@ -129,10 +129,10 @@ responses:
         {% else: %}
           {% set match = query.matched | map(attribute="name") | sort | list %}
           {% if match | length > 4 %}
-            {{ match[:3] | join(", ") }} and {{ (match | length - 3) }} more
+            {{ match[:3] | join(", ") }} in še {{ (match | length - 3) }} drugih.
           {% else %}
             {%- for name in match -%}
-              {% if not loop.first and not loop.last %}, {% elif loop.last and not loop.first %} and {% endif -%}
+              {% if not loop.first and not loop.last %}, {% elif loop.last and not loop.first %} in {% endif -%}
               {{ name }}
             {%- endfor -%}
           {% endif %}

--- a/sentences/sl/_common.yaml
+++ b/sentences/sl/_common.yaml
@@ -16,25 +16,25 @@ responses:
     no_device_class_in_floor: "V nadstropju {{ floor }} ne obstaja {{ device_class }}"
     no_entity: "Ni naprave ali entitete z imenom {{ entity }}"
     no_entity_in_area: "Ni naprave ali entitete z imenom {{ entity }} v območju {{ area }}"
-    no_entity_in_floor: "Ni naprave ali entitete z imenom {{ entity }} v nadstropju {{ floor }}"
+    no_entity_in_floor: "Ni naprave ali entitete z imenom {{ entity }} v {{ floor }}"
     entity_wrong_state: "Žal nobena naprava ni {{ state | lower }}"
     feature_not_supported: "Žal nobena naprava ne podpira zahtevanih funkcij"
 
     # Errors for when user is logged in and we can give more information
     no_entity_exposed: "Naprava ali entiteta z imenom {{ entity }} ni izpostavljena"
     no_entity_in_area_exposed: "Naprava ali entiteta z imenom {{ entity }} v območju {{ area }} ni izpostavljena"
-    no_entity_in_floor_exposed: "Naprava ali entiteta z imenom {{ entity }} v nadstropju {{ floor }} ni izpostavljena"
+    no_entity_in_floor_exposed: "Naprava ali entiteta z imenom {{ entity }} v {{ floor }} ni izpostavljena"
     no_domain_exposed: "Oprosti, {{ domain }} ni izpostavljena"
     no_domain_in_area_exposed: "Oprosti, {{ domain }} v območju {{ area }} ni izpostavljena"
-    no_domain_in_floor_exposed: "Oprosti, {{ domain }} v nadstropju {{ floor }} ni izpostavljena"
+    no_domain_in_floor_exposed: "Oprosti, {{ domain }} v {{ floor }} ni izpostavljena"
     no_device_class_exposed: "Oprosti, {{ device_class }} ni izpostavljena"
     no_device_class_in_area_exposed: "Oprosti, {{ device_class }} v območju {{ area }} ni izpostavljena"
-    no_device_class_in_floor_exposed: "Oprosti, {{ device_class }} v nadstropju {{ floor }} ni izpostavljena"
+    no_device_class_in_floor_exposed: "Oprosti, {{ device_class }} v {{ floor }} ni izpostavljena"
 
     # Used when multiple (exposed) devices have the same name
     duplicate_entities: "Oprosti, klicanih je bilo dvoje ali več naprav z imenom {{ entity }}"
     duplicate_entities_in_area: "Oprosti, v območju {{ area }} je bilo klicanih dvoje ali več naprav z imenom {{ entity }}"
-    duplicate_entities_in_floor: "Oprosti, v nadstropju {{ floor }} je bilo klicanih dvoje ali več naprav z imenom {{ entity }}"
+    duplicate_entities_in_floor: "Oprosti, v {{ floor }} je bilo klicanih dvoje ali več naprav z imenom {{ entity }}"
 
     # Errors for timers
     timer_not_found: "Oprosti tega časovnika nisem mogel najti"


### PR DESCRIPTION
Removed  duplicate floor for floor grouping in Slovenian language to make response more correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated error messages in Slovenian for clarity and conciseness regarding entities and their locations.
	- Streamlined language by removing redundant references to "nadstropju" (floor) in error messages.
	- Improved linguistic accuracy and cultural relevance in responses for the `HassGetState` intent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->