### PR TITLE
ci: improve readability of sentence_count check

### DIFF
--- a/.github/actions/count-words/action.yml
+++ b/.github/actions/count-words/action.yml
@@ -39,9 +39,10 @@ runs:
         if [ $(wc -l < ${SUMMARY_FILE}) -eq 2 ]; then
           PREV_COUNT=$(sed -n '1p' ${SUMMARY_FILE} | awk '{print $NF}')
           NEW_COUNT=$(sed -n '2p' ${SUMMARY_FILE} | awk '{print $NF}')
-          DIFF=$((NEW_COUNT - PREV_COUNT))
+          DIFF_ABS=$((NEW_COUNT - PREV_COUNT))
+          DIFF_REL=$((100 * DIFF_ABS / PREV_COUNT))
           echo "" >> ${SUMMARY_FILE}
-          echo "New count: $DIFF" | tee -a ${SUMMARY_FILE}
+          LC_ALL=en_US.UTF-8 printf "New count: %'i (%i%%)\n" $DIFF_ABS $DIFF_REL | tee -a ${SUMMARY_FILE}
         fi
 
     - uses: mshick/add-pr-comment@v2


### PR DESCRIPTION
Improve readability of the difference in counted sentences (see https://github.com/home-assistant/intents/pull/2630). Especially beneficial with larger numbers (compare 100000000 to 100,000,000). Also added relative difference in percent.

Before:
```
Counting previous sentences for language: en: 403495
Counting **NEW** sentences for language: en: 103495

New count: -300000
```

After:
```
Counting previous sentences for language: en: 403495
Counting **NEW** sentences for language: en: 103495

New count: -300,000 (-74%)
```
