### PR TITLE
[FR] Improve whole house intents

### DIFF
--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -699,8 +699,7 @@ expansion_rules:
   ferme_dirty: "faire"
 
   # Domains and Things
-  lumiere: "(lumière|lampe|ampoule)"
-  lumieres: "(lumières|lampes|ampoules)"
+  lumiere: "(lumière[s]|lampe[s]|ampoule[s])"
   ventilateur: "[le ](ventilateur|brasseur d'air)"
   ventilateurs: "[les ](ventilateurs|brasseurs d'air)"
   fenetre: "(fenetre[s]|fenêtre[s]|baie[s]|velux|vélux|lucarne[s])"

--- a/sentences/fr/cover_HassTurnOff.yaml
+++ b/sentences/fr/cover_HassTurnOff.yaml
@@ -28,10 +28,12 @@ intents:
 
       # device_class
       - sentences:
+          # Ferme les volets dans toute la maison
+          - <ferme> [<le>]{cover_classes:device_class} <partout>
           # Ferme tous les volets
           - <ferme> <tous> [<le>]{cover_classes:device_class}
-          # Ferme les volets dans toute la maison
-          - <ferme> [<tous>] [<le>]{cover_classes:device_class} <partout>
+          # Ferme tous les volets dans toute la maison
+          - <ferme> <tous> [<le>]{cover_classes:device_class} <partout>
         slots:
           domain: cover
         response: cover

--- a/sentences/fr/cover_HassTurnOn.yaml
+++ b/sentences/fr/cover_HassTurnOn.yaml
@@ -28,10 +28,12 @@ intents:
 
       # device_class
       - sentences:
+          # Ouvre les volets dans toute la maison
+          - <ouvre> [<le>]{cover_classes:device_class} <partout>
           # Ouvre tous les volets
           - <ouvre> <tous> [<le>]{cover_classes:device_class}
-          # Ouvre les volets dans toute la maison
-          - <ouvre> [<tous>] [<le>]{cover_classes:device_class} <partout>
+          # Ouvre tous les volets dans toute la maison
+          - <ouvre> <tous> [<le>]{cover_classes:device_class} <partout>
         slots:
           domain: cover
         response: cover

--- a/sentences/fr/light_HassLightSet.yaml
+++ b/sentences/fr/light_HassLightSet.yaml
@@ -7,7 +7,7 @@ intents:
           # Règle la luminosité de la statue à 50%
           - "(<regle>|<augmente>|<diminue>) [la] luminosité [<de>] [<le>]{name} [à] {brightness}<pourcent>"
           # Allume la lumière du mirroir à 70%
-          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>](<lumiere>|<lumieres>) [<de>] [<le>]{name} [à] {brightness}<pourcent>"
+          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]<lumiere> [<de>] [<le>]{name} [à] {brightness}<pourcent>"
           # Règle le mirrior à 50% de luminosité
           - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]{name} [à] {brightness}<pourcent> [de] luminosité"
           # Allume le sapin à 50%
@@ -29,7 +29,7 @@ intents:
           # Baisse la luminosité du bureau à 40%
           - "(<regle>|<augmente>|<diminue>) [la] luminosité [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
           # Allume la lumière du bureau à 70%
-          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>](<lumiere>|<lumieres>)  [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
+          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]<lumiere>  [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
           # Règle le bureau à 50% de luminosité
           - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]{area} [à] {brightness}<pourcent> [de] luminosité"
           # Monte le bureau a 100%
@@ -41,7 +41,7 @@ intents:
           # Bureau à 50 de luminosité
           - "[<le>]{area} [à] {brightness}<pourcent> [de] luminosité"
           # Règle les lumieres du bureau avec la luminosité à 50% (Too complex... We should think about removing that)
-          - "(<allume>|<regle>) [<tous>] [<le>][<lumieres>] [<de>] [<le>]{area} [avec la luminosité|avec la lumière] [à] {brightness}<pourcent>"
+          - "(<allume>|<regle>) [<tous>] [<le>][<lumiere>] [<de>] [<le>]{area} [avec la luminosité|avec la lumière] [à] {brightness}<pourcent>"
         response: brightness
 
       # brigtness (area + context awareness)
@@ -49,7 +49,7 @@ intents:
           # Baisse la luminosité à 40%
           - "(<regle>|<augmente>|<diminue>) [la] luminosité [à] {brightness}<pourcent>"
           # Allume la lumière à 70%
-          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>](<lumiere>|<lumieres>) [à] {brightness}<pourcent>"
+          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]<lumiere> [à] {brightness}<pourcent>"
           # Règle à 50% de luminosité
           - "(<allume>|<regle>|<augmente>|<diminue>) [à] {brightness}<pourcent> [de] luminosité"
           # Luminosité à 50%
@@ -66,7 +66,7 @@ intents:
           # Baisse la luminosité du mirrior de la salle de bain à 20%
           - "(<regle>|<augmente>|<diminue>) [la] luminosité [<de>] [<le>]{name} [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
           # Allume la lumière de la statue du jardin à 60%
-          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>](<lumiere>|<lumieres>)  [<de>] [<le>]{name} [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
+          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]<lumiere>  [<de>] [<le>]{name} [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
           # Règle les spots du salon à 60% de luminosité
           - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]{name} [<dans>] [<le>]{area} [à] {brightness}<pourcent> [de] luminosité"
           # Allume les spots du salon à 80%
@@ -91,7 +91,7 @@ intents:
           # Baisse la luminosité du rez-de-chaussée à 40%
           - "(<regle>|<augmente>|<diminue>) [la] luminosité [<dans>] [<le>]{floor} [à] {brightness}<pourcent>"
           # Allume la lumière du rez-de-chaussée à 70%
-          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>](<lumiere>|<lumieres>)  [<dans>] [<le>]{floor} [à] {brightness}<pourcent>"
+          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]<lumiere>  [<dans>] [<le>]{floor} [à] {brightness}<pourcent>"
           # Règle le rez-de-chaussée à 50% de luminosité
           - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]{floor} [à] {brightness}<pourcent> [de] luminosité"
           # Monte le rez-de-chaussée a 100%
@@ -103,7 +103,7 @@ intents:
           # Rez-de-chaussée à 50 de luminosité
           - "[<le>]{floor} [à] {brightness}<pourcent> [de] luminosité"
           # Règle les lumieres du rez-de-chaussée avec la luminosité à 50% (Too complex... We should think about removing that)
-          - "(<allume>|<regle>) [<tous>] [<le>][<lumieres>] [<de>] [<le>]{floor} [avec la luminosité|avec la lumière] [à] {brightness}<pourcent>"
+          - "(<allume>|<regle>) [<tous>] [<le>][<lumiere>] [<de>] [<le>]{floor} [avec la luminosité|avec la lumière] [à] {brightness}<pourcent>"
         response: brightness
 
       # color (name)
@@ -121,9 +121,9 @@ intents:
           # Règle la couleur du salon en vert
           - "<regle> la couleur [<de>] [<le>]{area} [en] {color}"
           # Règle la couleur des lumières du salon en vert
-          - "<regle> la couleur <de> [<tous>] [<le>](<lumiere>|<lumieres>) [<dans>] [<le>]{area} [en] {color}"
+          - "<regle> la couleur <de> [<tous>] [<le>]<lumiere> [<dans>] [<le>]{area} [en] {color}"
           # Allume les lumières du salon en rouge
-          - "(<regle>|<allume>) [<tous>] [<le>](<lumiere>|<lumieres>) [<de>] [<le>]{area} [avec la couleur | de couleur | en] {color}"
+          - "(<regle>|<allume>) [<tous>] [<le>]<lumiere> [<de>] [<le>]{area} [avec la couleur | de couleur | en] {color}"
           # Allume le salon en rouge
           - "(<regle>|<allume>) [<le>]{area} [avec la couleur | de couleur | en] {color}"
         response: color
@@ -133,9 +133,9 @@ intents:
           # Règle la couleur en vert
           - "<regle> la couleur [en] {color}"
           # Règle la couleur des lumières en vert
-          - "<regle> la couleur <de> [<tous>] [<le>](<lumiere>|<lumieres>) [en] {color}"
+          - "<regle> la couleur <de> [<tous>] [<le>]<lumiere> [en] {color}"
           # Allume les lumières en rouge
-          - "(<regle>|<allume>) [<tous>] [<le>](<lumiere>|<lumieres>) [avec la couleur | de couleur | en] {color}"
+          - "(<regle>|<allume>) [<tous>] [<le>]<lumiere> [avec la couleur | de couleur | en] {color}"
         response: color
         requires_context:
           area:
@@ -159,9 +159,9 @@ intents:
           # Règle la couleur du rez-de-chaussée en vert
           - "<regle> la couleur [<de>] [<le>]{floor} [en] {color}"
           # Règle la couleur des lumières du rez-de-chaussée en vert
-          - "<regle> la couleur <de> [<tous>] [<le>](<lumiere>|<lumieres>) [<dans>] [<le>]{floor} [en] {color}"
+          - "<regle> la couleur <de> [<tous>] [<le>]<lumiere> [<dans>] [<le>]{floor} [en] {color}"
           # Allume les lumières du rez-de-chaussée en rouge
-          - "(<regle>|<allume>) [<tous>] [<le>](<lumiere>|<lumieres>) [<de>] [<le>]{floor} [avec la couleur | de couleur | en] {color}"
+          - "(<regle>|<allume>) [<tous>] [<le>]<lumiere> [<de>] [<le>]{floor} [avec la couleur | de couleur | en] {color}"
           # Allume le rez-de-chaussée en rouge
           - "(<regle>|<allume>) [<le>]{floor} [avec la couleur | de couleur | en] {color}"
         response: color

--- a/sentences/fr/light_HassLightSet.yaml
+++ b/sentences/fr/light_HassLightSet.yaml
@@ -66,7 +66,7 @@ intents:
           # Baisse la luminosité du mirrior de la salle de bain à 20%
           - "(<regle>|<augmente>|<diminue>) [la] luminosité [<de>] [<le>]{name} [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
           # Allume la lumière de la statue du jardin à 60%
-          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]<lumiere>  [<de>] [<le>]{name} [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
+          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]<lumiere> [<de>] [<le>]{name} [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
           # Règle les spots du salon à 60% de luminosité
           - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]{name} [<dans>] [<le>]{area} [à] {brightness}<pourcent> [de] luminosité"
           # Allume les spots du salon à 80%
@@ -91,7 +91,7 @@ intents:
           # Baisse la luminosité du rez-de-chaussée à 40%
           - "(<regle>|<augmente>|<diminue>) [la] luminosité [<dans>] [<le>]{floor} [à] {brightness}<pourcent>"
           # Allume la lumière du rez-de-chaussée à 70%
-          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]<lumiere>  [<dans>] [<le>]{floor} [à] {brightness}<pourcent>"
+          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]<lumiere> [<dans>] [<le>]{floor} [à] {brightness}<pourcent>"
           # Règle le rez-de-chaussée à 50% de luminosité
           - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]{floor} [à] {brightness}<pourcent> [de] luminosité"
           # Monte le rez-de-chaussée a 100%

--- a/sentences/fr/light_HassLightSet.yaml
+++ b/sentences/fr/light_HassLightSet.yaml
@@ -29,7 +29,7 @@ intents:
           # Baisse la luminosité du bureau à 40%
           - "(<regle>|<augmente>|<diminue>) [la] luminosité [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
           # Allume la lumière du bureau à 70%
-          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]<lumiere>  [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
+          - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]<lumiere> [<dans>] [<le>]{area} [à] {brightness}<pourcent>"
           # Règle le bureau à 50% de luminosité
           - "(<allume>|<regle>|<augmente>|<diminue>) [<le>]{area} [à] {brightness}<pourcent> [de] luminosité"
           # Monte le bureau a 100%

--- a/sentences/fr/light_HassTurnOff.yaml
+++ b/sentences/fr/light_HassTurnOff.yaml
@@ -8,7 +8,7 @@ intents:
       # area
       - sentences:
           # Éteindre les lumieres du bureau
-          - "<eteins> [<tous>] [<le>](<lumiere>|<lumieres>) [<dans>] [<le>]{area}"
+          - "<eteins> [<tous>] [<le>]<lumiere> [<dans>] [<le>]{area}"
           # Éteint le salon
           - "<eteins> [<le>]{area}"
         slots:
@@ -17,9 +17,9 @@ intents:
       # area + context awareness
       - sentences:
           # Éteindre toutes les lumieres ici
-          - "<eteins> [<tous>] [<le>](<lumiere>|<lumieres>) <ici>"
+          - "<eteins> [<tous>] [<le>]<lumiere> <ici>"
           # Éteindre les lumieres
-          - "<eteins> [<le>](<lumiere>|<lumieres>)"
+          - "<eteins> [<le>]<lumiere>"
           # Jacouille, éteins les lumieres
           - (nuit|nuits)
         slots:
@@ -34,9 +34,11 @@ intents:
       # all
       - sentences:
           # Éteindre les lumieres de partout
-          - <eteins> [<le>](<lumiere>|<lumieres>) <partout>
+          - <eteins> [<le>]<lumiere> <partout>
           # Éteindre toutes lumieres
-          - <eteins> <tous> [<le>]<lumieres>
+          - <eteins> <tous> [<le>]<lumiere>
+          # Éteindre toutes lumieres de la maison
+          - <eteins> <tous> [<le>]<lumiere> <partout>
         slots:
           domain: light
 
@@ -46,7 +48,7 @@ intents:
       # floor
       - sentences:
           # Éteindre les lumieres du premiere étage
-          - "<eteins> [<tous>] [<le>](<lumiere>|<lumieres>) [<dans>] [<le>]{floor}"
+          - "<eteins> [<tous>] [<le>]<lumiere> [<dans>] [<le>]{floor}"
           # Éteint le rez-de-chaussée
           - "<eteins> [<le>]{floor}"
         slots:

--- a/sentences/fr/light_HassTurnOn.yaml
+++ b/sentences/fr/light_HassTurnOn.yaml
@@ -8,20 +8,20 @@ intents:
       # area
       - sentences:
           # Allume la lumiere du bureau
-          - "<allume> [<tous>] [<le>](<lumiere>|<lumieres>) [<dans>] [<le>]{area}"
+          - "<allume> [<tous>] [<le>]<lumiere> [<dans>] [<le>]{area}"
           # Allume le bureau
           - "(<allume>|<eclaire>) [<le>]{area}"
           # Lumière dans le bureau
-          - "(<lumiere>|<lumieres>) [<dans>] [<le>]{area}"
+          - "<lumiere> [<dans>] [<le>]{area}"
         slots:
           domain: light
 
       # area + context awareness
       - sentences:
           # Allume toutes les lumieres ici
-          - "<allume> [<tous>] [<le>](<lumiere>|<lumieres>) <ici>"
+          - "<allume> [<tous>] [<le>]<lumiere> <ici>"
           # Allume les lumieres
-          - "<allume> [<le>](<lumiere>|<lumieres>)"
+          - "<allume> [<le>]<lumiere>"
           # Jacouille, allume les lumieres
           - (jour|jours)
         slots:
@@ -35,8 +35,12 @@ intents:
 
       # all
       - sentences:
-          - <allume> [<le>](<lumiere>|<lumieres>) <partout>
-          - <allume> <tous> [<le>]<lumieres>
+          # Allume les lumieres de partout
+          - <allume> [<le>]<lumiere> <partout>
+          # Allume toutes lumieres
+          - <allume> <tous> [<le>]<lumiere>
+          # Allume toutes lumieres de la maison
+          - <allume> <tous> [<le>]<lumiere> <partout>
         slots:
           domain: light
 
@@ -46,10 +50,10 @@ intents:
       # floor
       - sentences:
           # Allume la lumiere du premier étage
-          - "<allume> [<tous>] [<le>](<lumiere>|<lumieres>) [<dans>] [<le>]{floor}"
+          - "<allume> [<tous>] [<le>]<lumiere> [<dans>] [<le>]{floor}"
           # Allume le rez-de-chaussée
           - "(<allume>|<eclaire>) [<le>]{floor}"
           # Lumière au premier étage
-          - "(<lumiere>|<lumieres>) [<dans>] [<le>]{floor}"
+          - "<lumiere> [<dans>] [<le>]{floor}"
         slots:
           domain: light

--- a/tests/fr/cover_HassTurnOff.yaml
+++ b/tests/fr/cover_HassTurnOff.yaml
@@ -44,6 +44,7 @@ tests:
       - ferme tous les volets
       - fermer les volets de la maison
       - baisser volets partout
+      - fermer tous les volets de la maison
     intent:
       name: HassTurnOff
       slots:

--- a/tests/fr/cover_HassTurnOn.yaml
+++ b/tests/fr/cover_HassTurnOn.yaml
@@ -46,6 +46,7 @@ tests:
       - ouvre toutes les portes
       - ouvrir les portes de la maison
       - ouvrir portes partout
+      - ouvrir toutes les portes de la maison
     intent:
       name: HassTurnOn
       slots:

--- a/tests/fr/light_HassTurnOff.yaml
+++ b/tests/fr/light_HassTurnOff.yaml
@@ -22,6 +22,8 @@ tests:
       - Éteins les lumières de partout
       - Éteindre la lumière partout
       - Désactiver toutes les lumières
+      - Éteindre toutes les lumières de la maison
+      - Éteindre la lumière de la maison
     intent:
       name: HassTurnOff
       slots:

--- a/tests/fr/light_HassTurnOn.yaml
+++ b/tests/fr/light_HassTurnOn.yaml
@@ -26,6 +26,8 @@ tests:
       - Allume les lumières de partout
       - Allumer la lumière partout
       - Activer toutes les lumières
+      - Allume toutes les lumières de la maison
+      - Allume la lumière de la maison
     intent:
       name: HassTurnOn
       slots:


### PR DESCRIPTION
Plural and singular form has been merged for lights.
Also, all house sentences has been improved by allowing "tous" and "partout" in the same sentences.

We can now say "Allume la lumière de la maison" et "Allume toutes les lumières de la maison".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced plural recognition for French error responses, improving user interaction with commands involving multiple items.
	- Added new sentence patterns for covering devices, allowing commands for closing and opening all shutters in the house.
	- Streamlined sentence structures for light control commands, simplifying user inputs for turning lights on and off.
	- Expanded command variations for turning off and on lights and covers, including specific phrases for whole house actions.

- **Bug Fixes**
	- Improved error responses for unrecognized entities, ensuring more robust handling of user commands.

- **Tests**
	- Expanded test cases for light and cover commands, adding new sentence variations to enhance recognition capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->