### PR TITLE
Update en language leaders

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -26,9 +26,9 @@ sentences/de-CH/ @dontinelli
 responses/de-CH/ @dontinelli
 tests/de-CH/ @dontinelli
 
-sentences/en/ @tetele
-responses/en/ @tetele
-tests/en/ @tetele
+sentences/en/ @tetele @mrdarrengriffin
+responses/en/ @tetele @mrdarrengriffin
+tests/en/ @tetele @mrdarrengriffin
 
 sentences/es/ @davefx
 responses/es/ @davefx

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -26,9 +26,9 @@ sentences/de-CH/ @dontinelli
 responses/de-CH/ @dontinelli
 tests/de-CH/ @dontinelli
 
-sentences/en/ @tetele @mrdarrengriffin
-responses/en/ @tetele @mrdarrengriffin
-tests/en/ @tetele @mrdarrengriffin
+sentences/en/ @mrdarrengriffin @tetele
+responses/en/ @mrdarrengriffin @tetele
+tests/en/ @mrdarrengriffin @tetele
 
 sentences/es/ @davefx
 responses/es/ @davefx

--- a/languages.yaml
+++ b/languages.yaml
@@ -41,6 +41,7 @@ en:
   nativeName: English
   leaders:
     - tetele
+    - mrdarrengriffin
 es:
   nativeName: Español
   leaders:


### PR DESCRIPTION
Adding myself as an EN language leader. Primary language leader for the UK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new leader entry `mrdarrengriffin` under the English language section.
- **Updates**
	- Updated ownership for English language directories to include `@mrdarrengriffin` alongside `@tetele` for `sentences/en/`, `responses/en/`, and `tests/en/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->