### PR TITLE
Add vacuum variant to match without vacuum name

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -315,6 +315,7 @@ HassVacuumStart:
       description: "Name of an area"
       required: false
   slot_combinations:
+    none: []
     name_only:
       - "name"
     area_only:
@@ -335,6 +336,7 @@ HassVacuumReturnToBase:
       description: "Name of an area"
       required: false
   slot_combinations:
+    none: []
     name_only:
       - "name"
     area_only:

--- a/sentences/ca/vacuum_HassVacuumReturnToBase.yaml
+++ b/sentences/ca/vacuum_HassVacuumReturnToBase.yaml
@@ -13,5 +13,3 @@ intents:
           - "[re]torn(a|i) [<pronom_singular>]aspirador[a] [a [la] (base|casa)]"
           - "fes que [<pronom_singular>]aspirador[a] ([re]torni|vagi) [a [la] (base|casa)]"
           - "recull [<pronom_singular>]aspirador[a]"
-        requires_context:
-          domain: vacuum

--- a/sentences/ca/vacuum_HassVacuumReturnToBase.yaml
+++ b/sentences/ca/vacuum_HassVacuumReturnToBase.yaml
@@ -5,5 +5,13 @@ intents:
       - sentences:
           - "(torn(a|i)) <name> [a [la] (base|casa)]"
           - "fes que <name> ([re]torni|vagi) [a [la] (base|casa)]"
+          - "recull <name>"
+        requires_context:
+          domain: vacuum
+
+      - sentences:
+          - "[re]torn(a|i) [<pronom_singular>]aspirador[a] [a [la] (base|casa)]"
+          - "fes que [<pronom_singular>]aspirador[a] ([re]torni|vagi) [a [la] (base|casa)]"
+          - "recull [<pronom_singular>]aspirador[a]"
         requires_context:
           domain: vacuum

--- a/sentences/ca/vacuum_HassVacuumStart.yaml
+++ b/sentences/ca/vacuum_HassVacuumStart.yaml
@@ -7,3 +7,11 @@ intents:
           - (arrenca|pasa)[r] <name> [en marxa]
         requires_context:
           domain: vacuum
+      - sentences:
+          - <engega> [<pronom_singular>]aspirador[a] [en marxa]
+          - (arrenca|pasa)[r] [<pronom_singular>]aspirador[a]
+      - sentences:
+          - <engega> [<pronom_singular>]aspirador[a] [en marxa] <area>
+          - (arrenca|pasa)[r] [<pronom_singular>]aspirador[a] <area>
+        requires_context:
+          domain: vacuum

--- a/sentences/en/vacuum_HassVacuumReturnToBase.yaml
+++ b/sentences/en/vacuum_HassVacuumReturnToBase.yaml
@@ -6,3 +6,6 @@ intents:
           - "return <name> [to base]"
         requires_context:
           domain: vacuum
+
+      - sentences:
+          - "return vacuum [to base]"

--- a/sentences/en/vacuum_HassVacuumStart.yaml
+++ b/sentences/en/vacuum_HassVacuumStart.yaml
@@ -6,3 +6,6 @@ intents:
           - "start <name>"
         requires_context:
           domain: vacuum
+
+      - sentences:
+          - start vacuum

--- a/tests/ca/_fixtures.yaml
+++ b/tests/ca/_fixtures.yaml
@@ -71,8 +71,8 @@ entities:
     id: media_player.radiocasset
     state: idle
 
-  - name: Aspiradora
-    id: vacuum.aspiradora
+  - name: Roomba
+    id: vacuum.roomba
     state: idle
 
   - name: Barcelona

--- a/tests/ca/vacuum_HassVacuumReturnToBase.yaml
+++ b/tests/ca/vacuum_HassVacuumReturnToBase.yaml
@@ -10,3 +10,12 @@ tests:
       slots:
         name: Roomba
     response: Tornant a la base
+
+  - sentences:
+      - torna l'aspiradora
+      - fes que l'aspiradora torni a la base
+      - fes que la aspiradora torni
+      - recull l'aspiradora
+    intent:
+      name: HassVacuumReturnToBase
+    response: Tornant a la base

--- a/tests/ca/vacuum_HassVacuumReturnToBase.yaml
+++ b/tests/ca/vacuum_HassVacuumReturnToBase.yaml
@@ -1,11 +1,12 @@
 language: ca
 tests:
   - sentences:
-      - torna l'aspiradora a base
-      - fes que l'aspiradora torni a la base
-      - fes que l'aspiradora torni
+      - torna la Roomba a base
+      - fes que la Roomba torni a la base
+      - fes que la Roomba torni
+      - recull la Roomba
     intent:
       name: HassVacuumReturnToBase
       slots:
-        name: Aspiradora
+        name: Roomba
     response: Tornant a la base

--- a/tests/ca/vacuum_HassVacuumStart.yaml
+++ b/tests/ca/vacuum_HassVacuumStart.yaml
@@ -1,12 +1,20 @@
 language: ca
 tests:
   - sentences:
+      - engega la Roomba
+      - arrenca la Roomba
+      - pasa la Roomba
+    intent:
+      name: HassVacuumStart
+      slots:
+        name: Roomba
+    response: Comença la neteja
+
+  - sentences:
       - engega la aspiradora
       - engega l'aspiradora
       - arrenca l'aspiradora
       - pasa l'aspiradora
     intent:
       name: HassVacuumStart
-      slots:
-        name: Aspiradora
     response: Comença la neteja

--- a/tests/en/vacuum_HassVacuumReturnToBase.yaml
+++ b/tests/en/vacuum_HassVacuumReturnToBase.yaml
@@ -7,3 +7,9 @@ tests:
       slots:
         name: "Rover"
     response: "Returning"
+
+  - sentences:
+      - "return vacuum to base"
+    intent:
+      name: HassVacuumReturnToBase
+    response: "Returning"

--- a/tests/en/vacuum_HassVacuumStart.yaml
+++ b/tests/en/vacuum_HassVacuumStart.yaml
@@ -7,3 +7,8 @@ tests:
       slots:
         name: "Rover"
     response: "Started"
+  - sentences:
+      - "start vacuum"
+    intent:
+      name: HassVacuumStart
+    response: "Started"


### PR DESCRIPTION
❗ NOTE: This adds a new `slot_combination` to `Vacuum` in `intents.yaml`, in order to skip specifying a name.

As the **vacuum** may have a different name than "vacuum", users will not trigger it by the entity name, but rather as "vacuum". This either forces the user to set an **alias** to the vacuum (named `vacuum`) to start it, or specify the full name for it.