### PR TITLE
[FR] overhaul of the weather intent, with detailed report

### DIFF
--- a/responses/fr/HassGetWeather.yaml
+++ b/responses/fr/HassGetWeather.yaml
@@ -3,22 +3,189 @@ responses:
   intents:
     HassGetWeather:
       default: >
-        {% set weather_condition = {
-          'clear': 'et le temps est clair',
-          'clear-night': 'et la nuit est claire',
-          'cloudy': 'et le temps est nuageux',
-          'exceptional': 'et les conditions météos sont exceptionnelles',
-          'fog': 'avec du brouillard',
-          'hail': 'avec de la grêle',
-          'lightning': 'avec de l\'orage',
-          'lightning-rainy': 'avec de l\'orage et de la pluie',
-          'partlycloudy': 'et un temps partiellement nuageux',
-          'pouring': 'et une pluie battante',
-          'rainy': 'et de la pluie',
-          'snowy': 'et de la neige',
-          'snowy-rainy': 'avec pluie et neige mêlées',
-          'sunny': 'et un temps ensoleillé',
-          'windy': 'avec un temps venteux',
-          'windy-variant': 'et un temps variable et venteux'
-        } %}
-        {{ state.attributes.get('temperature') }} {{ state.attributes.get('temperature_unit') }} {{ weather_condition.get((state.state | string).lower(), "") }}
+        {# Reuse weather condition already formatted and translated #}
+        {# just invert telling the condition then temperature #}
+        {{ state.state }}
+
+        {% set temperature = state.attributes.get('temperature') %}
+        {% if temperature is number %}
+          {% if temperature < 0 %}
+            {% set temperature_string = 'moins ' ~ (temperature * -1) | string | replace('.', ',') %}
+          {% else %}
+            {% set temperature_string = temperature | string | replace('.', ',') %}
+          {% endif %}
+          {% set temperature_unit = state.attributes.get('temperature_unit', '') %}
+          et il fait {{ temperature_string }} {{ temperature_unit.replace('°C', 'degrés') }}.
+        {% endif %}
+
+      # Starting from here, heavily inspired by the Hungarian template, kudos to RViktor
+      wind: >
+        {% set wind_speed = state.attributes.get('wind_speed') %}
+        {% set wind_speed_unit = state.attributes.get('wind_speed_unit', '') %}
+        {% set wind_bearing = state.attributes.get('wind_bearing') %}
+        {% set wind_gust_speed = state.attributes.get('wind_gust_speed') %}
+
+        {# Compute the Beaufort scale when possible #}
+        {% set beaufort_scale = '' %}
+        {% set wind_speed_ms = none %}
+        {% if wind_speed_unit == 'm/s' %}
+          {% set wind_speed_ms = wind_speed %}
+        {% elif wind_speed_unit == 'km/h' %}
+          {% set wind_speed_ms = wind_speed / 3.6 %}
+        {% endif %}
+        {% if wind_speed_ms is number %}
+          {# Borrowed from the speed converter in core, better to have a convert filter #}
+          {# Rounding is important, we want 3.9 to become 4, not 3 #}
+          {% set beaufort_force = (((wind_speed_ms / 0.836) ** 2) ** (1 / 3)) | round | int %}
+          {% set beaufort_scale = {
+            0: 'Vent calme',
+            1: 'Très légère brise',
+            2: 'Légère brise',
+            3: 'Petite brise',
+            4: 'Jolie brise',
+            5: 'Bonne brise',
+            6: 'Forte brise',
+            7: 'Grosse brise',
+            8: 'Coup de vent',
+            9: 'Fort coup de vent',
+            10: 'Tempête',
+            11: 'Violente tempête',
+            12: "Vent d'ouragan",
+          }.get(beaufort_force, 'Vent') %}
+        {% elif wind_speed is number %}
+          {# Other wind speed unit, no scale, just the speed #}
+          {% set beaufort_scale = 'Vent' %}
+        {% endif %}
+
+        {% set wind_bearing_text = '' %}
+        {% if wind_bearing is number %}
+          {% if wind_bearing < 45 %}
+            {% set wind_bearing_text = 'venant du nord' %}
+          {% elif wind_bearing < 90 %}
+            {% set wind_bearing_text = 'venant du nord-est' %}
+          {% elif wind_bearing < 135 %}
+            {% set wind_bearing_text = "venant de l'est" %}
+          {% elif wind_bearing < 180 %}
+            {% set wind_bearing_text = 'venant du sud-est' %}
+          {% elif wind_bearing < 225 %}
+            {% set wind_bearing_text = 'venant du sud' %}
+          {% elif wind_bearing < 270 %}
+            {% set wind_bearing_text = 'venant du sud-ouest' %}
+          {% elif wind_bearing < 315 %}
+            {% set wind_bearing_text = "venant de l'ouest" %}
+          {% elif wind_bearing <= 360 %}
+            {% set wind_bearing_text = 'venant du nord-ouest' %}
+          {% endif %}
+        {% endif %}
+
+        {# Help Piper pronounce units in a more natural way #}
+        {% set wind_speed_unit = {
+          'm/s': 'mètres par seconde',
+          'km/h': 'kilomètres par heure',
+          'mi/h': 'miles par heure',
+          'ft/s': 'pieds par seconde',
+          'kn': 'nœuds',
+        }.get(wind_speed_unit, wind_speed_unit) %}
+
+        {% if beaufort_scale and wind_bearing_text and wind_gust_speed is number %}
+          {{ beaufort_scale }} de {{ wind_speed | int }} {{ wind_speed_unit }} {{ wind_bearing_text }}, avec des rafales à {{ wind_gust_speed | int }} {{ wind_speed_unit }}.
+        {% elif beaufort_scale and wind_bearing_text %}
+          {{ beaufort_scale }} de {{ wind_speed | int }} {{ wind_speed_unit }} {{ wind_bearing_text }}.
+        {% elif beaufort_scale and wind_gust_speed is number %}
+          {{ beaufort_scale }} de {{ wind_speed | int }} {{ wind_speed_unit }}, avec des rafales à {{ wind_gust_speed | int }} {{ wind_speed_unit }}.
+        {% elif beaufort_scale %}
+          {{ beaufort_scale }} de {{ wind_speed | int }} {{ wind_speed_unit }}.
+        {% else %}
+          Aucune information météo sur le vent n'est disponible.
+        {% endif %}
+
+      pressure: >
+        {% set pressure = state.attributes.get('pressure') %}
+
+        {% if pressure is number %}
+          {% set pressure_unit = state.attributes.get('pressure_unit', '') %}
+          La pression atmosphérique est de : {{ pressure | int }} {{ pressure_unit.replace('hPa', 'hectopascal') }}.
+        {% else %}
+          La pression atmosphérique n'est pas pas disponible.
+        {% endif %}
+
+      uv: >
+        {% set uv_index = state.attributes.get('uv_index') %}
+
+        {% if uv_index is number %}
+          {% set uv_scale = '' %} {# Global standard #}
+          {% if uv_index <= 2 %}
+            {% set uv_scale = 'faible' %}
+          {% elif uv_index <= 5 %}
+            {% set uv_scale = 'modéré' %}
+          {% elif uv_index <= 7 %}
+            {% set uv_scale = 'élevé' %}
+          {% elif uv_index <= 10 %}
+            {% set uv_scale = 'très élevé' %}
+          {% else %}
+            {% set uv_scale = 'extrême' %}
+          {% endif %}
+          L'indice UV est de : {{ uv_index | int }} - {{ uv_scale }}
+        {% else %}
+          L'indice UV n'est pas pas disponible.
+        {% endif %}
+
+      detailed_weather: >
+        {# Reuse weather condition already formatted and translated #}
+        {{ state.state }}
+
+        {% set temperature = state.attributes.get('temperature') %}
+        {% if temperature is number %}
+          {% if temperature < 0 %}
+            {% set temperature_string = 'moins ' ~ (temperature * -1) | string | replace('.', ',') %}
+          {% else %}
+            {% set temperature_string = temperature | string | replace('.', ',') %}
+          {% endif %}
+          {% set temperature_unit = state.attributes.get('temperature_unit', '') %}
+          et il fait {{ temperature_string }} {{ temperature_unit.replace('°C', 'degrés') }}.
+        {% else %}
+          . {# Just finish the sentence #}
+        {% endif %}
+
+        {% set humidity = state.attributes.get('humidity') %}
+        {% if humidity is number %}
+          Humidité : {{ humidity }}%.
+        {% endif %}
+
+        {% set wind_speed = state.attributes.get('wind_speed') %}
+        {% set wind_speed_unit = state.attributes.get('wind_speed_unit', '') %}
+        {% set wind_gust_speed = state.attributes.get('wind_gust_speed') %}
+
+        {# Compute the Beaufort scale when possible #}
+        {% set beaufort_force = none %}
+        {% set wind_speed_ms = none %}
+        {% if wind_speed_unit == 'm/s' %}
+          {% set wind_speed_ms = wind_speed %}
+        {% elif wind_speed_unit == 'km/h' %}
+          {% set wind_speed_ms = wind_speed / 3.6 %}
+        {% endif %}
+        {% if wind_speed_ms is number %}
+          {# Rounding is important, we want 3.9 to become 4, not 3 #}
+          {% set beaufort_force = (((wind_speed_ms / 0.836) ** 2) ** (1 / 3)) | round | int %}
+        {% endif %}
+
+        {# Help Piper pronounce units in a more natural way #}
+        {% set wind_speed_unit = {
+          'm/s': 'mètres par seconde',
+          'km/h': 'kilomètres par heure',
+          'mi/h': 'miles par heure',
+          'ft/s': 'pieds par seconde',
+          'kn': 'nœuds',
+        }.get(wind_speed_unit, wind_speed_unit) %}
+
+        {% if beaufort_force and wind_gust_speed is number %}
+          Vent de force : {{ beaufort_force }}, avec des rafales.
+        {% elif beaufort_force %}
+          Vent de force : {{ beaufort_force }}.
+        {% elif wind_speed is number and wind_gust_speed is number %}
+          Vent de {{ wind_speed | int }} {{ wind_speed_unit }}, avec des rafales.
+        {% elif wind_speed is number %}
+          Vent de {{ wind_speed | int }} {{ wind_speed_unit }}.
+        {% elif wind_gust_speed is number %}
+          Rafales de {{ wind_gust_speed | int }} {{ wind_speed_unit }}.
+        {% endif %}

--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -485,6 +485,7 @@ expansion_rules:
   de: "(du|de|des)"
   tous: "(tout|tous|toute[s])"
   completement: "(complètement|totalement|entièrement)"
+  aujourdhui: "(aujourd'hui|maintenant|actuellement)"
 
   # Context awareness
   maison: maison|domicile|appartement|appart|logement
@@ -587,6 +588,7 @@ expansion_rules:
   atil: "(ont|a)[-][ ][t][ ][-][(il[s]|elle[s])]"
   quel: "quel[le][s]"
   quelest: "<quel> (est|sont)"
+  donnemoi: "(donne[s]|dis)[(-| )moi]"
 
 skip_words:
   - "s'il te plaît"

--- a/sentences/fr/weather_HassGetWeather.yaml
+++ b/sentences/fr/weather_HassGetWeather.yaml
@@ -3,12 +3,62 @@ intents:
   HassGetWeather:
     data:
       - sentences:
-          - "(<quelest>|donne[s][-moi]) (le|la|les) (temps|météo)"
-          - "(Donne[s]( |-)moi|Dis( |-)moi) le temps qu'il fait"
+          - "(<quelest>|<donnemoi>) (le|la|les) (temps|météo)"
+          - "<donnemoi> le temps qu'il fait"
           - "Quel temps fait-il"
       - sentences:
-          - "(<quelest>|donne[s][-moi]) (le|la|les) (temps|météo) (pour|à) [<le>]{name}"
-          - "(Donne-moi|Dis-moi) le temps qu'il fait à [<le>]{name}"
+          - "(<quelest>|<donnemoi>) (le|la|les) (temps|météo) (pour|à) [<le>]{name}"
+          - "<donnemoi> le temps qu'il fait à [<le>]{name}"
           - "Quel temps fait-il à [<le>]{name}"
         requires_context:
           domain: weather
+
+      - sentences:
+          - "[<donnemoi> (un[e]|le)] (bulletin|rapport) météo [détaillé[e]]"
+          - "(<quelest>|<donnemoi>) (le|la|les) (temps|météo) (détaillé[e]|en détail)"
+          - "<donnemoi> le temps qu'il fait en détail"
+          - "<donnemoi> le détail du temps qu'il fait"
+        response: detailed_weather
+      - sentences:
+          - "[<donnemoi> (un[e]|le)] (bulletin|rapport) météo [détaillé[e]] (pour|à) [<le>]{name}"
+          - "(<quelest>|<donnemoi>) (le|la|les) (temps|météo) (détaillé[e]|en détail) (pour|à) [<le>]{name}"
+          - "<donnemoi> le temps qu'il fait en détail à [<le>]{name}"
+          - "<donnemoi> le détail du temps qu'il fait à [<le>]{name}"
+        requires_context:
+          domain: weather
+        response: detailed_weather
+
+      - sentences:
+          - "[(<quelest>|<donnemoi>) la] pression atmosphérique [<aujourdhui>]"
+        response: pressure
+      - sentences:
+          - "[(<quelest>|<donnemoi>) la] pression atmosphérique [<aujourdhui>] (pour|à) [<le>]{name}"
+        requires_context:
+          domain: weather
+        response: pressure
+
+      - sentences:
+          - "[(<quelest>|<donnemoi>) l']indice UV [<aujourdhui>]"
+        response: uv
+      - sentences:
+          - "[(<quelest>|<donnemoi>) l']indice UV [<aujourdhui>] (pour|à) [<le>]{name}"
+        requires_context:
+          domain: weather
+        response: uv
+
+      - sentences:
+          - "(<quelest>|<donnemoi>) la (vitesse|force) du vent [<aujourdhui>]"
+          - "(À|A) <quel> vitesse le vent souffle [<aujourdhui>]"
+          - "[(<quelest>|<donnemoi>) la] météo du vent [<aujourdhui>]"
+          - "(<quelest>|<donnemoi>) le détail du vent [<aujourdhui>]"
+          - "<yatil> du vent [<aujourdhui>]"
+        response: wind
+      - sentences:
+          - "(<quelest>|<donnemoi>) la vitesse du vent [<aujourdhui>] à [<le>]{name}"
+          - "(À|A) <quel> vitesse le vent souffle [<aujourdhui>] à [<le>]{name}"
+          - "[(<quelest>|<donnemoi>) la] météo du vent [<aujourdhui>] (pour|à) [<le>]{name}"
+          - "(<quelest>|<donnemoi>) le détail du vent (pour|à) [<le>]{name}"
+          - "<yatil> du vent [<aujourdhui>] à [<le>]{name}"
+        requires_context:
+          domain: weather
+        response: wind

--- a/tests/fr/_fixtures.yaml
+++ b/tests/fr/_fixtures.yaml
@@ -770,17 +770,23 @@ entities:
 
   - name: "Paris"
     id: "weather.paris"
-    state: "rainy"
+    state: Pluvieux
     attributes:
-      temperature: "10"
+      temperature: 10.3
       temperature_unit: "°C"
+      humidity: 85
+      wind_speed: 23.5
+      wind_speed_unit: "km/h"
 
   - name: "Brest"
     id: "weather.brest"
-    state: "sunny"
+    state: Ensoleillé
     attributes:
-      temperature: "25"
+      temperature: 24.9
       temperature_unit: "°C"
+      pressure: 1017
+      pressure_unit: "hPa"
+      uv_index: 5
 
   - name: "Joseph"
     id: "person.jospeh"

--- a/tests/fr/weather_HassGetWeather.yaml
+++ b/tests/fr/weather_HassGetWeather.yaml
@@ -1,12 +1,13 @@
 language: fr
 tests:
+  # Default response
   - sentences:
-      - "Quel temps fait-il"
       - "Donne-moi la météo"
       - "Donne moi le temps qu'il fait"
+      - "Quel temps fait-il"
     intent:
       name: HassGetWeather
-    response: 10 °C et de la pluie
+    response: Pluvieux et il fait 10,3 degrés.
   - sentences:
       - "Quel temps fait-il à Paris"
       - "Donne-moi la météo à Paris"
@@ -14,7 +15,7 @@ tests:
       name: HassGetWeather
       slots:
         name: Paris
-    response: 10 °C et de la pluie
+    response: Pluvieux et il fait 10,3 degrés.
 
   - sentences:
       - "Quel temps fait-il à Brest"
@@ -22,4 +23,109 @@ tests:
       name: HassGetWeather
       slots:
         name: Brest
-    response: 25 °C et un temps ensoleillé
+    response: Ensoleillé et il fait 24,9 degrés.
+
+  # Detailed response
+  - sentences:
+      - "Donne-moi le bulletin météo"
+      - "Donne moi la météo en détail"
+      - "Quelle est la météo détaillée"
+      - "Donne-moi le temps qu'il fait en détail"
+      - "Donne moi le détail du temps qu'il fait"
+    intent:
+      name: HassGetWeather
+    response: "Pluvieux et il fait 10,3 degrés. Humidité : 85%. Vent de force : 4."
+  - sentences:
+      - "Donne-moi le bulletin météo pour Paris"
+      - "Donne moi la météo en détail à Paris"
+      - "Quelle est la météo détaillée pour Paris"
+      - "Donne-moi le temps qu'il fait en détail à Paris"
+      - "Donne moi le détail du temps qu'il fait à Paris"
+    intent:
+      name: HassGetWeather
+      slots:
+        name: Paris
+    response: "Pluvieux et il fait 10,3 degrés. Humidité : 85%. Vent de force : 4."
+  - sentences:
+      - "Donne-moi le bulletin météo pour Brest"
+      - "Donne moi la météo en détail à Brest"
+      - "Quelle est la météo détaillée pour Brest"
+      - "Donne-moi le temps qu'il fait en détail à Brest"
+      - "Donne moi le détail du temps qu'il fait à Brest"
+    intent:
+      name: HassGetWeather
+      slots:
+        name: Brest
+    response: "Ensoleillé et il fait 24,9 degrés."
+
+  - sentences:
+      - "Donne-moi la pression atmosphérique"
+    intent:
+      name: HassGetWeather
+    response: La pression atmosphérique n'est pas pas disponible.
+  - sentences:
+      - "Donne-moi la pression atmosphérique aujourd'hui pour Paris"
+    intent:
+      name: HassGetWeather
+      slots:
+        name: Paris
+    response: La pression atmosphérique n'est pas pas disponible.
+  - sentences:
+      - "Donne-moi la pression atmosphérique aujourd'hui pour Brest"
+    intent:
+      name: HassGetWeather
+      slots:
+        name: Brest
+    response: "La pression atmosphérique est de : 1017 hectopascal."
+
+  - sentences:
+      - "Donne-moi l'indice UV"
+    intent:
+      name: HassGetWeather
+    response: L'indice UV n'est pas pas disponible.
+  - sentences:
+      - "Donne-moi l'indice UV aujourd'hui pour Paris"
+    intent:
+      name: HassGetWeather
+      slots:
+        name: Paris
+    response: L'indice UV n'est pas pas disponible.
+  - sentences:
+      - "Donne-moi l'indice UV aujourd'hui pour Brest"
+    intent:
+      name: HassGetWeather
+      slots:
+        name: Brest
+    response: "L'indice UV est de : 5 - modéré"
+
+  - sentences:
+      - "Donne-moi la vitesse du vent"
+      - "À quelle vitesse le vent souffle aujourd'hui"
+      - "Quelle est la météo du vent"
+      - "Donne moi le détail du vent"
+      - "y a-t-il du vent aujourd'hui"
+    intent:
+      name: HassGetWeather
+    response: Jolie brise de 23 kilomètres par heure.
+  - sentences:
+      - "Donne-moi la vitesse du vent à Paris"
+      - "À quelle vitesse le vent souffle aujourd'hui à Paris"
+      - "Quelle est la météo du vent pour Paris"
+      - "Donne moi le détail du vent pour Paris"
+      - "y a-t-il du vent aujourd'hui à Paris"
+    intent:
+      name: HassGetWeather
+      slots:
+        name: Paris
+    response: Jolie brise de 23 kilomètres par heure.
+  - sentences:
+      - "Donne-moi la vitesse du vent à Brest"
+      - "À quelle vitesse le vent souffle aujourd'hui à Brest"
+      - "Quelle est la météo du vent pour Brest"
+      - "Donne moi le détail du vent pour Brest"
+      - "y a-t-il du vent aujourd'hui à Brest"
+    intent:
+      name: HassGetWeather
+      slots:
+        name: Brest
+    response: Aucune information météo sur le vent n'est disponible.


### PR DESCRIPTION
The current one would never give the weather condition, as the state was never "clear" or "sunny", but in French already.

The wind description is using the Beaufort scale.

Heavily inspired by the Hungarian template, kudos to RViktor!

I'd like to push it even further, with sentences like "va-t-il pleuvoir/neiger/geler ?", but it requires the Météo-France integration, which not everyone has. I stick to the built-in Met.no integration. Unless there is a way to ship intents along with the Météo-France integration itself.

A more reasonable next step would be "quelle est la météo pour demain ?".