### PR TITLE
Add "sticky" to table header

### DIFF
--- a/website/public/style.css
+++ b/website/public/style.css
@@ -42,6 +42,12 @@ table {
   border-radius: 4px;
 }
 
+thead {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
 tr.usable {
   background-color: rgba(0, 255, 0, 0.2);
 }


### PR DESCRIPTION
Hello, 

just a small improvement.

https://github.com/user-attachments/assets/f3543226-ff9e-48fc-aba7-972c20f8ff3c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a sticky header for tables, improving usability by keeping the header visible while scrolling through content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->