### PR TITLE
[EN] Add timer length and name to responses

### DIFF
--- a/responses/en/HassStartTimer.yaml
+++ b/responses/en/HassStartTimer.yaml
@@ -3,5 +3,24 @@ language: en
 responses:
   intents:
     HassStartTimer:
-      default: "Timer started"
-      command: "Command received"
+      default: >
+        {% set h = slots.hours if slots.hours is defined else none %}
+        {% set m = slots.minutes if slots.minutes is defined else none %}
+        {% set s = slots.seconds if slots.seconds is defined else none %}
+        {% set h_text = h ~ (' hour'  if h in [ "1", 'one'] else ' hours') if h else '' %}
+        {% set m_text = (30 if m in ['half', '1/2'] else m) ~ (' minute' if m in [ "1", 'one'] else ' minutes') if m else '' %}
+        {% set s_text = (30 if s in ['half', '1/2'] else s) ~ (' second' if s in [ "1", 'one'] else ' seconds') if s else '' %}
+        {% set text_list = [ h_text, m_text, s_text] | select() | list %}
+        {% set text = text_list[:-1] | join(', ') ~ ' and ' ~ text_list[-1] if text_list | count > 2 else text_list | join(' and ') %}
+        {% set name = (' named ' ~ slots.name | trim) if slots.name is defined else '' %}
+        Timer set for {{ text }}{{ name }}
+      command: >
+        {% set h = slots.hours if slots.hours is defined else none %}
+        {% set m = slots.minutes if slots.minutes is defined else none %}
+        {% set s = slots.seconds if slots.seconds is defined else none %}
+        {% set h_text = h ~ (' hour'  if h in [ "1", 'one'] else ' hours') if h else '' %}
+        {% set m_text = (30 if m in ['half', '1/2'] else m) ~ (' minute' if m in [ "1", 'one'] else ' minutes') if m else '' %}
+        {% set s_text = (30 if s in ['half', '1/2'] else s) ~ (' second' if s in [ "1", 'one'] else ' seconds') if s else '' %}
+        {% set text_list = [ h_text, m_text, s_text] | select() | list %}
+        {% set text = text_list[:-1] | join(', ') ~ ' and ' ~ text_list[-1] if text_list | count > 2 else text_list | join(' and ') %}
+        Command will be executed in {{ text }}

--- a/responses/nl/HassStartTimer.yaml
+++ b/responses/nl/HassStartTimer.yaml
@@ -3,4 +3,24 @@ language: nl
 responses:
   intents:
     HassStartTimer:
-      default: "Timer gestart"
+      default: >
+        {% set h = slots.hours if slots.hours is defined else none %}
+        {% set m = slots.minutes if slots.minutes is defined else none %}
+        {% set s = slots.seconds if slots.seconds is defined else none %}
+        {% set h_text = h ~ ' uur' if h else '' %}
+        {% set m_text = (30 if m in ['half', 'halve', '1/2', '1/2e'] else 90 if m in ['anderhalf', 'anderhalve'] else m) ~ (' minuut' if m in [ '1', 'een', 'één'] else ' minuten') if m else '' %}
+        {% set s_text = (30 if s in ['half', 'halve', '1/2', '1/2e'] else 90 if s in ['anderhalf', 'anderhalve'] else s) ~ (' seconde' if s in [ '1', 'een', 'één'] else ' seconden') if s else '' %}
+        {% set text_list = [ h_text, m_text, s_text] | select() | list %}
+        {% set text = text_list[:-1] | join(', ') ~ ' en ' ~ text_list[-1] if text_list | count > 2 else text_list | join(' en ') %}
+        {% set name = (' met de naam ' ~ slots.name | trim) if slots.name is defined else '' %}
+        Timer gezet voor {{ text }}{{ name }}
+      command: >
+        {% set h = slots.hours if slots.hours is defined else none %}
+        {% set m = slots.minutes if slots.minutes is defined else none %}
+        {% set s = slots.seconds if slots.seconds is defined else none %}
+        {% set h_text = h ~ ' uur' if h else '' %}
+        {% set m_text = (30 if m in ['half', 'halve', '1/2', '1/2e'] else 90 if m in ['anderhalf', 'anderhalve'] else m) ~ (' minuut' if m in [ '1', 'een', 'één'] else ' minuten') if m else '' %}
+        {% set s_text = (30 if s in ['half', 'halve', '1/2', '1/2e'] else 90 if s in ['anderhalf', 'anderhalve'] else s) ~ (' seconde' if s in [ '1', 'een', 'één'] else ' seconden') if s else '' %}
+        {% set text_list = [ h_text, m_text, s_text] | select() | list %}
+        {% set text = text_list[:-1] | join(', ') ~ ' en ' ~ text_list[-1] if text_list | count > 2 else text_list | join(' en ') %}
+        Opdracht wordt uitgevoerd over {{ text }}

--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -372,7 +372,25 @@ lists:
     range:
       from: 1
       to: 100
+  timer_half:
+    values:
+      - in: "half"
+        out: 30
+      - in: "halve"
+        out: 30
+      - in: "1/2"
+        out: 30
+      - in: "1/2e"
+        out: 30
+  timer_one_and_a_half:
+    values:
+      - in: "anderhalf"
+        out: 90
+      - in: "anderhalve"
+        out: 90
   timer_name:
+    wildcard: true
+  timer_command:
     wildcard: true
 
 expansion_rules:
@@ -455,10 +473,22 @@ expansion_rules:
   timer_set: "(start|zet|maak|creëer)"
   timer_cancel: "(annuleer|stop)"
   timer_duration_seconds: "{timer_seconds:seconds} seconde[s|n]"
-  timer_duration_minutes: "{timer_minutes:minutes} (minuut|minuten)[ [en ]{timer_seconds:seconds} seconde[s|n]]"
-  timer_duration_hours: "{timer_hours:hours} (uur|uren)[ [en ]{timer_minutes:minutes} (minuut|minuten)][ [en ]{timer_seconds:seconds} seconde[s|n]]"
+  timer_duration_minutes: >
+    (
+      {timer_minutes:minutes} (minuut[je[s]]|minuten) [[en] {timer_seconds:seconds} seconde[s|n]]
+      |{timer_minutes:minutes} [en] [een] {timer_half:seconds} minuut[je]
+      |{timer_half:seconds} minuut[je]
+      |{timer_one_and_a_half:seconds} minuut[je]
+    )
+  timer_duration_hours: >
+    (
+      {timer_hours:hours} (uur[tje]|uren|uurtjes)[ [en ]{timer_minutes:minutes} (minuut[je[s]]|minuten)][ [en ]{timer_seconds:seconds} seconde[s|n]]
+      |{timer_hours:hours} (uur[tje]|uren|uurtjes) en een {timer_half:seconds} minuut[je]
+      |{timer_hours:hours} [en] [een] {timer_half:minutes} uur[tje]
+      |{timer_half:minutes} uur[tje]
+      |{timer_one_and_a_half:minutes} uur[tje]
+    )
   timer_duration: "<timer_duration_seconds>|<timer_duration_minutes>|<timer_duration_hours>"
-
   timer_start_seconds: "{timer_seconds:start_seconds} seconde[s|n]"
   timer_start_minutes: "{timer_minutes:start_minutes} (minuut|minuten)[ [en ]{timer_seconds:start_seconds} seconde[n|s]]"
   timer_start_hours: "{timer_hours:start_hours} (uur|uren)[ [en ]{timer_minutes:start_minutes} (minuut|minuten)][ [en ]{timer_seconds:start_seconds} seconde[s|n]]"

--- a/sentences/nl/homeassistant_HassStartTimer.yaml
+++ b/sentences/nl/homeassistant_HassStartTimer.yaml
@@ -5,11 +5,15 @@ intents:
     data:
       - sentences:
           - "<timer_duration> timer"
-          - "timer (van|voor) <timer_duration>"
-          - "<timer_duration> timer (van|voor) {timer_name:name}"
+          - "timer (van|voor|op) <timer_duration>"
+          - "<timer_duration> timer (van|voor|op) {timer_name:name}"
           - "timer (van|voor) <timer_duration> (genaamd|met de naam|voor)  {timer_name:name}"
-          - "<timer_set>[ een] <timer_duration> timer"
-          - "<timer_set>[ een] timer (van|voor) <timer_duration>"
-          - "<timer_set>[ een] <timer_duration> timer (genaamd|met de naam|voor) {timer_name:name}"
-          - "<timer_set>[ een] timer (genaamd|met de naam|voor) {timer_name:name} (van|voor) <timer_duration>"
-          - "<timer_set>[ een] timer (van|voor) <timer_duration> (genaamd|met de naam|voor) {timer_name:name}"
+          - "<timer_set> [een] <timer_duration> timer"
+          - "<timer_set> [een] timer (van|voor|op) <timer_duration>"
+          - "<timer_set> [een] <timer_duration> timer (genaamd|met de naam|voor) {timer_name:name}"
+          - "<timer_set> [een] timer (genaamd|met de naam|voor) {timer_name:name} (van|voor|op) <timer_duration>"
+          - "<timer_set> [een] timer (van|voor|op) <timer_duration> (genaamd|met de naam|voor) {timer_name:name}"
+      - sentences:
+          - "{timer_command:conversation_command} over <timer_duration>"
+          - "over <timer_duration> {timer_command:conversation_command}"
+        response: command

--- a/tests/en/homeassistant_HassStartTimer.yaml
+++ b/tests/en/homeassistant_HassStartTimer.yaml
@@ -7,7 +7,7 @@ tests:
       name: HassStartTimer
       slots:
         minutes: 10
-    response: Timer started
+    response: Timer set for 10 minutes
 
   - sentences:
       - "start a 1 hour timer"
@@ -21,7 +21,7 @@ tests:
         area: Living Room
       slots:
         hours: 1
-    response: Timer started
+    response: Timer set for 1 hour
 
   - sentences:
       - "set a timer for 5 and a half minutes"
@@ -32,7 +32,7 @@ tests:
       slots:
         minutes: 5
         seconds: 30
-    response: Timer started
+    response: Timer set for 5 minutes and 30 seconds
 
   - sentences:
       - "set a timer for half a minute"
@@ -43,7 +43,7 @@ tests:
         area: Living Room
       slots:
         seconds: 30
-    response: Timer started
+    response: Timer set for 30 seconds
 
   - sentences:
       - "set a timer for 1 and a half hours"
@@ -55,7 +55,7 @@ tests:
       slots:
         hours: 1
         minutes: 30
-    response: Timer started
+    response: Timer set for 1 hour and 30 minutes
 
   - sentences:
       - "set a timer for half an hour"
@@ -66,7 +66,7 @@ tests:
         area: Living Room
       slots:
         minutes: 30
-    response: Timer started
+    response: Timer set for 30 minutes
 
   - sentences:
       - "start a 1 hour and 15 minute timer"
@@ -79,7 +79,7 @@ tests:
       slots:
         hours: 1
         minutes: 15
-    response: Timer started
+    response: Timer set for 1 hour and 15 minutes
 
   - sentences:
       - "start a 1 hour and 30 second timer"
@@ -92,7 +92,7 @@ tests:
       slots:
         hours: 1
         seconds: 30
-    response: Timer started
+    response: Timer set for 1 hour and 30 seconds
 
   - sentences:
       - "start a 1 hour 15 minute and 30 second timer"
@@ -106,7 +106,7 @@ tests:
         hours: 1
         minutes: 15
         seconds: 30
-    response: Timer started
+    response: Timer set for 1 hour, 15 minutes and 30 seconds
 
   - sentences:
       - "start a 5 minute timer"
@@ -118,7 +118,7 @@ tests:
         area: Living Room
       slots:
         minutes: 5
-    response: Timer started
+    response: Timer set for 5 minutes
 
   - sentences:
       - "start a 5 minute timer named pizza"
@@ -134,7 +134,7 @@ tests:
         name:
           - "pizza "
           - "pizza"
-    response: Timer started
+    response: Timer set for 5 minutes named pizza
 
   - sentences:
       - "start a 5 minute and 10 second timer"
@@ -147,7 +147,7 @@ tests:
       slots:
         minutes: 5
         seconds: 10
-    response: Timer started
+    response: Timer set for 5 minutes and 10 seconds
 
   - sentences:
       - "start a 45 second timer"
@@ -159,7 +159,7 @@ tests:
         area: Living Room
       slots:
         seconds: 45
-    response: Timer started
+    response: Timer set for 45 seconds
 
   - sentences:
       - "open the garage door in 5 minutes"
@@ -171,4 +171,4 @@ tests:
         conversation_command:
           - "open the garage door"
           - "open the garage door "
-    response: Command received
+    response: Command will be executed in 5 minutes

--- a/tests/nl/homeassistant_HassStartTimer.yaml
+++ b/tests/nl/homeassistant_HassStartTimer.yaml
@@ -13,11 +13,12 @@ tests:
         area: Woonkamer
       slots:
         hours: 1
-    response: Timer gestart
+    response: Timer gezet voor 1 uur
 
   - sentences:
       - "start een 1 uur en 15 minuten timer"
       - "timer van 1 uur en 15 minuten"
+      - "zet timer voor 1 uurtje en 15 minuten"
       - "zet timer voor 1 uur en 15 minuten"
     intent:
       name: HassStartTimer
@@ -26,7 +27,7 @@ tests:
       slots:
         hours: 1
         minutes: 15
-    response: Timer gestart
+    response: Timer gezet voor 1 uur en 15 minuten
 
   - sentences:
       - "start een 1 uur en 30 seconde timer"
@@ -39,7 +40,7 @@ tests:
       slots:
         hours: 1
         seconds: 30
-    response: Timer gestart
+    response: Timer gezet voor 1 uur en 30 seconden
 
   - sentences:
       - "start een 1 uur 15 minuten en 30 seconden timer"
@@ -53,7 +54,7 @@ tests:
         hours: 1
         minutes: 15
         seconds: 30
-    response: Timer gestart
+    response: Timer gezet voor 1 uur, 15 minuten en 30 seconden
 
   - sentences:
       - "start een 5 minuten timer"
@@ -65,7 +66,7 @@ tests:
         area: Woonkamer
       slots:
         minutes: 5
-    response: Timer gestart
+    response: Timer gezet voor 5 minuten
 
   - sentences:
       - "start een 5 minuten timer genaamd pizza"
@@ -81,11 +82,11 @@ tests:
         name:
           - "pizza "
           - "pizza"
-    response: Timer gestart
+    response: Timer gezet voor 5 minuten met de naam pizza
 
   - sentences:
       - "start een 5 minuten en 10 seconde timer"
-      - "timer voor 5 minuten en 10 seconden"
+      - "timer op 5 minuten en 10 seconden"
       - "5 minuten 10 secondes timer"
     intent:
       name: HassStartTimer
@@ -94,7 +95,7 @@ tests:
       slots:
         minutes: 5
         seconds: 10
-    response: Timer gestart
+    response: Timer gezet voor 5 minuten en 10 seconden
 
   - sentences:
       - "start een 45 seconde timer"
@@ -106,4 +107,53 @@ tests:
         area: Woonkamer
       slots:
         seconds: 45
-    response: Timer gestart
+    response: Timer gezet voor 45 seconden
+
+  - sentences:
+      - "timer voor 5 en een half uur"
+      - "timer voor 5 en 1/2 uurtje"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Woonkamer
+      slots:
+        hours: 5
+        minutes: 30
+    response: Timer gezet voor 5 uur en 30 minuten
+
+  - sentences:
+      - "timer voor 5 uur en een halve minuut"
+      - "timer voor 5 uur en een 1/2e minuut"
+      - "timer voor 5 uur en een half minuutje"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Woonkamer
+      slots:
+        hours: 5
+        seconds: 30
+    response: Timer gezet voor 5 uur en 30 seconden
+
+  - sentences:
+      - "timer voor anderhalf minuutje"
+      - "timer op anderhalf minuutje"
+      - "timer van anderhalve minuut"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Woonkamer
+      slots:
+        seconds: 90
+    response: Timer gezet voor 90 seconden
+
+  - sentences:
+      - "open de garagedeur over 5 minuten"
+      - "over 5 minuten open de garagedeur"
+    intent:
+      name: HassStartTimer
+      slots:
+        minutes: 5
+        conversation_command:
+          - "open de garagedeur"
+          - "open de garagedeur "
+    response: Opdracht wordt uitgevoerd over 5 minuten


### PR DESCRIPTION
As Missy mentioned on GitHub, currently the timer length is not included in the response. This can lead incorrectly set timers of which the user will be unware.

This PR adds the timer length and timer name to the response, so the user is aware of what has been set. The set name can be used to ask about the status of the timer.