### PR TITLE
[NL] Fix wrongly placed closing bracket in cover_HassSetPosition

### DIFF
--- a/sentences/nl/cover_HassSetPosition.yaml
+++ b/sentences/nl/cover_HassSetPosition.yaml
@@ -7,7 +7,7 @@ intents:
           - "[<numeric_value_set>|open|sluit] [de] (positie|stand) [van] <name>[[ ]<cover>] [<to>] <position>"
           - "[<change>] <name>[[ ]<cover>][[ ](positie|stand)] ([<to>] <position>;(omhoog|omlaag))"
           - "[<change>] [de] (positie|stand) [van] <name>[[ ]<cover>] ([<to>] <position>;(omhoog|omlaag))"
-          - "[<would> <name>][[ ](positie|stand)] [<to>] <position> (zetten|doen|verhogen|verlagen)"
+          - "[<would>] <name>[[ ](positie|stand)] [<to>] <position> (zetten|doen|verhogen|verlagen)"
           - "[<would>] [de] (positie|stand) [van] <name> [<to>] <position> (zetten|doen|verhogen|verlagen)"
         requires_context:
           domain: cover


### PR DESCRIPTION
a `]` was placed wrong making `<name>` optional in a sentence intended to target a cover by name.