### PR TITLE
[FR] A few missing simple intents

### DIFF
--- a/responses/fr/HassMediaPrevious.yaml
+++ b/responses/fr/HassMediaPrevious.yaml
@@ -1,0 +1,5 @@
+language: fr
+responses:
+  intents:
+    HassMediaPrevious:
+      default: "Média précédent"

--- a/responses/fr/HassRespond.yaml
+++ b/responses/fr/HassRespond.yaml
@@ -1,0 +1,6 @@
+language: fr
+responses:
+  intents:
+    HassRespond:
+      hello: "Bonjour depuis Home Assistant."
+      creator: "J'ai été créé par Home Assistant et sa communauté mondiale de passionnés de domotique."

--- a/sentences/fr/homeassistant_HassNevermind.yaml
+++ b/sentences/fr/homeassistant_HassNevermind.yaml
@@ -4,4 +4,9 @@ intents:
     data:
       - sentences:
           - "oublie[s]"
-          - "Annule[r]"
+          - "annule[r]"
+          - "[non] rien [du tout]"
+          - "chut"
+          - "tais toi"
+          - "tais-toi"
+          - "silence"

--- a/sentences/fr/homeassistant_HassRespond.yaml
+++ b/sentences/fr/homeassistant_HassRespond.yaml
@@ -1,0 +1,17 @@
+language: "fr"
+intents:
+  HassRespond:
+    data:
+      - sentences:
+          - "<bonjour>"
+        expansion_rules:
+          bonjour: "Salut|Bonjour|Bonsoir|Coucou"
+        response: hello
+
+      - sentences:
+          - "Qui t'a <invente>"
+          - "Qui est ton <inventeur>"
+        expansion_rules:
+          invente: (inventé[e])|(créé[e])|(développé(e))|(conçu[e])|(programmé[e])
+          inventeur: inventeur|créateur|developpeur|concepteur|programmeur
+        response: creator

--- a/sentences/fr/homeassistant_HassTimerStatus.yaml
+++ b/sentences/fr/homeassistant_HassTimerStatus.yaml
@@ -6,49 +6,56 @@ intents:
       # No name
       - sentences:
           # Combien de temps reste-t-il
-          - "Combien de temps reste-t-il"
+          - "Combien de temps <reste_t_il>"
           # Combien de temps reste-t-il au minuteur
-          - "Combien de temps reste-t-il au <minuteur>"
+          - "Combien de temps <reste_t_il> au <minuteur>"
           # Combien de temps reste-t-il sur le minuteur
-          - "Combien de temps reste-t-il (sur|dans) [(le|mon)] <minuteur>"
+          - "Combien de temps <reste_t_il> (sur|dans) [(le|mon)] <minuteur>"
           # Il reste combien de temps
           - "Il reste combien [de temps]"
           # Il reste combien de temps au minuteur
           - "Il reste combien [de temps] au <minuteur>"
           # Il reste combien de temps sur le minuteur
           - "Il reste combien [de temps] (sur|dans) [(le|mon)] <minuteur>"
+        expansion_rules:
+          reste_t_il: "(reste-t-il)|(reste t il)"
 
       # area
       - sentences:
           # Combien de temps reste-t-il au minuteur de la cuisine
-          - "Combien de temps reste-t-il au <minuteur> [<de>] [<le>]{area}"
+          - "Combien de temps <reste_t_il> au <minuteur> [<de>] [<le>]{area}"
           # Combien de temps reste-t-il sur le minuteur de la cuisine
-          - "Combien de temps reste-t-il (sur|dans) [(le|mon)] <minuteur> [<de>] [<le>]{area}"
+          - "Combien de temps <reste_t_il> (sur|dans) [(le|mon)] <minuteur> [<de>] [<le>]{area}"
           # Il reste combien de temps au minuteur de la cuisine
           - "Il reste combien [de temps] au <minuteur> [<de>] [<le>]{area}"
           # Il reste combien de temps sur le minuteur de la cuisine
           - "Il reste combien [de temps] (sur|dans) [(le|mon)] <minuteur> [<de>] [<le>]{area}"
+        expansion_rules:
+          reste_t_il: "(reste-t-il)|(reste t il)"
 
       # duration
       - sentences:
           # Combien de temps reste-t-il au minuteur de 2 minutes
-          - "Combien de temps reste-t-il au <minuteur> [de] <timer_start>"
+          - "Combien de temps <reste_t_il> au <minuteur> [de] <timer_start>"
           # Combien de temps reste-t-il sur le minuteur de 2 minutes
-          - "Combien de temps reste-t-il (sur|dans) [(le|mon)] <minuteur> [de] <timer_start>"
+          - "Combien de temps <reste_t_il> (sur|dans) [(le|mon)] <minuteur> [de] <timer_start>"
           # Il reste combien de temps au minuteur de 2 minutes
           - "Il reste combien [de temps] au <minuteur> [de] <timer_start>"
           # Il reste combien de temps sur le minuteur de 2 minutes
           - "Il reste combien [de temps] (sur|dans) [(le|mon)] <minuteur> [de] <timer_start>"
+        expansion_rules:
+          reste_t_il: "(reste-t-il)|(reste t il)"
 
       # name
       - sentences:
           # Combien de temps reste-t-il au minuteur appelé Pizza
-          - "Combien de temps reste-t-il au <minuteur> [<appele>] {timer_name:name}"
+          - "Combien de temps <reste_t_il> au <minuteur> [<appele>] {timer_name:name}"
           # Combien de temps reste-t-il sur le minuteur appelé Pizza
-          - "Combien de temps reste-t-il (sur|dans) [(le|mon)] <minuteur> [<appele>] {timer_name:name}"
+          - "Combien de temps <reste_t_il> (sur|dans) [(le|mon)] <minuteur> [<appele>] {timer_name:name}"
           # Il reste combien de temps au minuteur appelé Pizza
           - "Il reste combien [de temps] au <minuteur> [<appele>] {timer_name:name}"
           # Il reste combien de temps sur le minuteur appelé Pizza
           - "Il reste combien [de temps] (sur|dans) [(le|mon)] <minuteur> [<appele>] {timer_name:name}"
         expansion_rules:
+          reste_t_il: "(reste-t-il)|(reste t il)"
           appele: "(appelé|nommé|surnomé)"

--- a/sentences/fr/media_player_HassMediaPrevious.yaml
+++ b/sentences/fr/media_player_HassMediaPrevious.yaml
@@ -1,0 +1,33 @@
+language: fr
+intents:
+  HassMediaPrevious:
+    data:
+      # name
+      - sentences:
+          # Chanson précédente sur la TV
+          - "<media> précédent[e] sur [<le>]{name}"
+          # Passe au morceau précédent sur la TV
+          - "<mets> (<le>|au |à la )<media> précédent[e] [sur] [<le>]{name}"
+        requires_context:
+          domain: media_player
+
+      # Area (Context awarenes)
+      - sentences:
+          # Précédent
+          - "précédent[e]"
+          # Chansion précédente
+          - "<media> précédent[e]"
+          # Mets l'épisode précédent
+          - "<mets> (<le>|au |à la )<media> précédent[e]"
+        requires_context:
+          area:
+            slot: true
+
+      # Area
+      - sentences:
+          # Précédent dans le salon
+          - "précédent[e] <dans> [<le>]{area}"
+          # Chansion précédente dans le salon
+          - "<media> précédent[e] <dans> [<le>]{area}"
+          # Mets l'episode précédent dans le bureau
+          - "<mets> (<le>|au |à la )<media> précédent[e] <dans> [<le>]{area}"

--- a/tests/fr/homeassistant_HassNevermind.yaml
+++ b/tests/fr/homeassistant_HassNevermind.yaml
@@ -3,6 +3,11 @@ tests:
   - sentences:
       - "oublie"
       - "annule"
+      - "non rien"
+      - "tais-toi"
+      - "tais toi"
+      - "chut"
+      - "silence"
     intent:
       name: HassNevermind
     response: ""

--- a/tests/fr/homeassistant_HassRespond.yaml
+++ b/tests/fr/homeassistant_HassRespond.yaml
@@ -1,0 +1,18 @@
+language: fr
+tests:
+  - sentences:
+      - Bonjour
+      - Salut
+      - Coucou
+    intent:
+      name: HassRespond
+    response: "Bonjour depuis Home Assistant."
+
+  - sentences:
+      - Qui est ton créateur
+      - Qui t'a conçue
+      - Qui t'a inventé
+      - Qui est ton concepteur
+    intent:
+      name: HassRespond
+    response: "J'ai été créé par Home Assistant et sa communauté mondiale de passionnés de domotique."

--- a/tests/fr/media_player_HassMediaPrevious.yaml
+++ b/tests/fr/media_player_HassMediaPrevious.yaml
@@ -1,0 +1,34 @@
+language: fr
+tests:
+  - sentences:
+      - "Morceau précédent sur TV"
+      - "Chanson précédente sur la TV"
+      - "Passe au morceau précédent sur la TV"
+      - "Mettre le film précédent sur la TV"
+    intent:
+      name: HassMediaPrevious
+      slots:
+        name: "TV"
+    response: "Média précédent"
+
+  - sentences:
+      - "Précédent"
+      - "Chanson précédente"
+      - "Mets l'épisode précédent"
+    intent:
+      name: HassMediaPrevious
+      context:
+        area: salon
+      slots:
+        area: salon
+    response: "Média précédent"
+
+  - sentences:
+      - "Précédent dans le garage"
+      - "Chanson précédente dans le garage"
+      - "Mets l'épisode précédent dans le garage"
+    intent:
+      name: HassMediaPrevious
+      slots:
+        area: garage
+    response: "Média précédent"


### PR DESCRIPTION
## Respond
Added the HAssRespond intent.
For now, I decided only to translate two use-case
- Hello
- Who made you

I do not think [the other use-cases](https://github.com/home-assistant/intents/blob/main/sentences/en/homeassistant_HassRespond.yaml) are worth translating as of today.

## Previous
Added the MediaPrevious intent.
A copy of the MediaNext intent

## Nevermind
Added lots of variation for the Nevermind intent

## Timer bug
Last release I added a few sentences using the `reste-t-il` syntax.
It turns out HA Cloud STT sometimes yields `reste t il` without the dashes
![image](https://github.com/user-attachments/assets/687c87cd-e72b-4712-b2fe-0d4757a05842)

I decided to use a local expansion rule for that. 
It adds a bit of duplication but it's pretty much local to a single intent