### PR TITLE
[EN] HassGetState floor support

### DIFF
--- a/sentences/en/homeassistant_HassGetState.yaml
+++ b/sentences/en/homeassistant_HassGetState.yaml
@@ -3,14 +3,14 @@ intents:
   HassGetState:
     data:
       - sentences:
-          - (do you know|tell me|<what_is>) [the [current] (state|value) of] <name> [in <area>]
+          - (do you know|tell me|<what_is>) [the [current] (state|value) of] <name> [<in_area_floor>]
         response: one
         excludes_context:
           domain:
             - scene
             - script
       - sentences:
-          - is [the] [state of] <name> {on_off_states:state} [in <area>]
+          - is [the] [state of] <name> {on_off_states:state} [<in_area_floor>]
         response: one_yesno
         excludes_context:
           domain:
@@ -18,19 +18,19 @@ intents:
             - binary_sensor
 
       - sentences:
-          - (is|are) [there] any {on_off_domains:domain} {on_off_states:state} [in <area>]
-          - (do you know|tell me) if there are any {on_off_domains:domain} {on_off_states:state} [in <area>]
+          - (is|are) [there] any {on_off_domains:domain} {on_off_states:state} [<in_area_floor>]
+          - (do you know|tell me) if there are any {on_off_domains:domain} {on_off_states:state} [<in_area_floor>]
         response: any
 
       - sentences:
-          - are all [the] {on_off_domains:domain} [(switched|turned|set [to])] {on_off_states:state} [in <area>]
-          - are all [the] {on_off_domains:domain} in <area> [(switched|turned|set [to])] {on_off_states:state}
+          - are all [the] {on_off_domains:domain} [(switched|turned|set [to])] {on_off_states:state} [<in_area_floor>]
+          - are all [the] {on_off_domains:domain} <in_area_floor> [(switched|turned|set [to])] {on_off_states:state}
         response: all
 
       - sentences:
-          - "[do you know] (which|what) {on_off_domains:domain} (is|are) {on_off_states:state} [in <area>]"
+          - "[do you know] (which|what) {on_off_domains:domain} (is|are) {on_off_states:state} [<in_area_floor>]"
         response: which
 
       - sentences:
-          - "[tell me] how many {on_off_domains:domain} (is|are) {on_off_states:state} [in <area>]"
+          - "[tell me] how many {on_off_domains:domain} (is|are) {on_off_states:state} [<in_area_floor>]"
         response: how_many

--- a/tests/en/homeassistant_HassGetState.yaml
+++ b/tests/en/homeassistant_HassGetState.yaml
@@ -20,10 +20,22 @@ tests:
 
   - sentences:
       - "are any switches on in the kitchen?"
+      - "tell me if there are any switches on in the kitchen"
     intent:
       name: HassGetState
       slots:
         area: "Kitchen"
+        domain: "switch"
+        state: "on"
+    response: "Yes, Kitchen Switch"
+
+  - sentences:
+      - "are there any switches on at the first floor?"
+      - "tell me if there are any switches on at the first floor"
+    intent:
+      name: HassGetState
+      slots:
+        floor: "First Floor"
         domain: "switch"
         state: "on"
     response: "Yes, Kitchen Switch"
@@ -36,6 +48,30 @@ tests:
         domain: "switch"
         state: "on"
     response: "No, Bedroom Switch is not on"
+
+  - sentences:
+      - "are all switches on in the kitchen?"
+      - "are all the switches turned on in the kitchen?"
+      - "are all switches in the kitchen on?"
+    intent:
+      name: HassGetState
+      slots:
+        area: "Kitchen"
+        domain: "switch"
+        state: "on"
+    response: "Yes"
+
+  - sentences:
+      - "are all switches on at the first floor?"
+      - "are all the switches turned on at the first floor?"
+      - "are all switches at the first floor on?"
+    intent:
+      name: HassGetState
+      slots:
+        floor: "First Floor"
+        domain: "switch"
+        state: "on"
+    response: "Yes"
 
   - sentences:
       - "are all lights off?"
@@ -56,6 +92,26 @@ tests:
     response: "Garage Light, Kitchen cabinets, Kitchen ceiling and 3 more"
 
   - sentences:
+      - "which lights are on in the kitchen?"
+    intent:
+      name: HassGetState
+      slots:
+        area: "Kitchen"
+        domain: "light"
+        state: "on"
+    response: "Kitchen cabinets, Kitchen ceiling and Kitchen countertop"
+
+  - sentences:
+      - "which lights are on at the first floor?"
+    intent:
+      name: HassGetState
+      slots:
+        floor: "First Floor"
+        domain: "light"
+        state: "on"
+    response: "Garage Light, Kitchen cabinets, Kitchen ceiling and 3 more"
+
+  - sentences:
       - "how many lights are on?"
     intent:
       name: HassGetState
@@ -65,13 +121,21 @@ tests:
     response: "6"
 
   - sentences:
-      - "are all the lights on in the kitchen"
-      - "are all lights turned on in the kitchen?"
-      - "are all lights in the kitchen on?"
+      - "how many lights are on in the kitchen?"
     intent:
       name: HassGetState
       slots:
+        area: "Kitchen"
         domain: "light"
         state: "on"
-        area: "Kitchen"
-    response: "Yes"
+    response: "3"
+
+  - sentences:
+      - "how many lights are on at the first floor?"
+    intent:
+      name: HassGetState
+      slots:
+        floor: "First Floor"
+        domain: "light"
+        state: "on"
+    response: "6"


### PR DESCRIPTION
Add support for `HassGetState` queries using `floor`.

E.g. "is there any light on upstairs?", "are all the switches off in the basement?" etc.

`binary_sensor` and `sensor` were intentionally excluded from this PR due to an ongoing discussion regarding their fate.

Also improved tests for this intent