### PR TITLE
[CA] Improve expansion rules to generate less invalid variants (3)

### DIFF
--- a/sentences/ca/_common.yaml
+++ b/sentences/ca/_common.yaml
@@ -177,7 +177,7 @@ expansion_rules:
   baixar: "[a]baixa[r|t]"
   configura: "(posa[r]|puja[r]|configura[r]|ajusta[r]|canvia[r]|establ(ir|eix|ix))"
   posició: "{position}[<percent>]"
-  percent: "[ ](%|per[ ]cent)"
+  percent: "(%|per[ ]cent)"
   cancela: "cancel[·l]a[r|t]"
   seguent: "(següent|proper[a]|pròxim[a])"
   anterior: "[l'|s'](anterior|enrer(e|a)|últim[a])"

--- a/sentences/ca/_common.yaml
+++ b/sentences/ca/_common.yaml
@@ -140,9 +140,9 @@ lists:
         out: 30
       - in: "1/2"
         out: 30
-      - in: "[un |1 ]quart[ de| d']"
+      - in: "[un|1] quart [de |d']"
         out: 15
-      - in: "(tres|3) quarts[ de| d']"
+      - in: "(tres|3) quarts [de |d']"
         out: 45
   timer_name:
     wildcard: true
@@ -186,7 +186,7 @@ expansion_rules:
   reproduir_again: "(reproduir|posar|ficar|escoltar)"
   reactiva: "(reanuda[r]|reactiva[r]|repr(è|e)n[dre]|continua[r]|segu(ir|eix|ix))"
   hora: "hor(a|es)"
-  how_much: "((quan[t]|quin)[s|a|es]|què)"
+  how_much: "(quan|(quant|quin)[s|a|es]|què)"
   again: "([un|una] altr(e|a) (cop|vegada)|de nou)"
 
   # Timers


### PR DESCRIPTION
Following #2620 ,

Drops count from `51,126,745` to `49,180,843` **(3.8%)**