### PR TITLE
Add floors to test fixtures and matching

### DIFF
--- a/script/intentfest/parse.py
+++ b/script/intentfest/parse.py
@@ -15,6 +15,7 @@ from hassil.util import merge_dict, normalize_whitespace
 
 from shared import (
     get_areas,
+    get_floors,
     get_matched_states,
     get_slot_lists,
     get_states,
@@ -69,6 +70,7 @@ def run() -> int:
     slot_lists = get_slot_lists(fixtures)
     states = get_states(fixtures)
     areas = get_areas(fixtures)
+    floors = get_floors(fixtures)
 
     # Load intents
     intents_dict: Dict[str, Any] = {}
@@ -116,7 +118,7 @@ def run() -> int:
                 output_dict["text_chunks_matched"] = result.text_chunks_matched
 
                 # Response
-                matched, unmatched = get_matched_states(states, areas, result)
+                matched, unmatched = get_matched_states(states, areas, floors, result)
                 output_dict["response_key"] = result.response
                 response_template = responses.get(result.intent.name, {}).get(
                     result.response

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -242,6 +242,12 @@ TESTS_SCHEMA = vol.Schema(
 TESTS_FIXTURES = vol.Schema(
     {
         vol.Required("language"): str,
+        vol.Optional("floors"): [
+            {
+                vol.Required("name"): str,
+                vol.Required("id"): str,
+            }
+        ],
         vol.Optional("areas"): [
             {
                 vol.Required("name"): str,

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -350,7 +350,7 @@ def get_slot_lists(fixtures: dict[str, Any]) -> dict[str, SlotList]:
 
     # area/floor
     floor_names: List[str] = []
-    for floor in fixtures["floors"]:
+    for floor in fixtures.get("floors", []):
         floor_name = floor["name"]
         if is_template(floor_name):
             floor_names.extend(
@@ -361,7 +361,7 @@ def get_slot_lists(fixtures: dict[str, Any]) -> dict[str, SlotList]:
             floor_names.append(floor_name.strip())
 
     area_names: List[str] = []
-    for area in fixtures["areas"]:
+    for area in fixtures.get("areas", []):
         area_name = area["name"]
         if is_template(area_name):
             area_names.extend(

--- a/shared/__init__.py
+++ b/shared/__init__.py
@@ -55,6 +55,16 @@ class AreaEntry:
     id: str
     name: str
     aliases: Set[str] = field(default_factory=set)
+    floor_id: Optional[str] = None
+
+
+@dataclass
+class FloorEntry:
+    """Minimal HA-like floor object for responses."""
+
+    id: str
+    name: str
+    aliases: Set[str] = field(default_factory=set)
 
 
 @dataclass
@@ -89,7 +99,10 @@ class Timer:
 
 
 def get_matched_states(
-    states: List[State], areas: List[AreaEntry], result: RecognizeResult
+    states: List[State],
+    areas: List[AreaEntry],
+    floors: List[FloorEntry],
+    result: RecognizeResult,
 ) -> Tuple[List[State], List[State]]:
     """Split states into matched/unmatched."""
     if result.intent.name in ("HassClimateGetTemperature", "HassClimateSetTemperature"):
@@ -110,6 +123,11 @@ def get_matched_states(
     if area_entity is not None:
         area_name = _normalize_name(area_entity.value)
 
+    floor_name: Optional[str] = None
+    floor_entity = result.entities.get("floor")
+    if floor_entity is not None:
+        floor_name = _normalize_name(floor_entity.value)
+
     domain_name: Optional[str] = None
     domain_entity = result.entities.get("domain")
     if domain_entity is not None:
@@ -127,10 +145,19 @@ def get_matched_states(
 
     # name -> id
     area_ids: Dict[str, str] = {}
+    id_to_area: Dict[str, AreaEntry] = {}
     for area in areas:
+        id_to_area[area.id] = area
         area_ids[_normalize_name(area.name)] = area.id
         for area_alias in area.aliases:
             area_ids[_normalize_name(area_alias)] = area.id
+
+    # name -> id
+    floor_ids: Dict[str, str] = {}
+    for floor in floors:
+        floor_ids[_normalize_name(floor.name)] = floor.id
+        for floor_alias in floor.aliases:
+            floor_ids[_normalize_name(floor_alias)] = floor.id
 
     matched: List[State] = []
     unmatched: List[State] = []
@@ -149,6 +176,16 @@ def get_matched_states(
             if not name_match:
                 # Filter by entity name
                 continue
+
+        state_floor_id: Optional[str] = None
+        if state.area_id:
+            state_area = id_to_area.get(state.area_id)
+            if (state_area is not None) and state_area.floor_id:
+                state_floor_id = state_area.floor_id
+
+        if (floor_name is not None) and (state_floor_id != floor_ids.get(floor_name)):
+            # Filter by floor
+            continue
 
         if (area_name is not None) and (state.area_id != area_ids.get(area_name)):
             # Filter by area
@@ -312,8 +349,18 @@ def get_slot_lists(fixtures: dict[str, Any]) -> dict[str, SlotList]:
     slot_lists: dict[str, SlotList] = {}
 
     # area/floor
-    area_names: List[str] = []
     floor_names: List[str] = []
+    for floor in fixtures["floors"]:
+        floor_name = floor["name"]
+        if is_template(floor_name):
+            floor_names.extend(
+                floor_name.strip()
+                for floor_name in sample_expression(parse_sentence(floor_name))
+            )
+        else:
+            floor_names.append(floor_name.strip())
+
+    area_names: List[str] = []
     for area in fixtures["areas"]:
         area_name = area["name"]
         if is_template(area_name):
@@ -323,18 +370,6 @@ def get_slot_lists(fixtures: dict[str, Any]) -> dict[str, SlotList]:
             )
         else:
             area_names.append(area_name.strip())
-
-        floor_name = area.get("floor")
-        if not floor_name:
-            continue
-
-        if is_template(floor_name):
-            floor_names.extend(
-                floor_name.strip()
-                for floor_name in sample_expression(parse_sentence(floor_name))
-            )
-        else:
-            floor_names.append(floor_name.strip())
 
     slot_lists["area"] = TextSlotList.from_strings(area_names)
     slot_lists["floor"] = TextSlotList.from_strings(floor_names)
@@ -418,9 +453,36 @@ def get_areas(fixtures: dict[str, Any]) -> List[AreaEntry]:
             area_names.append(area_name.strip())
 
         areas.append(
-            AreaEntry(id=area["id"], name=area_names[0], aliases=set(area_names[1:]))
+            AreaEntry(
+                id=area["id"],
+                name=area_names[0],
+                aliases=set(area_names[1:]),
+                floor_id=area.get("floor"),
+            )
         )
     return areas
+
+
+def get_floors(fixtures: dict[str, Any]) -> List[FloorEntry]:
+    """Load floors from test fixtures."""
+    floors: List[FloorEntry] = []
+    for floor in fixtures.get("floors", []):
+        floor_names: List[str] = []
+        floor_name = floor["name"]
+        if is_template(floor_name):
+            floor_names.extend(
+                floor_name.strip()
+                for floor_name in sample_expression(parse_sentence(floor_name))
+            )
+        else:
+            floor_names.append(floor_name.strip())
+
+        floors.append(
+            FloorEntry(
+                id=floor["id"], name=floor_names[0], aliases=set(floor_names[1:])
+            )
+        )
+    return floors
 
 
 def get_timers(fixtures: dict[str, Any]) -> List[Timer]:

--- a/tests/ar/_fixtures.yaml
+++ b/tests/ar/_fixtures.yaml
@@ -1,52 +1,57 @@
 language: ar
+floors:
+  - name: "الطابق الأول"
+    id: first_floor_id
+  - name: "الطابق الثاني"
+    id: second_floor_id
 areas:
   - name: المطبخ
     id: kitchen
-    floor: "الطابق الأول"
+    floor: first_floor_id
 
   - name: غرفة المعيشة
     id: living_room
-    floor: "الطابق الأول"
+    floor: first_floor_id
 
   - name: غرفة النوم
     id: bedroom
-    floor: "الطابق الثاني"
+    floor: second_floor_id
 
   - name: الجراج
     id: garage
-    floor: "الطابق الأول"
+    floor: first_floor_id
 
   - name: الحمام
     id: bathroom
-    floor: "الطابق الثاني"
+    floor: second_floor_id
 
   - name: غرفة النوم 2
     id: bedroom_2
-    floor: "الطابق الثاني"
+    floor: second_floor_id
 
   - name: غرفة نوم الأطفال
     id: kids_bedroom
-    floor: "الطابق الثاني"
+    floor: second_floor_id
 
   - name: غرفة نوم الضيوف
     id: guest_bedroom
-    floor: "الطابق الثاني"
+    floor: second_floor_id
 
   - name: غرفة استقبال الضيوف
     id: reception
-    floor: "الطابق الأول"
+    floor: first_floor_id
 
   - name: حمام الضيوف
     id: guest_bathroom
-    floor: "الطابق الأول"
+    floor: first_floor_id
 
   - name: الحديقة
     id: garden
-    floor: "الطابق الأول"
+    floor: first_floor_id
 
   - name: الشرفة
     id: balacony
-    floor: "الطابق الثاني"
+    floor: second_floor_id
 
 entities:
   # LIGHTS

--- a/tests/cs/_fixtures.yaml
+++ b/tests/cs/_fixtures.yaml
@@ -1,26 +1,31 @@
 language: cs
+floors:
+  - name: (Přízemí|Spodní[m] pat(ro|ře))
+    id: ground_floor_id
+  - name: (První|Horní|Vrchní)[m] pat(ro|ře)
+    id: first_floor_id
 areas:
   - name: Kuchy(ň|ni|ně)
     id: kitchen
-    floor: (Přízemí|Spodní[m] pat(ro|ře))
+    floor: ground_floor_id
   - name: (Obývací[m] pokoj[i]|obývák[u])
     id: living_room
-    floor: (Přízemí|Spodní[m] pat(ro|ře))
+    floor: ground_floor_id
   - name: Ložnic(e|i)
     id: bedroom
-    floor: (První|Horní|Vrchní)[m] pat(ro|ře)
+    floor: first_floor_id
   - name: Pokoj[i] pro hosty
     id: guest_room
-    floor: (První|Horní|Vrchní)[m] pat(ro|ře)
+    floor: first_floor_id
   - name: Garáž[i]
     id: garage
-    floor: (Přízemí|Spodní[m] pat(ro|ře))
+    floor: ground_floor_id
   - name: Předsíň[i]
     id: entrance
-    floor: (Přízemí|Spodní[m] pat(ro|ře))
+    floor: ground_floor_id
   - name: Zahrad[a|ě]
     id: garden
-    floor: (Přízemí|Spodní[m] pat(ro|ře))
+    floor: ground_floor_id
 
 entities:
   - name: "(Lamp(a|y|u)|lampičk(a|y|u)|světl(o|a)) v ložnici"

--- a/tests/de-CH/_fixtures.yaml
+++ b/tests/de-CH/_fixtures.yaml
@@ -1,26 +1,33 @@
 language: de-CH
+floors:
+  - name: "Parterre"
+    id: ground_floor_id
+  - name: "Obergeschoss"
+    id: upstairs_id
+  - name: "Garte"
+    id: garden_id
 areas:
   - name: "Chuchi"
     id: kitchen
-    floor: "Parterre"
+    floor: ground_floor_id
   - name: "Stub(e|ä)"
     id: living_room
-    floor: "Parterre"
+    floor: ground_floor_id
   - name: "Salon"
     id: living_room
-    floor: "Parterre"
+    floor: ground_floor_id
   - name: "Wohnz(i|e)mmer"
     id: living_room
-    floor: "Parterre"
+    floor: ground_floor_id
   - name: "Schl(a|o)fz(i|e)mmer"
     id: bedroom
-    floor: "Obergschoss"
+    floor: upstairs_id
   - name: "Garage"
     id: garage
-    floor: "Garte"
+    floor: garden_id
   - name: "(Ygang|I[i]gang)"
     id: entrance
-    floor: "Parterre"
+    floor: ground_floor_id
 
 entities:
   - name: "Deck(e|i|ä)-Venti[lator]"

--- a/tests/de/_fixtures.yaml
+++ b/tests/de/_fixtures.yaml
@@ -1,27 +1,34 @@
 language: de
+floors:
+  - name: "Erdgeschoss"
+    id: ground_floor_id
+  - name: "Obergeschoss"
+    id: upstairs_id
+  - name: "Keller"
+    id: basement_id
 areas:
   - name: Küche
     id: kitchen
-    floor: "Erdgeschoss"
+    floor: ground_floor_id
   - name: Flur
     id: corridor
-    floor: "Erdgeschoss"
+    floor: ground_floor_id
   - name: Wohnzimmer
     id: living_room
-    floor: "Erdgeschoss"
+    floor: ground_floor_id
   - name: Schlafzimmer
     id: bedroom
-    floor: "Obergeschoss"
+    floor: upstairs_id
   - name: Garage
     id: garage
   - name: Garten
     id: garden
   - name: Eingang
     id: entrance
-    floor: "Erdgeschoss"
+    floor: ground_floor_id
   - name: Büro
     id: office
-    floor: "Keller"
+    floor: basement_id
   - name: Auffahrt
     id: driveway
 entities:

--- a/tests/en/_fixtures.yaml
+++ b/tests/en/_fixtures.yaml
@@ -1,38 +1,49 @@
 language: "en"
+floors:
+  - name: "Upstairs"
+    id: "upstairs_id"
+  - name: "Ground Floor"
+    id: "ground_floor_id"
+  - name: "First Floor"
+    id: "first_floor_id"
+  - name: "Second Floor"
+    id: "second_floor_id"
+  - name: "Basement"
+    id: "basement_id"
 areas:
   - name: "Guest Room"
     id: "guest_room_id"
     # prepositional floor
-    floor: "Upstairs"
+    floor: "upstairs_id"
 
   - name: "Outside"
     # prepositional area
     id: "outside_id"
-    floor: "Ground Floor"
+    floor: "ground_floor_id"
 
   - name: "Kitchen"
     id: "kitchen_id"
-    floor: "First Floor"
+    floor: "first_floor_id"
 
   - name: "Living Room"
     id: "living_room_id"
-    floor: "First Floor"
+    floor: "first_floor_id"
 
   - name: "Bedroom"
     id: "bedroom_id"
-    floor: "Second Floor"
+    floor: "second_floor_id"
 
   - name: "Garage"
     id: "garage_id"
-    floor: "First Floor"
+    floor: "first_floor_id"
 
   - name: "Entrance"
     id: "entrance_id"
-    floor: "First Floor"
+    floor: "first_floor_id"
 
   - name: "Office"
     id: "office_id"
-    floor: "Basement"
+    floor: "basement_id"
 entities:
   - name: "Bedroom Lamp"
     id: "light.bedroom_lamp"

--- a/tests/en/cover_HassGetState.yaml
+++ b/tests/en/cover_HassGetState.yaml
@@ -82,7 +82,7 @@ tests:
         floor: "First Floor"
         device_class: curtain
         state: "open"
-    response: "No, Bedroom Curtain and Curtain Right are not open"
+    response: "No, Curtain Right is not open"
 
   - sentences:
       - "which curtains are closed?"

--- a/tests/es/_fixtures.yaml
+++ b/tests/es/_fixtures.yaml
@@ -1,37 +1,48 @@
 language: es
+floors:
+  - name: "Planta alta"
+    id: upstairs_id
+  - name: "Planta baja"
+    id: ground_floor_id
+  - name: "Primera planta"
+    id: first_floor_id
+  - name: "Sótano"
+    id: basement_id
+  - name: "Planta suelo"
+    id: outside_id
 areas:
   - name: "Habitación de invitados"
     id: id_habitacion_invitados
-    floor: "Planta alta"
+    floor: upstairs_id
 
   - name: Fuera
     # área preposicional
     id: id_fuera
-    floor: "Planta suelo"
+    floor: outside_id
 
   - name: Cocina
     id: id_cocina
-    floor: "Planta baja"
+    floor: ground_floor_id
 
   - name: Salón
     id: id_salon
-    floor: "Planta baja"
+    floor: ground_floor_id
 
   - name: Dormitorio
     id: id_dormitorio
-    floor: "Primera planta"
+    floor: first_floor_id
 
   - name: Garaje
     id: id_garaje
-    floor: "Planta baja"
+    floor: ground_floor_id
 
   - name: Entrada
     id: id_entrada
-    floor: "Planta baja"
+    floor: ground_floor_id
 
   - name: Oficina
     id: id_oficina
-    floor: "Sótano"
+    floor: basement_id
 
 entities:
   - name: Lámpara de la mesilla

--- a/tests/es/cover_HassGetState.yaml
+++ b/tests/es/cover_HassGetState.yaml
@@ -79,7 +79,7 @@ tests:
         floor: "Primera planta"
         device_class: curtain
         state: "open"
-    response: "No, ni Cortina derecha ni Cortina dormitorio tienen el estado abiertas"
+    response: "No, el dispositivo Cortina dormitorio no tiene ese estado"
 
   - sentences:
       - "qué cortina está cerrada?"

--- a/tests/fr/_fixtures.yaml
+++ b/tests/fr/_fixtures.yaml
@@ -1,24 +1,29 @@
 language: fr
+floors:
+  - name: "Rez-De-Chaussée"
+    id: ground_floor_id
+  - name: "Premier Étage"
+    id: first_floor_id
 areas:
   - name: "cuisine"
     id: "kitchen"
-    floor: "Rez-De-Chaussée"
+    floor: ground_floor_id
 
   - name: "salon"
     id: "living_room"
-    floor: "Rez-De-Chaussée"
+    floor: ground_floor_id
 
   - name: "chambre"
     id: "bedroom"
-    floor: "Premier Étage"
+    floor: first_floor_id
 
   - name: "garage"
     id: "garage"
-    floor: "Rez-De-Chaussée"
+    floor: ground_floor_id
 
   - name: "entrée"
     id: "hall"
-    floor: "Rez-De-Chaussée"
+    floor: ground_floor_id
 
 entities:
   - name: "lumière du plafond"

--- a/tests/hu/_fixtures.yaml
+++ b/tests/hu/_fixtures.yaml
@@ -1,29 +1,36 @@
 language: hu
+floors:
+  - name: "első emelet"
+    id: first_floor_id
+  - name: "földszint"
+    id: ground_floor_id
+  - name: "pince"
+    id: basement_id
 areas:
   - name: konyha
     id: kitchen
-    floor: "első emelet"
+    floor: first_floor_id
   - name: nappali
     id: living_room
-    floor: "első emelet"
+    floor: first_floor_id
   - name: háló
     id: bedroom
-    floor: "első emelet"
+    floor: first_floor_id
   - name: garázs
     id: garage
-    floor: "első emelet"
+    floor: first_floor_id
   - name: terasz
     id: terrace
-    floor: "első emelet"
+    floor: first_floor_id
   - name: kint
     id: outdoor
-    floor: "földszint"
+    floor: ground_floor_id
   - name: iroda
     id: office
-    floor: "pince"
+    floor: basement_id
   - name: bejárat
     id: entrance
-    floor: "földszint"
+    floor: ground_floor_id
 
 entities:
   - name: éjjeli lámpa 1

--- a/tests/nb/_fixtures.yaml
+++ b/tests/nb/_fixtures.yaml
@@ -1,28 +1,35 @@
 language: nb
+floors:
+  - name: "Første etasje"
+    id: first_floor_id
+  - name: "Andre etasje"
+    id: second_floor_id
+  - name: "Kjeller"
+    id: basement_id
 areas:
   - name: Kjøkken
     id: kitchen
-    floor: Første etasje
+    floor: first_floor_id
 
   - name: Stue
     id: living_room
-    floor: Første etasje
+    floor: first_floor_id
 
   - name: Soverom
     id: bedroom
-    floor: Andre etasje
+    floor: second_floor_id
 
   - name: Garasje
     id: garage
-    floor: Kjeller
+    floor: basement_id
 
   - name: Bad
     id: bathroom
-    floor: Andre etasje
+    floor: second_floor_id
 
   - name: Inngang
     id: entrance
-    floor: Første etasje
+    floor: first_floor_id
 
 entities:
   - name: Soveromlampe

--- a/tests/pt-br/_fixtures.yaml
+++ b/tests/pt-br/_fixtures.yaml
@@ -1,28 +1,34 @@
 language: pt-br
+floors:
+  - name: "Térreo"
+    id: ground_floor_id
+  - name: "Primeiro andar"
+    id: first_floor_id
+
 areas:
   - name: "Cozinha"
     id: "cozinha"
-    floor: "Térreo"
+    floor: ground_floor_id
 
   - name: "Sala de Estar"
     id: "sala_de_estar"
-    floor: "Térreo"
+    floor: ground_floor_id
 
   - name: "Quarto"
     id: "quarto"
-    floor: "Primeiro andar"
+    floor: first_floor_id
 
   - name: "Garagem"
     id: "garagem"
-    floor: "Térreo"
+    floor: ground_floor_id
 
   - name: "Entrada"
     id: "entrada"
-    floor: "Térreo"
+    floor: ground_floor_id
 
   - name: "Sala"
     id: "sala"
-    floor: "Térreo"
+    floor: ground_floor_id
 
 entities:
   - name: "Luz do Quarto"

--- a/tests/ro/_fixtures.yaml
+++ b/tests/ro/_fixtures.yaml
@@ -1,26 +1,33 @@
 language: ro
+floors:
+  - name: "Parter"
+    id: ground_floor_id
+  - name: "Primul etaj"
+    id: first_floor_id
+  - name: "Afara"
+    id: outside_id
 areas:
   - name: "Bucatarie"
     id: kitchen
-    floor: Parter
+    floor: ground_floor_id
   - name: "Sufragerie"
     id: living_room
-    floor: Parter
+    floor: ground_floor_id
   - name: "Dormitor"
     id: bedroom
-    floor: Primul etaj
+    floor: first_floor_id
   - name: "Garaj"
     id: garage
-    floor: Afara
+    floor: outside_id
   - name: "Hol"
     id: hall
-    floor: Primul etaj
+    floor: first_floor_id
   - name: "Intrare"
     id: entrance
-    floor: Primul etaj
+    floor: first_floor_id
   - name: "Curte"
     id: frontyard
-    floor: Afara
+    floor: outside_id
 entities:
   # Lights
   - name: "lustra"

--- a/tests/sl/_fixtures.yaml
+++ b/tests/sl/_fixtures.yaml
@@ -1,14 +1,23 @@
 language: sl
+floors:
+  - name: "pritlič(ju|e)"
+    id: ground_floor_id
+  - name: "klet[i]"
+    id: basement_id
+  - name: "drug(o|em) nadstropj(e|u)"
+    id: second_floor_id
+  - name: "prv(o|em) nadstropj(u|e)"
+    id: first_floor_id
 areas:
   - name: "spalnic(i|a|o|e)"
     id: bedroom
-    floor: "drug(o|em) nadstropj(e|u)"
+    floor: second_floor_id
   - name: "garaž(a|e|i|o|na|ne|ni)"
     id: garage
-    floor: "pritlič(ju|e)"
+    floor: ground_floor_id
   - name: "pisarn(a|i|o)|kabinet(a|u)"
     id: office
-    floor: "klet[i]"
+    floor: basement_id
   - name: "balkon(u)"
     id: balcony
   - name: "teras(a|i|o)"
@@ -29,16 +38,16 @@ areas:
     id: staircase
   - name: "kuhinj(o|a|i|ska|sko|ski|ske)"
     id: kitchen
-    floor: "prv(o|em) nadstropj(u|e)"
+    floor: first_floor_id
   - name: "dnevna soba|dnevni sobi|dnevne sobe|dnevn(a|i)"
     id: living_room
-    floor: "prv(o|em) nadstropj(u|e)"
+    floor: first_floor_id
   - name: "kopalni(ca|ci|co|cah|cama|ška|ški|ške|ško)"
     id: bathroom
-    floor: "drug(o|em) nadstropj(u|e)"
+    floor: second_floor_id
   - name: "utility"
     id: utility
-    floor: "klet[i]"
+    floor: basement_id
 entities:
   - name: "luč[ko|i|ka] v spalnici"
     id: light.bedroom_lamp

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -17,9 +17,11 @@ from yaml import safe_load
 
 from shared import (
     AreaEntry,
+    FloorEntry,
     State,
     Timer,
     get_areas,
+    get_floors,
     get_matched_states,
     get_matched_timers,
     get_slot_lists,
@@ -67,6 +69,13 @@ def areas_fixture(language: str) -> List[AreaEntry]:
     return get_areas(fixtures)
 
 
+@pytest.fixture(name="floors", scope="session")
+def floors_fixture(language: str) -> List[FloorEntry]:
+    """Loads test floors for the language."""
+    fixtures = load_test(language, "_fixtures")
+    return get_floors(fixtures)
+
+
 @pytest.fixture(name="timers", scope="session")
 def timers_fixture(language: str) -> List[Timer]:
     """Loads test timers for the language."""
@@ -82,6 +91,7 @@ def do_test_language_sentences_file(
     slot_lists: dict[str, SlotList],
     states: List[State],
     areas: List[AreaEntry],
+    floors: List[FloorEntry],
     timers: List[Timer],
     language_sentences: Intents,
     language_responses: dict[str, Any],
@@ -238,7 +248,9 @@ def do_test_language_sentences_file(
                         response_template_str
                     ), f"No response template for intent {result.intent.name} named {actual_response_key}: {sentence}"
 
-                    matched, unmatched = get_matched_states(states, areas, result)
+                    matched, unmatched = get_matched_states(
+                        states, areas, floors, result
+                    )
                     actual_response_text = render_response(
                         response_template_str,
                         result,
@@ -266,6 +278,7 @@ def gen_test(test_file_stem: str) -> None:
         slot_lists: dict[str, SlotList],
         states: List[State],
         areas: List[AreaEntry],
+        floors: List[FloorEntry],
         timers: List[Timer],
         language_sentences: Intents,
         language_responses: dict[str, Any],
@@ -278,6 +291,7 @@ def gen_test(test_file_stem: str) -> None:
             slot_lists=slot_lists,
             states=states,
             areas=areas,
+            floors=floors,
             timers=timers,
             language_sentences=language_sentences,
             language_responses=language_responses,

--- a/tests/uk/_fixtures.yaml
+++ b/tests/uk/_fixtures.yaml
@@ -1,14 +1,20 @@
 language: uk
+floors:
+  - name: "Перш(ий|ому) повер(х|сі)"
+    id: first_floor_id
+  - name: "Друг(ий|ому) повер(х|сі)"
+    id: second_floor_id
+
 areas:
   - name: Кухн(я|і)
     id: kitchen
-    floor: Перш(ий|ому) повер(х|сі)
+    floor: first_floor_id
   - name: Вітальн(я|і)
     id: living_room
-    floor: Перш(ий|ому) повер(х|сі)
+    floor: first_floor_id
   - name: Спальн(я|і)
     id: bedroom
-    floor: Друг(ий|ому) повер(х|сі)
+    floor: second_floor_id
   - name: Гараж[і]
     id: garage
 

--- a/tests/zh-hk/_fixtures.yaml
+++ b/tests/zh-hk/_fixtures.yaml
@@ -1,29 +1,36 @@
 language: zh-hk
+floors:
+  - name: "First Floor"
+    id: first_floor_id
+  - name: "Second Floor"
+    id: second_floor_id
+  - name: "Basement"
+    id: basement_id
 areas:
   - name: "廚房"
     id: kitchen
     # prepositional floor
-    floor: "First Floor"
+    floor: first_floor_id
 
   - name: "客廳"
     id: living_room
-    floor: "First Floor"
+    floor: first_floor_id
 
   - name: "睡房"
     id: bedroom
-    floor: "Second Floor"
+    floor: second_floor_id
 
   - name: "車房"
     id: garage
-    floor: "First Floor"
+    floor: first_floor_id
 
   - name: "玄關"
     id: entrance
-    floor: "First Floor"
+    floor: first_floor_id
 
   - name: "辦公室"
     id: office
-    floor: "Basement"
+    floor: basement_id
 
 entities:
   - name: "廚房開關制"


### PR DESCRIPTION
Adds a proper "floors" section to the test fixtures, and uses floors correctly during matching.
The `floor` property of an area is now the **floor id** rather than the floor name:

```yaml
floors:
  - name: "Upstairs"
    id: "upstairs_id"
areas:
  - name: "Guest Room"
    id: "guest_room_id"
    floor: "upstairs_id"
```