### PR TITLE
Add vividboarder as an en language leader

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -26,9 +26,9 @@ sentences/de-CH/ @dontinelli
 responses/de-CH/ @dontinelli
 tests/de-CH/ @dontinelli
 
-sentences/en/ @mrdarrengriffin @tetele
-responses/en/ @mrdarrengriffin @tetele
-tests/en/ @mrdarrengriffin @tetele
+sentences/en/ @mrdarrengriffin @tetele @vividboarder
+responses/en/ @mrdarrengriffin @tetele @vividboarder
+tests/en/ @mrdarrengriffin @tetele @vividboarder
 
 sentences/es/ @davefx
 responses/es/ @davefx

--- a/languages.yaml
+++ b/languages.yaml
@@ -40,8 +40,9 @@ el:
 en:
   nativeName: English
   leaders:
-    - tetele
     - mrdarrengriffin
+    - tetele
+    - vividboarder
 es:
   nativeName: Español
   leaders:


### PR DESCRIPTION
To reduce future conflicts (maybe optimistic), I sorted the list in `languages.yaml` too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated ownership assignments for English language directories to include a new owner, `@vividboarder`.
	- Modified the leadership structure for the English language entry in `languages.yaml`, replacing `mrdarrengriffin` with `vividboarder`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->