### PR TITLE
Bump to hassil 2.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hassil==2.0.1
+hassil==2.0.2
 PyYAML==6.0.2
 voluptuous==0.15.2
 regex==2024.11.6


### PR DESCRIPTION
Includes some important bugfixes for `unicode-rbnf` (a dependency)