### PR TITLE
Website: move empty languages to own table

### DIFF
--- a/script/intentfest/website_summary.py
+++ b/script/intentfest/website_summary.py
@@ -12,6 +12,7 @@ from .util import load_merged_responses, load_merged_sentences
 
 def run() -> int:
     language_summaries = {}
+    empty_languages = []
 
     language_info = yaml.safe_load(LANGUAGES_FILE.read_text())
 
@@ -54,6 +55,18 @@ def run() -> int:
             translation.startswith("TODO ")
             for translation in merged_sentences["responses"]["errors"].values()
         )
+
+        completely_empty = sum(intent_sentence_count.values()) == 0
+
+        if completely_empty:
+            empty_languages.append(
+                {
+                    "language": language,
+                    "native_name": language_info[language]["nativeName"],
+                    "leaders": language_info[language].get("leaders"),
+                }
+            )
+            continue
 
         missing_intents = [
             intent for intent in IMPORTANT_INTENTS if not intent_sentence_count[intent]
@@ -108,6 +121,7 @@ def run() -> int:
                     )
                     if info["missing_intents"]
                 ],
+                "empty_languages": empty_languages,
             },
             indent=2,
         )

--- a/website/src-11ty/index.html
+++ b/website/src-11ty/index.html
@@ -99,14 +99,17 @@ Cell format:
   </tbody>
 </table>
 <p><i>Every cell in the table links to the relevant file.</i></p>
+
 <h2>Road to Team 💚</h2>
 List of languages that are missing important intent coverage.
 <table>
-  <tr>
-    <th>Language</th>
-    <th>Missing</th>
-    <th>Intents</th>
-  </tr>
+  <thead>
+    <tr>
+      <th>Language</th>
+      <th>Missing</th>
+      <th>Intents</th>
+    </tr>
+  </thead>
   {% for language in intentSummary.improvements %}
   <tr>
     <td>{{ language }}</td>
@@ -115,6 +118,44 @@ List of languages that are missing important intent coverage.
       {% for intent in intentSummary.languages[language].missing_intents %}
         {{ intent }}{% if forloop.last == false %}, {% endif %}
       {% endfor %}
+    </td>
+  </tr>
+  {% endfor %}
+</table>
+
+<h2>Empty language files</h2>
+<table>
+  <thead>
+    <tr>
+      <th>Language</th>
+      <th>Leader</th>
+    </tr>
+  </thead>
+  {% for summary in intentSummary.empty_languages %}
+  <tr>
+    <td>
+      <a
+        href="https://github.com/home-assistant/intents/blob/main/sentences/{{ summary.language }}/"
+        target="_blank"
+      >
+        <code>{{summary.language}}</code> {{summary.native_name}}
+      </a>
+    </td>
+    <td
+      class="{% if summary.leaders and (summary.leaders | len) > 1 %}multiple{% endif %}"
+    >
+      {% if summary.leaders %} {% for leader in summary.leaders %}
+      <a href="https://github.com/{{ leader }}" target="_blank">
+        @{{ leader }}
+      </a>
+      {% endfor %} {% else %}
+      <a
+        href="https://developers.home-assistant.io/docs/voice/language-leaders/"
+        target="_blank"
+      >
+        &lt;position open&gt;
+      </a>
+      {% endif %}
     </td>
   </tr>
   {% endfor %}


### PR DESCRIPTION
Move empty languages out of the intent dashboard and into own table.

<img width="275" alt="image" src="https://github.com/user-attachments/assets/428fd3d8-e14b-47a4-8947-4e92ab891abb">
