### PR TITLE
[EN] New "any" query for HassGetState for area, domain and state

### DIFF
--- a/sentences/en/homeassistant_HassGetState.yaml
+++ b/sentences/en/homeassistant_HassGetState.yaml
@@ -20,6 +20,7 @@ intents:
       - sentences:
           - (is|are) [there] any {on_off_domains:domain} {on_off_states:state} [<in_area_floor>]
           - (do you know|tell me) if there are any {on_off_domains:domain} {on_off_states:state} [<in_area_floor>]
+          - <is> <area> {on_off_domains:domain} {on_off_states:state}
         response: any
 
       - sentences:

--- a/tests/en/homeassistant_HassGetState.yaml
+++ b/tests/en/homeassistant_HassGetState.yaml
@@ -19,6 +19,16 @@ tests:
     response: "No, off"
 
   - sentences:
+      - "is the bedroom light off?"
+    intent:
+      name: HassGetState
+      slots:
+        area: "Bedroom"
+        domain: "light"
+        state: "off"
+    response: "Yes, Bedroom Lamp"
+
+  - sentences:
       - "are any switches on in the kitchen?"
       - "tell me if there are any switches on in the kitchen"
     intent:


### PR DESCRIPTION
Now will match queries like "is the bedroom light off" if there is no entity specifically named "bedroom light" in the bedroom. It will instead consider if "any" bedroom light is on and respond in kind.