### PR TITLE
[NL] Cleanup of _common.yaml

### DIFF
--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -677,7 +677,7 @@ expansion_rules:
       |[<by>] <name> [<in>] <area>
     )
   change: "(zet|mag|mogen|doe|verander|maak|schakel)"
-  would: "(kan|kun|wil) je"
+  would: "(kan|kun|wil) (je|jij)"
   to: "(naar|op)"
   is: "(zijn|is|staa(n|t)|zit[ten]|word[t|en]|lig(t|gen))"
   all: "(alle[maal]|elk[e]|ieder[e]|overal)"

--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -676,8 +676,8 @@ expansion_rules:
       |[<in> [<area>]] [<by>] <name>
       |[<by>] <name> [<in>] <area>
     )
-  change: "(zet[ten]|mag|mogen|doe[n]|verander[en]|maak|maken|schakel[en])"
-  would: "(kan|kun[t]|zal|zou|wil[t]) [je|jij|u]"
+  change: "(zet|mag|mogen|doe|verander|maak|schakel)"
+  would: "(kan|kun|wil) je"
   to: "(naar|op)"
   is: "(zijn|is|staa(n|t)|zit[ten]|word[t|en]|lig(t|gen))"
   all: "(alle[maal]|elk[e]|ieder[e]|overal)"


### PR DESCRIPTION
Both `<would>` and `<change>` were used at the start and end of sentences before. And therefor included singular and plural forms.

In the review of the intents I changed this and now only singular forms are needed. Also `<would>` is not using `u` anymore.