### PR TITLE
[NL] Review HassGetState

### DIFF
--- a/sentences/nl/homeassistant_HassGetState.yaml
+++ b/sentences/nl/homeassistant_HassGetState.yaml
@@ -3,30 +3,39 @@ intents:
   HassGetState:
     data:
       - sentences:
-          - Wat is [[<in>] <area>] [[de] [huidige] <state> [van]] [<area>][ ]<name>[ ][<type>][ ][<state>] [[<in>] <area>]
-          - "[[<in>] <area>] [de] [huidige] <state> [van] [<area>][ ]<name>[ ][<type>] [[<in>] <area>]"
-          - "[[<in>] <area>][ ]<name>[ ][<type>][ ]<state> [[<in>] <area>]"
+          - Wat is [[de] [huidige] <state> [van]] [<area>[ ]]<name>[ ][<type>][ ][<state>]
+          - Wat is ([<in>] <area>;[[de] [huidige] <state> [van]] <name>[ ][<type>][ ][<state>])
+          - "[de] [huidige] <state> [van] [<area>][ ]<name>[ ][<type>]"
+          - "([<in>] <area>;[de] [huidige] <state> [van] <name>[ ][<type>])"
+          - "[<area>[ ]]<name>[ ][<type>][ ]<state>"
+          - "([<in>] <area>;<name>[ ][<type>][ ]<state>)"
         response: one
 
       - sentences:
-          - <is> [[<in>] <area>] [[de] [huidige] <state> [van]] <name>[ ][<type>][ ][<state>] [[<in>] <area>] [op] {on_off_states:state} [[<in>] <area>]
+          - <is> [[de] [huidige] <state> [van]] <name>[ ][<type>][ ][<state>] [op] {on_off_states:state} [[<in>] <area>]
+          - <is> ([<in>] <area>;[[de] [huidige] <state> [van]] <name>[ ][<type>][ ][<state>]) [op] {on_off_states:state} [[<in>] <area>]
         response: one_yesno
         excludes_context:
           domain:
             - cover
 
       - sentences:
-          - <is> er [[<in>] <area>] {on_off_domains:domain} [[<in>] <area>] {on_off_states:state} [[<in>] <area>]
+          - <is> er {on_off_domains:domain} {on_off_states:state} [[<in>] <area>]
+          - <is> er ({on_off_domains:domain};[<in>] <area>) {on_off_states:state}
         response: any
 
       - sentences:
-          - <is> [[<in>] <area>] [<all>] [de] {on_off_domains:domain} [[<in>] <area>] {on_off_states:state} [[<in>] <area>]
+          - <is> [<all>] [de] {on_off_domains:domain} {on_off_states:state}
+          - <is> [<all>] [de] {on_off_domains:domain} ([<in>] <area>;{on_off_states:state})
+          - <is> ([<in>] <area>;[<all>] [de] {on_off_domains:domain}) {on_off_states:state}
         response: all
 
       - sentences:
-          - Welk[e] {on_off_domains:domain} [[<in>] <area>] <is> [[<in>] <area>] {on_off_states:state} [[<in>] <area>]
+          - Welk[e] {on_off_domains:domain} <is> [[<in>] <area>] {on_off_states:state}
+          - Welk[e] {on_off_domains:domain} ([<in>] <area>;<is> {on_off_states:state})
         response: which
 
       - sentences:
-          - Hoe[ ]veel {on_off_domains:domain} <is> [er] [[<in>] <area>] {on_off_states:state} [[<in>] <area>]
+          - Hoe[ ]veel {on_off_domains:domain} <is> [er] {on_off_states:state}
+          - Hoe[ ]veel {on_off_domains:domain} <is> [er] ([<in>] <area>;{on_off_states:state})
         response: how_many


### PR DESCRIPTION
Split sentences which were using the same optional part (e.g. `<area>`) multiple times.