### PR TITLE
[NL] Remove `<type>` expansion rule

### DIFF
--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -677,7 +677,7 @@ expansion_rules:
       |[<by>] <name> [<in>] <area>
     )
   change: "(zet|mag|mogen|doe|verander|maak|schakel)"
-  would: "(kan|kun|wil) je"
+  would: "(kan|kun|wil) (je|jij)"
   to: "(naar|op)"
   is: "(zijn|is|staa(n|t)|zit[ten]|word[t|en]|lig(t|gen))"
   all: "(alle[maal]|elk[e]|ieder[e]|overal)"

--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -667,8 +667,9 @@ expansion_rules:
   here: "(hier|in deze (kamer|ruimte))"
   name_area: >
     (
-      <name>[[ ]<type>] <in> <area>
-      |[<in> <area>[ ]]<name>[[ ]<type>]
+      <name> <in> <area>
+      |<in> <area> <name>
+      |<area>[ ]<name>
     )
   sensor_name_area: >
     (
@@ -713,8 +714,6 @@ expansion_rules:
       |[<in> <area>] <lock_name>)
       |<area>[ ]<name>[ ]([deur]slot[en]|vergrendeling[en]
     )
-  # combination of device/entity types
-  type: (<light>|<fan>|<cover>|<switch>)
   # light brightness
   brightness: "[de] (helderheid|felheid|intensiteit|lichtsterkte)"
   brightness_value: "{brightness}[ ][%|procent]"

--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -676,8 +676,8 @@ expansion_rules:
       |[<in> [<area>]] [<by>] <name>
       |[<by>] <name> [<in>] <area>
     )
-  change: "(zet[ten]|mag|mogen|doe[n]|verander[en]|maak|maken|schakel[en])"
-  would: "(kan|kun[t]|zal|zou|wil[t]) [je|jij|u]"
+  change: "(zet|mag|mogen|doe|verander|maak|schakel)"
+  would: "(kan|kun|wil) je"
   to: "(naar|op)"
   is: "(zijn|is|staa(n|t)|zit[ten]|word[t|en]|lig(t|gen))"
   all: "(alle[maal]|elk[e]|ieder[e]|overal)"

--- a/sentences/nl/homeassistant_HassGetState.yaml
+++ b/sentences/nl/homeassistant_HassGetState.yaml
@@ -3,21 +3,81 @@ intents:
   HassGetState:
     data:
       - sentences:
-          - Wat is [[de] [huidige] <state> [van]] [<area>[ ]]<name>[ ][<type>][ ][<state>]
-          - Wat is ([<in>] <area>;[[de] [huidige] <state> [van]] <name>[ ][<type>][ ][<state>])
-          - "[de] [huidige] <state> [van] [<area>][ ]<name>[ ][<type>]"
-          - "([<in>] <area>;[de] [huidige] <state> [van] <name>[ ][<type>])"
-          - "[<area>[ ]]<name>[ ][<type>][ ]<state>"
-          - "([<in>] <area>;<name>[ ][<type>][ ]<state>)"
+          - Wat is [[de] [huidige] <state> [van]] [<area>[ ]]<name>[ ][<state>]
+          - Wat is ([<in>] <area>;[[de] [huidige] <state> [van]] <name>[ ][<state>])
+          - "[de] [huidige] <state> [van] [<area>][ ]<name>"
+          - "([<in>] <area>;[de] [huidige] <state> [van] <name>)"
+          - "[<area>[ ]]<name>[ ]<state>"
+          - "([<in>] <area>;<name>[ ]<state>)"
         response: one
 
       - sentences:
-          - <is> [[de] [huidige] <state> [van]] <name>[ ][<type>][ ][<state>] [op] {on_off_states:state} [[<in>] <area>]
-          - <is> ([<in>] <area>;[[de] [huidige] <state> [van]] <name>[ ][<type>][ ][<state>]) [op] {on_off_states:state} [[<in>] <area>]
+          - <is> [[de] [huidige] <state> [van]] <name>[ ][<state>] [op] {on_off_states:state} [[<in>] <area>]
+          - <is> ([<in>] <area>;[[de] [huidige] <state> [van]] <name>[ ][<state>]) [op] {on_off_states:state} [[<in>] <area>]
         response: one_yesno
         excludes_context:
           domain:
             - cover
+
+      - sentences:
+          - Wat is [[de] [huidige] <state> [van]] [<area>[ ]]<name>[ ]<light>[ ][<state>]
+          - Wat is ([<in>] <area>;[[de] [huidige] <state> [van]] <name>[ ]<light>[ ][<state>])
+          - "[de] [huidige] <state> [van] [<area>][ ]<name>[ ]<light>"
+          - "([<in>] <area>;[de] [huidige] <state> [van] <name>[ ]<light>)"
+          - "[<area>[ ]]<name>[ ]<light>[ ]<state>"
+          - "([<in>] <area>;<name>[ ]<light>[ ]<state>)"
+        response: one
+        requires_context:
+          domain:
+            - light
+
+      - sentences:
+          - <is> [[de] [huidige] <state> [van]] <name>[ ]<light>[ ][<state>] [op] {on_off_states:state} [[<in>] <area>]
+          - <is> ([<in>] <area>;[[de] [huidige] <state> [van]] <name>[ ]<light>[ ][<state>]) [op] {on_off_states:state} [[<in>] <area>]
+        response: one_yesno
+        requires_context:
+          domain:
+            - light
+
+      - sentences:
+          - Wat is [[de] [huidige] <state> [van]] [<area>[ ]]<name>[ ]<switch>[ ][<state>]
+          - Wat is ([<in>] <area>;[[de] [huidige] <state> [van]] <name>[ ]<switch>[ ][<state>])
+          - "[de] [huidige] <state> [van] [<area>][ ]<name>[ ]<switch>"
+          - "([<in>] <area>;[de] [huidige] <state> [van] <name>[ ]<switch>)"
+          - "[<area>[ ]]<name>[ ]<switch>[ ]<state>"
+          - "([<in>] <area>;<name>[ ]<switch>[ ]<state>)"
+        response: one
+        requires_context:
+          domain:
+            - switch
+
+      - sentences:
+          - <is> [[de] [huidige] <state> [van]] <name>[ ]<switch>[ ][<state>] [op] {on_off_states:state} [[<in>] <area>]
+          - <is> ([<in>] <area>;[[de] [huidige] <state> [van]] <name>[ ]<switch>[ ][<state>]) [op] {on_off_states:state} [[<in>] <area>]
+        response: one_yesno
+        requires_context:
+          domain:
+            - switch
+
+      - sentences:
+          - Wat is [[de] [huidige] <state> [van]] [<area>[ ]]<name>[ ]<fan>[ ][<state>]
+          - Wat is ([<in>] <area>;[[de] [huidige] <state> [van]] <name>[ ]<fan>[ ][<state>])
+          - "[de] [huidige] <state> [van] [<area>][ ]<name>[ ]<fan>"
+          - "([<in>] <area>;[de] [huidige] <state> [van] <name>[ ]<fan>)"
+          - "[<area>[ ]]<name>[ ]<fan>[ ]<state>"
+          - "([<in>] <area>;<name>[ ]<fan>[ ]<state>)"
+        response: one
+        requires_context:
+          domain:
+            - fan
+
+      - sentences:
+          - <is> [[de] [huidige] <state> [van]] <name>[ ]<fan>[ ][<state>] [op] {on_off_states:state} [[<in>] <area>]
+          - <is> ([<in>] <area>;[[de] [huidige] <state> [van]] <name>[ ]<fan>[ ][<state>]) [op] {on_off_states:state} [[<in>] <area>]
+        response: one_yesno
+        requires_context:
+          domain:
+            - fan
 
       - sentences:
           - <is> er {on_off_domains:domain} {on_off_states:state} [[<in>] <area>]

--- a/sentences/nl/homeassistant_HassTurnOff.yaml
+++ b/sentences/nl/homeassistant_HassTurnOff.yaml
@@ -3,9 +3,9 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "[<change>] <name>[[ ]<type>] [<to>] uit [<in> <area>]"
+          - "[<change>] <name>[<to>] uit [<in> <area>]"
           - "[<change>] <name_area> [<to>] uit"
-          - "[<would>] <name>[[ ]<type>] ((uit[ ](zetten|doen)|uit[ ]schakelen|doen);<in> <area>)"
+          - "[<would>] <name> (uit[ ](zetten|doen)|uit[ ]schakelen|doen) [<in> <area>]"
           - "[<would>] <name_area> (uit[ ](zetten|doen)|uit[ ]schakelen|doen)"
         excludes_context:
           domain:
@@ -17,3 +17,51 @@ intents:
             - sensor
             - valve
             - vacuum
+      # light
+      - sentences:
+          - "[<change>] <name>[ ]<light> [<to>] uit [<in> <area>]"
+          - "[<change>] <light_name_area> [<to>] uit"
+          - "[<would>] <name>[ ]<light> [<to>] (uit[ ](zetten|doen)|uit[ ]schakelen|doen) [<in> <area>]"
+          - "[<would>] <light_name_area> (uit[ ](zetten|doen)|inschakelen)"
+        expansion_rules:
+          light_name_area: >
+            (
+              <name>[ ]<light> <in> <area>
+              |<in> <area> <name>[ ]<light>
+              |{area}[ ]<name>[ ]<light>
+            )
+        requires_context:
+          domain:
+            - light
+      # light
+      - sentences:
+          - "[<change>] <name>[ ]<switch> [<to>] uit [<in> <area>]"
+          - "[<change>] <light_name_area> [<to>] uit"
+          - "[<would>] <name>[ ]<switch> [<to>] (uit[ ](zetten|doen)|uit[ ]schakelen|doen) [<in> <area>]"
+          - "[<would>] <light_name_area> (uit[ ](zetten|doen)|inschakelen)"
+        expansion_rules:
+          light_name_area: >
+            (
+              <name>[ ]<switch> <in> <area>
+              |<in> <area> <name>[ ]<switch>
+              |{area}[ ]<name>[ ]<switch>
+            )
+        requires_context:
+          domain:
+            - switch
+      # light
+      - sentences:
+          - "[<change>] <name>[ ]<fan> [<to>] uit [<in> <area>]"
+          - "[<change>] <light_name_area> [<to>] uit"
+          - "[<would>] <name>[ ]<fan> [<to>] (uit[ ](zetten|doen)|uit[ ]schakelen|doen) [<in> <area>]"
+          - "[<would>] <light_name_area> (uit[ ](zetten|doen)|inschakelen)"
+        expansion_rules:
+          light_name_area: >
+            (
+              <name>[ ]<fan> <in> <area>
+              |<in> <area> <name>[ ]<fan>
+              |{area}[ ]<name>[ ]<fan>
+            )
+        requires_context:
+          domain:
+            - fan

--- a/sentences/nl/homeassistant_HassTurnOn.yaml
+++ b/sentences/nl/homeassistant_HassTurnOn.yaml
@@ -3,11 +3,11 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "[<change>] <name>[[ ]<type>] [<to>] aan [<in> <area>]"
+          - "[<change>] <name> [<to>] aan [<in> <area>]"
           - "[<change>] <name_area> [<to>] aan"
-          - "schakel <name>[[ ]<type>] [<to>] in [<in> <area>]"
+          - "schakel <name> [<to>] in [<in> <area>]"
           - "schakel <name_area> [<to>] in"
-          - "[<would>] <name>[[ ]<type>] [<to>] ((aan[ ](zetten|doen)|inschakelen);<in> <area>)"
+          - "[<would>] <name> [<to>] (aan[ ](zetten|doen)|inschakelen) [<in> <area>]"
           - "[<would>] <name_area> (aan[ ](zetten|doen)|inschakelen)"
         excludes_context:
           domain:
@@ -19,3 +19,60 @@ intents:
             - sensor
             - valve
             - vacuum
+
+      # light
+      - sentences:
+          - "[<change>] <name>[ ]<light> [<to>] aan [<in> <area>]"
+          - "[<change>] <light_name_area> [<to>] aan"
+          - "schakel <name>[ ]<light> [<to>] in [<in> <area>]"
+          - "schakel <light_name_area> [<to>] in"
+          - "[<would>] <name>[ ]<light> [<to>] (aan[ ](zetten|doen)|inschakelen) [<in> <area>]"
+          - "[<would>] <light_name_area> (aan[ ](zetten|doen)|inschakelen)"
+        expansion_rules:
+          light_name_area: >
+            (
+              <name>[ ]<light> <in> <area>
+              |<in> <area> <name>[ ]<light>
+              |{area}[ ]<name>[ ]<light>
+            )
+        requires_context:
+          domain:
+            - light
+
+      # switch
+      - sentences:
+          - "[<change>] <name>[ ]<switch> [<to>] aan [<in> <area>]"
+          - "[<change>] <light_name_area> [<to>] aan"
+          - "schakel <name>[ ]<switch> [<to>] in [<in> <area>]"
+          - "schakel <light_name_area> [<to>] in"
+          - "[<would>] <name>[ ]<switch> [<to>] (aan[ ](zetten|doen)|inschakelen) [<in> <area>]"
+          - "[<would>] <light_name_area> (aan[ ](zetten|doen)|inschakelen)"
+        expansion_rules:
+          light_name_area: >
+            (
+              <name>[ ]<switch> <in> <area>
+              |<in> <area> <name>[ ]<switch>
+              |{area}[ ]<name>[ ]<switch>
+            )
+        requires_context:
+          domain:
+            - switch
+
+      # fan
+      - sentences:
+          - "[<change>] <name>[ ]<fan> [<to>] aan [<in> <area>]"
+          - "[<change>] <light_name_area> [<to>] aan"
+          - "schakel <name>[ ]<fan> [<to>] in [<in> <area>]"
+          - "schakel <light_name_area> [<to>] in"
+          - "[<would>] <name>[ ]<fan> [<to>] (aan[ ](zetten|doen)|inschakelen) [<in> <area>]"
+          - "[<would>] <light_name_area> (aan[ ](zetten|doen)|inschakelen)"
+        expansion_rules:
+          light_name_area: >
+            (
+              <name>[ ]<fan> <in> <area>
+              |<in> <area> <name>[ ]<fan>
+              |{area}[ ]<name>[ ]<fan>
+            )
+        requires_context:
+          domain:
+            - fan

--- a/tests/nl/homeassistant_HassGetState.yaml
+++ b/tests/nl/homeassistant_HassGetState.yaml
@@ -23,6 +23,8 @@ tests:
       slots:
         name: "Speelhoek"
         area: "Woonkamer"
+      context:
+        domain: fan
     response: "Speelhoek is uit"
 
   - sentences:
@@ -36,6 +38,27 @@ tests:
 
   - sentences:
       - "Staat de werkbank in de garage aan?"
+    intent:
+      name: HassGetState
+      slots:
+        name: "Werkbank"
+        area: "Garage"
+        state: "on"
+    response: "Ja"
+
+  - sentences:
+      - "Staat de speelhoekventilator uit?"
+      - "Staat de huidige stand van speelhoek fan op uit?"
+    intent:
+      name: HassGetState
+      slots:
+        name: "Speelhoek"
+        state: "off"
+      context:
+        domain: fan
+    response: "Ja"
+
+  - sentences:
       - "Staat in de garage de werkbankverlichting aan?"
       - "Staat in garage de huidige stand van werkbank lamp op aan?"
     intent:
@@ -44,7 +67,22 @@ tests:
         name: "Werkbank"
         area: "Garage"
         state: "on"
+      context:
+        domain: light
     response: "Ja"
+
+  - sentences:
+      - "Staat in de keuken de waterkokerswitch aan?"
+      - "Staat in keuken de huidige stand van waterkoker schakelaar op aan?"
+    intent:
+      name: HassGetState
+      slots:
+        name: "Waterkoker"
+        area: "Keuken"
+        state: "on"
+      context:
+        domain: switch
+    response: "Nee, die is uit"
 
   - sentences:
       - "Staan er lampen aan?"

--- a/tests/nl/homeassistant_HassTurnOff.yaml
+++ b/tests/nl/homeassistant_HassTurnOff.yaml
@@ -23,6 +23,8 @@ tests:
       name: HassTurnOff
       slots:
         name: Werkbank
+      context:
+        domain: light
 
   - sentences:
       - Zet waterkokerswitch uit
@@ -35,6 +37,8 @@ tests:
       name: HassTurnOff
       slots:
         name: Waterkoker
+      context:
+        domain: switch
 
   - sentences:
       - Zet waterkoker in de keuken uit
@@ -48,6 +52,8 @@ tests:
       slots:
         name: Waterkoker
         area: Keuken
+      context:
+        domain: switch
 
   - sentences:
       - Doe speelhoek ventilator uit
@@ -60,3 +66,5 @@ tests:
       name: HassTurnOff
       slots:
         name: Speelhoek
+      context:
+        domain: fan

--- a/tests/nl/homeassistant_HassTurnOn.yaml
+++ b/tests/nl/homeassistant_HassTurnOn.yaml
@@ -12,6 +12,18 @@ tests:
         name: Slaapkamerlampje
 
   - sentences:
+      - Zet waterkoker in de keuken aan
+      - Zet de keukenwaterkoker aan
+      - waterkoker aan in de keuken
+      - de keukenwaterkoker aanzetten
+      - waterkoker in de keuken inschakelen?
+    intent:
+      name: HassTurnOn
+      slots:
+        name: Waterkoker
+        area: Keuken
+
+  - sentences:
       - Doe werkbank lamp aan
       - Schakel werkbank verlichting in
       - Zet werkbank licht naar aan
@@ -23,6 +35,8 @@ tests:
       name: HassTurnOn
       slots:
         name: Werkbank
+      context:
+        domain: light
 
   - sentences:
       - Zet waterkokerswitch aan
@@ -34,18 +48,9 @@ tests:
       name: HassTurnOn
       slots:
         name: Waterkoker
+      context:
+        domain: switch
 
-  - sentences:
-      - Zet waterkokerswitch in de keuken aan
-      - Zet de keukenwaterkokerschakelaar aan
-      - waterkoker switch aan in de keuken
-      - de keukenwaterkokerschakelaar aanzetten
-      - waterkoker in de keuken inschakelen?
-    intent:
-      name: HassTurnOn
-      slots:
-        name: Waterkoker
-        area: Keuken
   - sentences:
       - Doe speelhoek ventilator aan
       - Schakel speelhoekfan in
@@ -56,3 +61,5 @@ tests:
       name: HassTurnOn
       slots:
         name: Speelhoek
+      context:
+        domain: fan


### PR DESCRIPTION
The way `HassTurnOn` and `HassGetState` were set up using `<type>` could get unwanted results. Saying something like `zet TV lamp aan` (turn tv light on) could target a meida_player entity called TV, as there was no link to an action domain.

I've now split the domains which were added to the `<type>` expansion rule into seperate sentences and removed the `<type>` expansion rule.

I was doubting a bit where to place these new sentences. In `homeassistant_HassTurnOn` or in eg `light_HassTurnOn`. I decided to leave them in `homeassistant_HassTurnOn` as it will make it less likely that changes to the generic one are not adepted in the domain specific ones as well. Also it allows adding more domains like eg `media_player` which don't have their own `media_player_HassTurnOn` intent.