### PR TITLE
[en] Add min as a represenation of minimum

### DIFF
--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -76,7 +76,7 @@ lists:
     values:
       - in: (max|maximum|highest)
         out: 100
-      - in: (minimum|lowest)
+      - in: (min|minimum|lowest)
         out: 1
   on_off_states:
     values:

--- a/tests/en/light_HassLightSet.yaml
+++ b/tests/en/light_HassLightSet.yaml
@@ -79,6 +79,7 @@ tests:
       - "set the bedroom lamp brightness to the lowest"
       - "change the brightness of bedroom lamp to lowest"
       - "set the bedroom lamp to minimum brightness"
+      - "set the bedroom lamp to min brightness"
     intent:
       name: HassLightSet
       slots:
@@ -91,6 +92,7 @@ tests:
       - "change the brightness of bedroom to lowest"
       - "set the bedroom brightness to the minimum"
       - "change the bedroom to minimum brightness"
+      - "change the bedroom to min brightness"
     intent:
       name: HassLightSet
       slots:


### PR DESCRIPTION
Small change as I was looking through some of the state mappings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced input flexibility for brightness levels, allowing for more concise commands.
	- Expanded test coverage for brightness control, including new sentences for setting minimum brightness.

- **Bug Fixes**
	- Retained error messages for scenarios where users are not logged in, ensuring consistent user experience.

- **Documentation**
	- Updated mappings for brightness levels in the documentation for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->