### PR TITLE
[NL] Remove accidentally added double `[` and `]` from PersonGetState

### DIFF
--- a/sentences/nl/person_HassGetState.yaml
+++ b/sentences/nl/person_HassGetState.yaml
@@ -51,7 +51,7 @@ intents:
           domain: person
           state: not_home
       - sentences:
-          - "is [er] iemand [[<in>]] [de|het] {zone:state}"
+          - "is [er] iemand [<in>] [de|het] {zone:state}"
         response: any
         slots:
           domain: person
@@ -69,7 +69,7 @@ intents:
           domain: person
           state: not_home
       - sentences:
-          - "is iedereen [[<in>]] [de|het] {zone:state}"
+          - "is iedereen [<in>] [de|het] {zone:state}"
         response: all
         slots:
           domain: person


### PR DESCRIPTION
SSIA