### PR TITLE
[NL] fix some spelling mistake

### DIFF
--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -129,7 +129,7 @@ responses:
         "valve": "klep"
         } %}
       {% if domain in translations -%}
-        Sorry, ik kan geen {{ translations[domain] }} vinden in {{ area }}"
+        Sorry, ik kan geen {{ translations[domain] }} vinden in {{ floor }}"
       {%- else -%}
         Sorry, ik kan in {{ floor }} geen apparaat van dat type vinden.
       {%- endif %}
@@ -152,7 +152,7 @@ responses:
       {%- endif %}
     no_entity_in_floor: "Sorry, ik kan geen apparaat met de naam {{ entity }} in {{ floor }} vinden"
     entity_wrong_state: "Sorry, geen enkel apparaat heeft de status {{ state | lower }}"
-    feature_not_supported: "Sorry, er is geen appararaat wat dit ondersteund."
+    feature_not_supported: "Sorry, er is geen apparaat wat dit ondersteund."
 
     # Errors for when user is logged in and we can give more information
     no_entity_exposed: "Sorry, {{ entity }} is niet ontsloten"


### PR DESCRIPTION
I think it was meant to be `floor` instead of `area` as every other language uses `floor` for this message and it is located inside `no_domain_in_floor`