### PR TITLE
Tidy timer status file, added "how long" phrase

### DIFF
--- a/sentences/en/homeassistant_HassTimerStatus.yaml
+++ b/sentences/en/homeassistant_HassTimerStatus.yaml
@@ -3,18 +3,32 @@ language: "en"
 intents:
   HassTimerStatus:
     data:
+      # Timer status
       - sentences:
-          - "timer[s] status"
-          - "status of[ the| my] timer[s]"
-          - "[how much ]time[ is] left on[ the| my] timer[s]"
           - "<timer_start> timer status"
-          - "status of[ the| my] <timer_start> timer"
-          - "[how much ]time[ is] left on[ the| my] <timer_start> timer"
+          - "timer[s] status"
           - "{area} timer status"
-          - "status of[ the| my] {area} timer[s]"
-          - "status of[ the| my] timer[s] in <area>"
-          - "[how much ]time[ is] left on[ the| my] {area} timer"
-          - "[how much ]time[ is] left on[ the| my] timer[s] in <area>"
+      # How much...
+      - sentences:
+          - "[how much] time [is] left on [the|my] timer[s]"
+          - "[how much] time [is] left on [the|my] <timer_start> timer"
+          - "[how much] time [is] left on [the|my] {area} timer"
+          - "[how much] time [is] left on [the|my] timer[s] in <area>"
+      # How long...
+      - sentences:
+          - "how long [is] left on [the|my] timer[s]"
+          - "how long [is] left on [the|my] <timer_start> timer"
+          - "how long [is] left on [the|my] {area} timer"
+          - "how long [is] left on [the|my] timer[s] in <area>"
+      # Status of...
+      - sentences:
+          - "status of [the|my] timer[s]"
+          - "status of [the|my] <timer_start> timer"
+          - "status of [the|my] {area} timer[s]"
+          - "status of [the|my] timer[s] in <area>"
+      # Named timers
+      - sentences:
           - "{timer_name:name} timer status"
-          - "status of[ the| my] {timer_name:name} timer[s]"
-          - "[how much ]time[ is] left on[ the| my] {timer_name:name} timer"
+          - "[how much] time [is] left on [the|my] {timer_name:name} timer"
+          - "status of [the|my] {timer_name:name} timer[s]"
+          - "how long [is] left on [the|my] {timer_name:name} timer"

--- a/tests/en/homeassistant_HassTimerStatus.yaml
+++ b/tests/en/homeassistant_HassTimerStatus.yaml
@@ -5,15 +5,17 @@ tests:
       - "timer status"
       - "status of my timers"
       - "how much time is left on my timers"
+      - "how long is left on my timers"
     intent:
       name: HassTimerStatus
     response: |
       2 running timers. 1 paused timer. 3 minutes left on 5 minute kitchen timer.
 
   - sentences:
+      - "status of 1 hour timer"
       - "1 hour timer status"
       - "time left on the 1 hour timer"
-      - "status of 1 hour timer"
+      - "how long is left on my 1 hour timer"
     intent:
       name: HassTimerStatus
       slots:
@@ -25,6 +27,7 @@ tests:
       - "pizza timer status"
       - "status of pizza timer"
       - "how much time left on pizza timer"
+      - "how long is left on the pizza timer"
     intent:
       name: HassTimerStatus
       slots:
@@ -38,6 +41,8 @@ tests:
       - "status of timer in kitchen"
       - "how much time is left on the kitchen timer"
       - "how much time is left on the timer in the kitchen"
+      - "how long is left on the kitchen timer"
+      - "how long is left on the timer in the kitchen"
     intent:
       name: HassTimerStatus
       slots:


### PR DESCRIPTION
- Updated `homeassistant_HassTimerStatus.yaml` to be more semantic
- Added "how long..." phrase which is used in the UK
- Added appropriate tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced organization of timer status inquiries with new categories: "How Much," "How Long," "Status of," and "Named Timers."
  - Added specific sentence variations for querying timer statuses and remaining times.

- **Bug Fixes**
  - Improved recognition of user queries related to general and named timers in the testing framework. 

These updates enhance user experience by providing clearer and more comprehensive ways to inquire about timers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->