### PR TITLE
[en] Add "take off/from" timer to decrease

### DIFF
--- a/sentences/en/homeassistant_HassDecreaseTimer.yaml
+++ b/sentences/en/homeassistant_HassDecreaseTimer.yaml
@@ -3,19 +3,30 @@ language: "en"
 intents:
   HassDecreaseTimer:
     data:
+      # Remove...
       - sentences:
-          - "remove <timer_duration> from[ the| my] timer"
-          - "remove <timer_duration> from[ the| my] <timer_start> timer"
-          - "remove <timer_duration> from[ the| my] timer for <timer_start>"
-          - "remove <timer_duration> from[ the| my] {area} timer"
-          - "remove <timer_duration> from[ the| my] timer in <area>"
-          - "remove <timer_duration> from[ the| my] {timer_name:name} timer"
-          - "remove <timer_duration> from[ the| my] timer (named|called|for) {timer_name:name}"
+          - "remove <timer_duration> from [the|my] timer"
+          - "remove <timer_duration> from [the|my] <timer_start> timer"
+          - "remove <timer_duration> from [the|my] timer for <timer_start>"
+          - "remove <timer_duration> from [the|my] {area} timer"
+          - "remove <timer_duration> from [the|my] timer in <area>"
+          - "remove <timer_duration> from [the|my] {timer_name:name} timer"
+          - "remove <timer_duration> from [the|my] timer (named|called|for) {timer_name:name}"
+      # Take...
       - sentences:
-          - "decrease[ the| my] timer by <timer_duration>"
-          - "decrease[ the| my] <timer_start> timer by <timer_duration>"
-          - "decrease[ the| my] timer for <timer_start> by <timer_duration>"
-          - "decrease[ the| my] {area} timer by <timer_duration>"
-          - "decrease[ the| my] timer in <area> by <timer_duration>"
-          - "decrease[ the| my] {timer_name:name} timer by <timer_duration>"
-          - "decrease[ the| my] timer (named|called|for) {timer_name:name} by <timer_duration>"
+          - "take <timer_duration> [from|off] [the|my] timer"
+          - "take <timer_duration> [from|off] [the|my] <timer_start> timer"
+          - "take <timer_duration> [from|off] [the|my] timer for <timer_start>"
+          - "take <timer_duration> [from|off] [the|my] {area} timer"
+          - "take <timer_duration> [from|off] [the|my] timer in <area>"
+          - "take <timer_duration> [from|off] [the|my] {timer_name:name} timer"
+          - "take <timer_duration> [from|off] [the|my] timer (named|called|for) {timer_name:name}"
+      # Decrease...
+      - sentences:
+          - "decrease [the|my] timer by <timer_duration>"
+          - "decrease [the|my] <timer_start> timer by <timer_duration>"
+          - "decrease [the|my] timer for <timer_start> by <timer_duration>"
+          - "decrease [the|my] {area} timer by <timer_duration>"
+          - "decrease [the|my] timer in <area> by <timer_duration>"
+          - "decrease [the|my] {timer_name:name} timer by <timer_duration>"
+          - "decrease [the|my] timer (named|called|for) {timer_name:name} by <timer_duration>"

--- a/tests/en/homeassistant_HassDecreaseTimer.yaml
+++ b/tests/en/homeassistant_HassDecreaseTimer.yaml
@@ -3,6 +3,8 @@ language: en
 tests:
   - sentences:
       - "remove 5 minutes from timer"
+      - "take 5 minutes off my timer"
+      - "take 5 minutes from my timer"
       - "decrease my timer by 5 minutes"
     intent:
       name: HassDecreaseTimer
@@ -13,6 +15,8 @@ tests:
   - sentences:
       - "remove 5 minutes from 1 hour timer"
       - "remove 5 minutes from timer for 1 hour"
+      - "take 5 minutes off 1 hour timer"
+      - "take 5 minutes from 1 hour timer"
       - "decrease 1 hour timer by 5 minutes"
       - "decrease timer for 1 hour by 5 minutes"
     intent:
@@ -25,6 +29,8 @@ tests:
   - sentences:
       - "remove 5 minutes from pizza timer"
       - "remove 5 minutes from timer named pizza"
+      - "take 5 minutes off pizza timer"
+      - "take 5 minutes from pizza timer"
       - "decrease pizza timer by 5 minutes"
       - "decrease timer for pizza by 5 minutes"
     intent:
@@ -39,6 +45,8 @@ tests:
   - sentences:
       - "remove 5 minutes from kitchen timer"
       - "remove 5 minutes from timer in kitchen"
+      - "take 5 minutes off kitchen timer"
+      - "take 5 minutes from timer in kitchen"
       - "decrease timer in kitchen by 5 minutes"
       - "decrease kitchen timer by 5 minutes"
     intent:


### PR DESCRIPTION
Adds more British variants for decreasing a timer and tidied up the `homeassistant_HassDecreaseTimer.yaml` file.

 The following variants have been added:

"Take 5 minutes (off/from) (the/my) timer"



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated phrasing for timer manipulation commands, replacing "decrease" with "take" for improved clarity.
	- Added new command variations for removing and decreasing timer durations.
  
- **Bug Fixes**
	- Enhanced natural language processing for timer decrement commands with additional test cases.

These changes aim to provide a more intuitive user experience when interacting with timer functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->