### PR TITLE
[en] Add more expansions for state values

### DIFF
--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -86,7 +86,7 @@ lists:
         out: "off"
   on_off_domains:
     values:
-      - in: (light|lamp)[s]
+      - in: light[s]
         out: light
       - in: fan[s]
         out: fan

--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -86,7 +86,7 @@ lists:
         out: "off"
   on_off_domains:
     values:
-      - in: light[s]
+      - in: (light|lamp)[s]
         out: light
       - in: fan[s]
         out: fan
@@ -96,11 +96,11 @@ lists:
     values:
       - in: "open"
         out: "open"
-      - in: "closed"
+      - in: "(closed|shut)"
         out: "closed"
       - in: "opening"
         out: "opening"
-      - in: "closing"
+      - in: "(closing|shutting)"
         out: "closing"
   cover_classes:
     values:
@@ -134,7 +134,7 @@ lists:
     values:
       - in: "low"
         out: "on"
-      - in: "normal"
+      - in: "(normal|charged)"
         out: "off"
 
   bs_battery_charging_states:
@@ -169,14 +169,14 @@ lists:
     values:
       - in: "open"
         out: "on"
-      - in: "closed"
+      - in: "(closed|shut)"
         out: "off"
 
   bs_garage_door_states:
     values:
       - in: "open"
         out: "on"
-      - in: "closed"
+      - in: "(closed|shut)"
         out: "off"
 
   bs_gas_states:
@@ -232,7 +232,7 @@ lists:
     values:
       - in: "open"
         out: "on"
-      - in: "closed"
+      - in: "(closed|shut)"
         out: "off"
 
   bs_plug_states:
@@ -253,7 +253,7 @@ lists:
     values:
       - in: "(home|present)"
         out: "on"
-      - in: "(away|not present)"
+      - in: "(away|not (home|present)|gone)"
         out: "off"
 
   bs_problem_states:

--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -316,8 +316,8 @@ lists:
     values:
       - in: "open"
         out: "on"
-      - in: "clear"
-        out: "closed"
+      - in: "(closed|shut)"
+        out: "off"
 
   shopping_list_item:
     wildcard: true

--- a/tests/en/binary_sensor_HassGetState.yaml
+++ b/tests/en/binary_sensor_HassGetState.yaml
@@ -13,6 +13,18 @@ tests:
     response: "No, normal"
 
   - sentences:
+      - "is the phone battery normal?"
+      - "is the phone battery charged?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "binary_sensor"
+        device_class: "battery"
+        name: "Phone"
+        state: "off"
+    response: "Yes"
+
+  - sentences:
       - "are any batteries low?"
     intent:
       name: HassGetState
@@ -277,6 +289,7 @@ tests:
   # Garage door
   - sentences:
       - "is the secondary garage door closed?"
+      - "is the secondary garage door shut?"
     intent:
       name: HassGetState
       slots:
@@ -655,6 +668,18 @@ tests:
     response: "No, closed"
 
   - sentences:
+      - "is the shed door closed?"
+      - "is the shed door shut?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "binary_sensor"
+        device_class: "opening"
+        name: "Shed Door"
+        state: "off"
+    response: "Yes"
+
+  - sentences:
       - "are any openings open?"
     intent:
       name: HassGetState
@@ -809,6 +834,17 @@ tests:
         name: "Phone"
         state: "on"
     response: "No, away"
+
+  - sentences:
+      - "is the phone gone?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "binary_sensor"
+        device_class: "presence"
+        name: "Phone"
+        state: "off"
+    response: "Yes"
 
   - sentences:
       - "are any devices home?"
@@ -1142,3 +1178,15 @@ tests:
         name: "Shed Window"
         state: "on"
     response: "Yes"
+
+  - sentences:
+      - "is the shed window shut?"
+      - "is the shed window closed?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "binary_sensor"
+        device_class: "window"
+        name: "Shed Window"
+        state: "off"
+    response: "No, open"

--- a/tests/en/cover_HassGetState.yaml
+++ b/tests/en/cover_HassGetState.yaml
@@ -3,6 +3,7 @@ tests:
   - sentences:
       - "is curtain left closed?"
       - "is the curtain left closed?"
+      - "is the curtain left shut?"
     intent:
       name: HassGetState
       slots:


### PR DESCRIPTION
Found a bunch of state expansions that have terms that are used interchangeably. Expanding them here to improve matching.

I'm working on another PR to expand test sentences and then work towards closing gaps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced input handling for device states, allowing synonyms and variations.
	- Expanded recognition for terms in `cover_states`, `lock_states`, and binary sensor states, including "closed" and "shut," as well as variations for "locked" and "unlocked."
	- Broadened input options for `bs_presence_states`, now accepting "away," "not present," or "gone."
	- Added new test cases for various binary sensors, improving the coverage of the `HassGetState` intent.
	- Introduced a new sentence variation for curtain state inquiries, enhancing natural language processing capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->