### PR TITLE
[NL] Use YAML anchors for HassTurnOn/Off and HassGetState

### DIFF
--- a/sentences/nl/homeassistant_HassGetState.yaml
+++ b/sentences/nl/homeassistant_HassGetState.yaml
@@ -2,78 +2,72 @@ language: nl
 intents:
   HassGetState:
     data:
-      - sentences:
-          - Wat is [[de] [huidige] <state> [van]] [<area>[ ]]<name>[ ][<state>]
-          - Wat is ([<in>] <area>;[[de] [huidige] <state> [van]] <name>[ ][<state>])
-          - "[de] [huidige] <state> [van] [<area>][ ]<name>"
-          - "([<in>] <area>;[de] [huidige] <state> [van] <name>)"
-          - "[<area>[ ]]<name>[ ]<state>"
-          - "([<in>] <area>;<name>[ ]<state>)"
+      - sentences: &one_sentences
+          - Wat is [[de] [huidige] <state> [van]] [<area>[ ]]<name_type>[ ][<state>]
+          - Wat is ([<in>] <area>;[[de] [huidige] <state> [van]] <name_type>[ ][<state>])
+          - "[de] [huidige] <state> [van] [<area>][ ]<name_type>"
+          - "([<in>] <area>;[de] [huidige] <state> [van] <name_type>)"
+          - "[<area>[ ]]<name_type>[ ]<state>"
+          - "([<in>] <area>;<name_type>[ ]<state>)"
+        expansion_rules:
+          name_type: <name>
         response: one
 
-      - sentences:
-          - <is> [[de] [huidige] <state> [van]] <name>[ ][<state>] [op] {on_off_states:state} [[<in>] <area>]
-          - <is> ([<in>] <area>;[[de] [huidige] <state> [van]] <name>[ ][<state>]) [op] {on_off_states:state}
+      - sentences: &one_yesno_sentences
+          - <is> [[de] huidige] <name_type>[ ][<state>] [op] {on_off_states:state} [[<in>] <area>]
+          - <is> [[de] huidige] <state> [van] <name_type> [op] {on_off_states:state} [[<in>] <area>]
+          - <is> ([<in>] <area>;[[de] huidige] <state> [van] <name_type>) [op] {on_off_states:state}
+          - <is> ([<in>] <area>;[[de] huidige] <name_type>[ ][<state>]) [op] {on_off_states:state}
+        expansion_rules:
+          name_type: <name>
         response: one_yesno
         excludes_context:
           domain:
             - cover
 
-      - sentences:
-          - Wat is [[de] [huidige] <state> [van]] [<area>[ ]]<name>[ ]<light>[ ][<state>]
-          - Wat is ([<in>] <area>;[[de] [huidige] <state> [van]] <name>[ ]<light>[ ][<state>])
-          - "[de] [huidige] <state> [van] [<area>][ ]<name>[ ]<light>"
-          - "([<in>] <area>;[de] [huidige] <state> [van] <name>[ ]<light>)"
-          - "[<area>[ ]]<name>[ ]<light>[ ]<state>"
-          - "([<in>] <area>;<name>[ ]<light>[ ]<state>)"
+      - sentences: *one_sentences
+        expansion_rules:
+          name_type: <name>[ ]<light>
         response: one
         requires_context:
           domain:
             - light
 
-      - sentences:
-          - <is> [[de] [huidige] <state> [van]] <name>[ ]<light>[ ][<state>] [op] {on_off_states:state} [[<in>] <area>]
-          - <is> ([<in>] <area>;[[de] [huidige] <state> [van]] <name>[ ]<light>[ ][<state>]) [op] {on_off_states:state} [[<in>] <area>]
+      - sentences: *one_yesno_sentences
+        expansion_rules:
+          name_type: <name>[ ]<light>
         response: one_yesno
         requires_context:
           domain:
             - light
 
-      - sentences:
-          - Wat is [[de] [huidige] <state> [van]] [<area>[ ]]<name>[ ]<switch>[ ][<state>]
-          - Wat is ([<in>] <area>;[[de] [huidige] <state> [van]] <name>[ ]<switch>[ ][<state>])
-          - "[de] [huidige] <state> [van] [<area>][ ]<name>[ ]<switch>"
-          - "([<in>] <area>;[de] [huidige] <state> [van] <name>[ ]<switch>)"
-          - "[<area>[ ]]<name>[ ]<switch>[ ]<state>"
-          - "([<in>] <area>;<name>[ ]<switch>[ ]<state>)"
+      - sentences: *one_sentences
+        expansion_rules:
+          name_type: <name>[ ]<switch>
         response: one
         requires_context:
           domain:
             - switch
 
-      - sentences:
-          - <is> [[de] [huidige] <state> [van]] <name>[ ]<switch>[ ][<state>] [op] {on_off_states:state} [[<in>] <area>]
-          - <is> ([<in>] <area>;[[de] [huidige] <state> [van]] <name>[ ]<switch>[ ][<state>]) [op] {on_off_states:state} [[<in>] <area>]
+      - sentences: *one_yesno_sentences
+        expansion_rules:
+          name_type: <name>[ ]<switch>
         response: one_yesno
         requires_context:
           domain:
             - switch
 
-      - sentences:
-          - Wat is [[de] [huidige] <state> [van]] [<area>[ ]]<name>[ ]<fan>[ ][<state>]
-          - Wat is ([<in>] <area>;[[de] [huidige] <state> [van]] <name>[ ]<fan>[ ][<state>])
-          - "[de] [huidige] <state> [van] [<area>][ ]<name>[ ]<fan>"
-          - "([<in>] <area>;[de] [huidige] <state> [van] <name>[ ]<fan>)"
-          - "[<area>[ ]]<name>[ ]<fan>[ ]<state>"
-          - "([<in>] <area>;<name>[ ]<fan>[ ]<state>)"
+      - sentences: *one_sentences
+        expansion_rules:
+          name_type: <name>[ ]<fan>
         response: one
         requires_context:
           domain:
             - fan
 
-      - sentences:
-          - <is> [[de] [huidige] <state> [van]] <name>[ ]<fan>[ ][<state>] [op] {on_off_states:state} [[<in>] <area>]
-          - <is> ([<in>] <area>;[[de] [huidige] <state> [van]] <name>[ ]<fan>[ ][<state>]) [op] {on_off_states:state} [[<in>] <area>]
+      - sentences: *one_yesno_sentences
+        expansion_rules:
+          name_type: <name>[ ]<fan>
         response: one_yesno
         requires_context:
           domain:

--- a/sentences/nl/homeassistant_HassGetState.yaml
+++ b/sentences/nl/homeassistant_HassGetState.yaml
@@ -14,10 +14,10 @@ intents:
         response: one
 
       - sentences: &one_yesno_sentences
-          - <is> [[de] huidige] <name_type>[ ][<state>] [op] {on_off_states:state} [[<in>] <area>]
+          - <is> [[de] huidige] <name_type>[[ ]<state>] [op] {on_off_states:state} [[<in>] <area>]
           - <is> [[de] huidige] <state> [van] <name_type> [op] {on_off_states:state} [[<in>] <area>]
+          - <is> ([<in>] <area>;[[de] huidige] <name_type>[[ ]<state>]) [op] {on_off_states:state}
           - <is> ([<in>] <area>;[[de] huidige] <state> [van] <name_type>) [op] {on_off_states:state}
-          - <is> ([<in>] <area>;[[de] huidige] <name_type>[ ][<state>]) [op] {on_off_states:state}
         expansion_rules:
           name_type: <name>
         response: one_yesno

--- a/sentences/nl/homeassistant_HassTurnOff.yaml
+++ b/sentences/nl/homeassistant_HassTurnOff.yaml
@@ -2,11 +2,13 @@ language: nl
 intents:
   HassTurnOff:
     data:
-      - sentences:
-          - "[<change>] <name>[<to>] uit [<in> <area>]"
+      - sentences: &sentences
+          - "[<change>] <name_type> [<to>] uit [<in> <area>]"
           - "[<change>] <name_area> [<to>] uit"
-          - "[<would>] <name> (uit[ ](zetten|doen)|uit[ ]schakelen|doen) [<in> <area>]"
+          - "[<would>] <name_type> (uit[ ](zetten|doen)|uit[ ]schakelen|doen) [<in> <area>]"
           - "[<would>] <name_area> (uit[ ](zetten|doen)|uit[ ]schakelen|doen)"
+        expansion_rules:
+          name_type: <name>
         excludes_context:
           domain:
             - binary_sensor
@@ -17,51 +19,35 @@ intents:
             - sensor
             - valve
             - vacuum
+
       # light
-      - sentences:
-          - "[<change>] <name>[ ]<light> [<to>] uit [<in> <area>]"
-          - "[<change>] <light_name_area> [<to>] uit"
-          - "[<would>] <name>[ ]<light> [<to>] (uit[ ](zetten|doen)|uit[ ]schakelen|doen) [<in> <area>]"
-          - "[<would>] <light_name_area> (uit[ ](zetten|doen)|inschakelen)"
+      - sentences: *sentences
         expansion_rules:
-          light_name_area: >
+          name_type: <name>[ ]<light>
+          name_area: &name_area >
             (
-              <name>[ ]<light> <in> <area>
-              |<in> <area> <name>[ ]<light>
-              |<area>[ ]<name>[ ]<light>
+              <name_type> <in> <area>
+              |<in> <area> <name_type>
+              |<area>[ ]<name_type>
             )
         requires_context:
           domain:
             - light
-      # light
-      - sentences:
-          - "[<change>] <name>[ ]<switch> [<to>] uit [<in> <area>]"
-          - "[<change>] <light_name_area> [<to>] uit"
-          - "[<would>] <name>[ ]<switch> [<to>] (uit[ ](zetten|doen)|uit[ ]schakelen|doen) [<in> <area>]"
-          - "[<would>] <light_name_area> (uit[ ](zetten|doen)|inschakelen)"
+
+      # switch
+      - sentences: *sentences
         expansion_rules:
-          light_name_area: >
-            (
-              <name>[ ]<switch> <in> <area>
-              |<in> <area> <name>[ ]<switch>
-              |<area>[ ]<name>[ ]<switch>
-            )
+          name_type: <name>[ ]<switch>
+          name_area: *name_area
         requires_context:
           domain:
             - switch
-      # light
-      - sentences:
-          - "[<change>] <name>[ ]<fan> [<to>] uit [<in> <area>]"
-          - "[<change>] <light_name_area> [<to>] uit"
-          - "[<would>] <name>[ ]<fan> [<to>] (uit[ ](zetten|doen)|uit[ ]schakelen|doen) [<in> <area>]"
-          - "[<would>] <light_name_area> (uit[ ](zetten|doen)|inschakelen)"
+
+      # fan
+      - sentences: *sentences
         expansion_rules:
-          light_name_area: >
-            (
-              <name>[ ]<fan> <in> <area>
-              |<in> <area> <name>[ ]<fan>
-              |<area>[ ]<name>[ ]<fan>
-            )
+          name_type: <name>[ ]<fan>
+          name_area: *name_area
         requires_context:
           domain:
             - fan

--- a/sentences/nl/homeassistant_HassTurnOn.yaml
+++ b/sentences/nl/homeassistant_HassTurnOn.yaml
@@ -2,13 +2,15 @@ language: nl
 intents:
   HassTurnOn:
     data:
-      - sentences:
-          - "[<change>] <name> [<to>] aan [<in> <area>]"
+      - sentences: &sentences
+          - "[<change>] <name_type> [<to>] aan [<in> <area>]"
           - "[<change>] <name_area> [<to>] aan"
-          - "schakel <name> [<to>] in [<in> <area>]"
+          - "schakel <name_type> [<to>] in [<in> <area>]"
           - "schakel <name_area> [<to>] in"
-          - "[<would>] <name> [<to>] (aan[ ](zetten|doen)|inschakelen) [<in> <area>]"
+          - "[<would>] <name_type> [<to>] (aan[ ](zetten|doen)|inschakelen) [<in> <area>]"
           - "[<would>] <name_area> (aan[ ](zetten|doen)|inschakelen)"
+        expansion_rules:
+          name_type: <name>
         excludes_context:
           domain:
             - binary_sensor
@@ -21,58 +23,33 @@ intents:
             - vacuum
 
       # light
-      - sentences:
-          - "[<change>] <name>[ ]<light> [<to>] aan [<in> <area>]"
-          - "[<change>] <light_name_area> [<to>] aan"
-          - "schakel <name>[ ]<light> [<to>] in [<in> <area>]"
-          - "schakel <light_name_area> [<to>] in"
-          - "[<would>] <name>[ ]<light> [<to>] (aan[ ](zetten|doen)|inschakelen) [<in> <area>]"
-          - "[<would>] <light_name_area> (aan[ ](zetten|doen)|inschakelen)"
+      - sentences: *sentences
         expansion_rules:
-          light_name_area: >
+          name_type: <name>[ ]<light>
+          name_area: &name_area >
             (
-              <name>[ ]<light> <in> <area>
-              |<in> <area> <name>[ ]<light>
-              |<area>[ ]<name>[ ]<light>
+              <name_type> <in> <area>
+              |<in> <area> <name_type>
+              |<area>[ ]<name_type>
             )
         requires_context:
           domain:
             - light
 
       # switch
-      - sentences:
-          - "[<change>] <name>[ ]<switch> [<to>] aan [<in> <area>]"
-          - "[<change>] <light_name_area> [<to>] aan"
-          - "schakel <name>[ ]<switch> [<to>] in [<in> <area>]"
-          - "schakel <light_name_area> [<to>] in"
-          - "[<would>] <name>[ ]<switch> [<to>] (aan[ ](zetten|doen)|inschakelen) [<in> <area>]"
-          - "[<would>] <light_name_area> (aan[ ](zetten|doen)|inschakelen)"
+      - sentences: *sentences
         expansion_rules:
-          light_name_area: >
-            (
-              <name>[ ]<switch> <in> <area>
-              |<in> <area> <name>[ ]<switch>
-              |<area>[ ]<name>[ ]<switch>
-            )
+          name_type: <name>[ ]<switch>
+          name_area: *name_area
         requires_context:
           domain:
             - switch
 
       # fan
-      - sentences:
-          - "[<change>] <name>[ ]<fan> [<to>] aan [<in> <area>]"
-          - "[<change>] <light_name_area> [<to>] aan"
-          - "schakel <name>[ ]<fan> [<to>] in [<in> <area>]"
-          - "schakel <light_name_area> [<to>] in"
-          - "[<would>] <name>[ ]<fan> [<to>] (aan[ ](zetten|doen)|inschakelen) [<in> <area>]"
-          - "[<would>] <light_name_area> (aan[ ](zetten|doen)|inschakelen)"
+      - sentences: *sentences
         expansion_rules:
-          light_name_area: >
-            (
-              <name>[ ]<fan> <in> <area>
-              |<in> <area> <name>[ ]<fan>
-              |<area>[ ]<name>[ ]<fan>
-            )
+          name_type: <name>[ ]<fan>
+          name_area: *name_area
         requires_context:
           domain:
             - fan


### PR DESCRIPTION
Using YAML anchors and local expansion_rules the generic and domain specific sentences for HassGetState and HassTurnOn/Off can be maintained in one place, instead of 4