### PR TITLE
Website: list per language the missing intents

### DIFF
--- a/script/intentfest/website_summary.py
+++ b/script/intentfest/website_summary.py
@@ -55,7 +55,9 @@ def run() -> int:
             for translation in merged_sentences["responses"]["errors"].values()
         )
 
-        missing_intents = [intent for intent in IMPORTANT_INTENTS if not intent_sentence_count[intent]]
+        missing_intents = [
+            intent for intent in IMPORTANT_INTENTS if not intent_sentence_count[intent]
+        ]
 
         usable = not missing_intents and errors_translated
 
@@ -73,19 +75,18 @@ def run() -> int:
         }
 
         language_summaries[language] = {
-                "language": language,
-                "native_name": language_info[language]["nativeName"],
-                "leaders": language_info[language].get("leaders"),
-                "intents": intent_sentence_count,
-                "used_responses": used_responses_count,
-                "responses": response_sentence_count,
-                "intent_responses_translated": intent_responses_translated,
-                "errors_translated": errors_translated,
-                "usable": usable,
-                "complete": complete,
-                "missing_intents": missing_intents,
-            }
-
+            "language": language,
+            "native_name": language_info[language]["nativeName"],
+            "leaders": language_info[language].get("leaders"),
+            "intents": intent_sentence_count,
+            "used_responses": used_responses_count,
+            "responses": response_sentence_count,
+            "intent_responses_translated": intent_responses_translated,
+            "errors_translated": errors_translated,
+            "usable": usable,
+            "complete": complete,
+            "missing_intents": missing_intents,
+        }
 
     intents = {}
     for intent, info in intent_info.items():
@@ -94,17 +95,19 @@ def run() -> int:
             "important": intent in IMPORTANT_INTENTS,
         }
 
-
     print(
         json.dumps(
             {
                 "intents": intents,
                 "languages": language_summaries,
                 "improvements": [
-                    info['language']
-                    for info in sorted(language_summaries.values(), key=lambda x: (len(x['missing_intents']), x['language']))
-                    if info['missing_intents']
-                ]
+                    info["language"]
+                    for info in sorted(
+                        language_summaries.values(),
+                        key=lambda x: (len(x["missing_intents"]), x["language"]),
+                    )
+                    if info["missing_intents"]
+                ],
             },
             indent=2,
         )

--- a/website/src-11ty/index.html
+++ b/website/src-11ty/index.html
@@ -30,7 +30,7 @@ Cell format:
   <thead>
     <tr>
       <th>Language</th>
-      {% for intent in intentSummary.languages[0].intents %}
+      {% for intent in intentSummary.languages.en.intents %}
       <th>{{intent[0] | remove_first: "Hass"}}</th>
       {% endfor %}
       <th>Errors translated</th>
@@ -38,7 +38,8 @@ Cell format:
     </tr>
   </thead>
   <tbody>
-    {% for summary in intentSummary.languages %}
+    {% for item in intentSummary.languages %}
+    {% assign summary = item[1] %}
     <tr class="{% if summary.usable %}usable{% endif %}">
       <td>
         <a
@@ -98,3 +99,23 @@ Cell format:
   </tbody>
 </table>
 <p><i>Every cell in the table links to the relevant file.</i></p>
+<h2>Road to Team 💚</h2>
+List of languages that are missing important intent coverage.
+<table>
+  <tr>
+    <th>Language</th>
+    <th>Missing</th>
+    <th>Intents</th>
+  </tr>
+  {% for language in intentSummary.improvements %}
+  <tr>
+    <td>{{ language }}</td>
+    <td>{{ intentSummary.languages[language].missing_intents | size }}</td>
+    <td style="text-align: left; padding-left: 16px;">
+      {% for intent in intentSummary.languages[language].missing_intents %}
+        {{ intent }}{% if forloop.last == false %}, {% endif %}
+      {% endfor %}
+    </td>
+  </tr>
+  {% endfor %}
+</table>


### PR DESCRIPTION
Add a new table at the bottom of the intents dashboard that lists per language which intents are missing. The list is sorted by languages that are missing the least amount of intents.

<img width="1343" alt="image" src="https://github.com/user-attachments/assets/765ea320-01d9-4bbd-b80d-3380bffd1085">
