### PR TITLE
Use trie to filter name slot list before matching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hassil==2.0.3
+hassil==2.0.4
 PyYAML==6.0.2
 voluptuous==0.15.2
 regex==2024.11.6


### PR DESCRIPTION
Filter the `{name}` slot list before matching using a trie and the input text. This speeds up tests by around 10-15%.