### PR TITLE
[FR] New lock support

### DIFF
--- a/responses/fr/HassTurnOff.yaml
+++ b/responses/fr/HassTurnOff.yaml
@@ -5,5 +5,5 @@ responses:
       default: "Éteint"
       fans: "Ventilateurs éteints"
       cover: "Fermé"
-      lock: "Ouvert"
+      lock: "Déverrouillé"
       valve: "Fermé"

--- a/responses/fr/HassTurnOn.yaml
+++ b/responses/fr/HassTurnOn.yaml
@@ -5,7 +5,7 @@ responses:
       default: "Allumé"
       fans: "Ventilateurs allumés"
       cover: "Ouvert"
-      lock: "Fermé"
+      lock: "Verrouillé"
       scene: "Scène activée"
       script: "Script démarré"
       valve: "Ouvert"

--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -688,7 +688,9 @@ expansion_rules:
   cree: "(créer|crée)"
   supprime: "(supprime|supprimer)"
   enleve: "(enlève|enlever|soustrais|soustrait|soustraire|retranche|retrancher)"
-  ajoute: "(ajoute|ajouter|rajoute|rajotuer)"
+  ajoute: "(ajoute|ajouter|rajoute|rajouter)"
+  verrouille: "(verrouiller|verrouille|barre|barrer)"
+  deverrouille: "(déverrouiller|déverrouille)"
 
   # Dirty Verbs. We have some heavy STT limitations today. We're willing to support this hack for now. Ideally this should be removed once we have a better STT engine. Hence the fact that we decided to put it on a different expansion rules. The goal of this expansion rule is to be removed in the future.
   # Éteins
@@ -710,6 +712,7 @@ expansion_rules:
   lecture: "(lecture|visionnage)"
   volume: "(volume|son|watt[s])"
   minuteur: "(compte a rebours)|(compte à rebours)|(minuteur)|(décompte)"
+  serrure: "(verrou[s]|serrure[s]|loquet[s]|porte[s])"
 
   ### Timers ###
   # mix numerical and litteral value for seconds, minutes and hours for the setting of the duration of the timmer

--- a/sentences/fr/lock_HassTurnOff.yaml
+++ b/sentences/fr/lock_HassTurnOff.yaml
@@ -2,14 +2,72 @@ language: fr
 intents:
   HassTurnOff:
     data:
+      # name
       - sentences:
-          - "déverrouille[(z|r)] [<le>]{name} [<dans> [<le>]{area}]"
+          # Déverrouiller la porte d'entrée
+          - <deverrouille> [<le>]{name}
         requires_context:
           domain: lock
         response: lock
 
+      # area
       - sentences:
-          - "déverrouille[(z|r)] [<tous>] [(la|le[s])] [(porte[s]|serrure[s]|verrou[s])] [<dans>] [<le>]{area}"
+          # Déverrouiller le salon
+          - <deverrouille> [<le>]{area}
+          # Déverrouille les serrures du jardin
+          - <deverrouille> [<tous>] [<le>] <serrure> [<dans>] [<le>]{area}
         slots:
-          domain: "lock"
+          domain: lock
+        response: lock
+
+      # name and area
+
+      - sentences:
+          # Déverrouille la serrure Aqara du jardin
+          - <deverrouille> [<le>]{name} [<dans>] [<le>]{area}
+        requires_context:
+          domain: lock
+        response: lock
+
+      # Context area awareness
+      - sentences:
+          # Déverrouille le loquet
+          - <deverrouille> [<le>] <serrure>
+          # Déverrouille toutes les serrures dans cette pièce
+          - <deverrouille> [<tous>] [<le>] <serrure> <ici>
+        requires_context:
+          area:
+            slot: true
+        slots:
+          domain: lock
+        response: lock
+
+      # floor
+      - sentences:
+          # Déverrouille le premier étage
+          - <deverrouille> [<le>]{floor}
+          # Déverrouille les loquets du premier étage
+          - <deverrouille> [<tous>] [<le>] <serrure> [<dans>] [<le>]{floor}
+        slots:
+          domain: lock
+        response: lock
+
+      # name and floor
+      - sentences:
+          # Déverrouille la serrure Aqara du rez-de-chaussée
+          - <deverrouille> [<le>]{name} [<dans>] [<le>]{floor}
+        requires_context:
+          domain: lock
+        response: lock
+
+      # the whole house
+      - sentences:
+          # Déverrouille les portes dans toute la maison
+          - <deverrouille> [<le>] <serrure> <partout>
+          # Déverrouiller toutes les serrures dans toute la maison
+          - <deverrouille> <tous> [<le>] <serrure> <partout>
+          # Déverrouiller toutes les serrures
+          - <deverrouille> <tous> [<le>] <serrure>
+        slots:
+          domain: lock
         response: lock

--- a/sentences/fr/lock_HassTurnOff.yaml
+++ b/sentences/fr/lock_HassTurnOff.yaml
@@ -21,7 +21,6 @@ intents:
         response: lock
 
       # name and area
-
       - sentences:
           # Déverrouille la serrure Aqara du jardin
           - <deverrouille> [<le>]{name} [<dans>] [<le>]{area}

--- a/sentences/fr/lock_HassTurnOff.yaml
+++ b/sentences/fr/lock_HassTurnOff.yaml
@@ -28,7 +28,7 @@ intents:
           domain: lock
         response: lock
 
-      # Context area awareness
+      # context area awareness
       - sentences:
           # Déverrouille le loquet
           - <deverrouille> [<le>] <serrure>

--- a/sentences/fr/lock_HassTurnOn.yaml
+++ b/sentences/fr/lock_HassTurnOn.yaml
@@ -28,7 +28,7 @@ intents:
           domain: lock
         response: lock
 
-      # Context area awareness
+      # context area awareness
       - sentences:
           # Verrouille le loquet
           - <verrouille> [<le>] <serrure>

--- a/sentences/fr/lock_HassTurnOn.yaml
+++ b/sentences/fr/lock_HassTurnOn.yaml
@@ -2,15 +2,72 @@ language: fr
 intents:
   HassTurnOn:
     data:
+      # name
       - sentences:
-          - "verrouille[(z|r)] [<le>]{name} [<dans> [<le>]{area}]"
+          # Barre la porte d'entrée 🇨🇦
+          - <verrouille> [<le>]{name}
         requires_context:
           domain: lock
         response: lock
 
+      # area
       - sentences:
-          - "verrouille[(z|r)] [<tous>] [(la|le[s])] [(porte[s]|serrure[s]|verrou[s])] [<dans>] [<le>]{area}"
-          - "verrouille[(z|r)] [<tous>] (la|le[s]) (porte[s]|serrure[s]|verrou[s]) [<dans> [<le>]{area}]"
+          # Verrouiller le salon
+          - <verrouille> [<le>]{area}
+          # Verrouille les serrures du jardin
+          - <verrouille> [<tous>] [<le>] <serrure> [<dans>] [<le>]{area}
         slots:
-          domain: "lock"
+          domain: lock
+        response: lock
+
+      # name and area
+
+      - sentences:
+          # Verrouille la serrure Aqara du jardin
+          - <verrouille> [<le>]{name} [<dans>] [<le>]{area}
+        requires_context:
+          domain: lock
+        response: lock
+
+      # Context area awareness
+      - sentences:
+          # Verrouille le loquet
+          - <verrouille> [<le>] <serrure>
+          # Verrouille toutes les serrures dans cette pièce
+          - <verrouille> [<tous>] [<le>] <serrure> <ici>
+        requires_context:
+          area:
+            slot: true
+        slots:
+          domain: lock
+        response: lock
+
+      # floor
+      - sentences:
+          # Verrouille le premier étage
+          - <verrouille> [<le>]{floor}
+          # Verrouille les loquets du premier étage
+          - <verrouille> [<tous>] [<le>] <serrure> [<dans>] [<le>]{floor}
+        slots:
+          domain: lock
+        response: lock
+
+      # name and floor
+      - sentences:
+          # Verrouille la serrure Aqara du rez-de-chaussée
+          - <verrouille> [<le>]{name} [<dans>] [<le>]{floor}
+        requires_context:
+          domain: lock
+        response: lock
+
+      # the whole house
+      - sentences:
+          # Verrouille les portes dans toute la maison
+          - <verrouille> [<le>] <serrure> <partout>
+          # Verrouiller toutes les serrures dans toute la maison
+          - <verrouille> <tous> [<le>] <serrure> <partout>
+          # Verrouiller toutes les serrures
+          - <verrouille> <tous> [<le>] <serrure>
+        slots:
+          domain: lock
         response: lock

--- a/sentences/fr/lock_HassTurnOn.yaml
+++ b/sentences/fr/lock_HassTurnOn.yaml
@@ -21,7 +21,6 @@ intents:
         response: lock
 
       # name and area
-
       - sentences:
           # Verrouille la serrure Aqara du jardin
           - <verrouille> [<le>]{name} [<dans>] [<le>]{area}

--- a/tests/fr/_fixtures.yaml
+++ b/tests/fr/_fixtures.yaml
@@ -109,6 +109,13 @@ entities:
   #    attributes:
   #      device_class: "lock"
 
+  - name: "serrure Aqara"
+    id: "lock.aqara"
+    area: "kitchen"
+    state:
+      in: "déverrouillé"
+      out: "unlocked"
+
   - name: "porte de garage"
     id: "lock.garage"
     area: "garage"

--- a/tests/fr/lock_HassGetState.yaml
+++ b/tests/fr/lock_HassGetState.yaml
@@ -20,7 +20,7 @@ tests:
       slots:
         domain: lock
         state: "unlocked"
-    response: "Oui, porte d'entrée est déverrouillé"
+    response: "Oui, porte d'entrée et serrure Aqara sont déverrouillé"
 
   - sentences:
       - "Toutes les portes sont-elles fermées ?"
@@ -29,7 +29,7 @@ tests:
       slots:
         domain: lock
         state: "locked"
-    response: "Non, pas porte d'entrée"
+    response: "Non, pas porte d'entrée et serrure Aqara"
 
   - sentences:
       - "Quelles portes sont verrouillées ?"

--- a/tests/fr/lock_HassTurnOff.yaml
+++ b/tests/fr/lock_HassTurnOff.yaml
@@ -1,31 +1,88 @@
 language: fr
 tests:
+  # name
   - sentences:
-      - "déverrouille la porte d'entrée"
+      - déverrouille la porte d'entrée
+      - déverrouiller la porte d'entrée
     intent:
       name: HassTurnOff
       context:
         domain: lock
       slots:
-        name: "porte d'entrée"
-    response: "Ouvert"
+        name: porte d'entrée
+    response: "Déverrouillé"
 
+  # area
   - sentences:
-      - "déverrouille toutes les serrures du garage"
-      - "déverrouille le garage"
-      - "déverrouille tout dans le garage"
+      - déverrouiller le salon
+      - déverrouille les serrures du salon
     intent:
       name: HassTurnOff
       slots:
-        area: garage
+        area: salon
         domain: lock
-    response: "Ouvert"
+    response: "Déverrouillé"
 
+  # name and area
   - sentences:
-      - "déverrouille l'entrée"
+      - déverrouille la serrure Aqara de la cuisine
+      - déverrouiller la serrure Aqara dans cuisine
+    intent:
+      name: HassTurnOff
+      context:
+        domain: lock
+      slots:
+        name: serrure Aqara
+        area: cuisine
+    response: "Déverrouillé"
+
+  # Context area awareness
+  - sentences:
+      - déverrouille le loquet
+      - déverrouille les loquets
+      - déverrouille toutes les serrures dans cette pièce
+      - déverrouille toutes les portes ici
+    intent:
+      name: HassTurnOff
+      context:
+        area: salon
+      slots:
+        area: salon
+        domain: lock
+    response: "Déverrouillé"
+
+  # floor
+  - sentences:
+      - déverrouille le premier étage
+      - déverrouille les loquets du premier étage
+      - déverrouille tous les loquets du premier étage
     intent:
       name: HassTurnOff
       slots:
-        area: entrée
+        floor: Premier Étage
         domain: lock
-    response: "Ouvert"
+    response: "Déverrouillé"
+
+  # name and floor
+  - sentences:
+      - déverrouille la serrure Aqara du rez-de-chaussée
+    intent:
+      name: HassTurnOff
+      context:
+        domain: lock
+      slots:
+        name: serrure Aqara
+        floor: Rez-De-Chaussée
+    response: "Déverrouillé"
+
+  # the whole house
+  - sentences:
+      - déverrouille les portes dans toute la maison
+      - déverrouiller toutes les serrures
+      - déverrouiller toutes les portes
+      - déverrouiller toutes les serrures dans toute la maison
+    intent:
+      name: HassTurnOff
+      slots:
+        domain: lock
+    response: "Déverrouillé"

--- a/tests/fr/lock_HassTurnOff.yaml
+++ b/tests/fr/lock_HassTurnOff.yaml
@@ -3,7 +3,7 @@ tests:
   # name
   - sentences:
       - déverrouille la porte d'entrée
-      - déverrouiller la porte d'entrée
+      - déverrouiller porte d'entrée
     intent:
       name: HassTurnOff
       context:

--- a/tests/fr/lock_HassTurnOn.yaml
+++ b/tests/fr/lock_HassTurnOn.yaml
@@ -1,31 +1,87 @@
 language: fr
 tests:
+  # name
   - sentences:
-      - "verrouille la porte d'entrée"
+      - barre la porte d'entrée
+      - verrouille la porte d'entrée
+      - verrouiller la porte d'entrée
     intent:
       name: HassTurnOn
       context:
         domain: lock
       slots:
         name: porte d'entrée
-    response: "Fermé"
+    response: "Verrouillé"
 
+  # area
   - sentences:
-      - "verrouille toutes les serrures du garage"
-      - "verrouille le garage"
-      - "verrouille tout dans le garage"
+      - verrouiller le salon
+      - verrouille les serrures du salon
+      - verrouille toutes les serrures du salon
     intent:
       name: HassTurnOn
       slots:
-        area: garage
+        area: salon
         domain: lock
-    response: "Fermé"
+    response: "Verrouillé"
 
+  # name and area
   - sentences:
-      - "verrouille l'entrée"
+      - verrouille la serrure Aqara de la cuisine
+    intent:
+      name: HassTurnOn
+      context:
+        domain: lock
+      slots:
+        name: serrure Aqara
+        area: cuisine
+    response: "Verrouillé"
+
+  # Context area awareness
+  - sentences:
+      - Verrouille le loquet
+      - Verrouille toutes les serrures ici
+      - Verrouille les serrures dans cette pièce
+    intent:
+      name: HassTurnOn
+      context:
+        area: salon
+      slots:
+        area: salon
+        domain: lock
+    response: "Verrouillé"
+
+  # floor
+  - sentences:
+      - Verrouille le premier étage
+      - Verrouille les loquets du premier étage
+      - Verrouille tous les loquets du premier étage
     intent:
       name: HassTurnOn
       slots:
-        area: entrée
+        floor: Premier Étage
         domain: lock
-    response: "Fermé"
+    response: "Verrouillé"
+
+  # name and floor
+  - sentences:
+      - Verrouille la serrure Aqara du rez-de-chaussée
+    intent:
+      name: HassTurnOn
+      context:
+        domain: lock
+      slots:
+        name: serrure Aqara
+        floor: Rez-De-Chaussée
+    response: "Verrouillé"
+
+  # the whole house
+  - sentences:
+      - Verrouille les portes dans toute la maison
+      - Verrouiller toutes les serrures
+      - Verrouiller toutes les serrures dans toute la maison
+    intent:
+      name: HassTurnOn
+      slots:
+        domain: lock
+    response: "Verrouillé"


### PR DESCRIPTION
New lock support (aligned with our ongoing effort)

You can target locks by
- name
- area
- name and area
- floor
- name and floor
- the whole house
- locks in the current area

Co-authored-by: Paul Bottein <piitaya@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated French responses for locking and unlocking commands, enhancing clarity and specificity.
	- Added new sentence patterns for various contexts, improving command recognition for locking mechanisms.
	- Introduced new error messages related to device locking and unlocking.

- **Bug Fixes**
	- Corrected terminology in responses from "Ouvert" to "Déverrouillé" and "Fermé" to "Verrouillé".

- **Tests**
	- Expanded test coverage for locking functionalities, including new scenarios and contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->