### PR TITLE
[NL] Add options for Pause and Unpause media

### DIFF
--- a/sentences/nl/media_player_HassMediaPause.yaml
+++ b/sentences/nl/media_player_HassMediaPause.yaml
@@ -4,18 +4,21 @@ intents:
     data:
       - sentences:
           - "(pauzeer|stop) [[de|het] <media_item> [op]] <name>"
-          - "[zet] <name> [op] (pauze|stop)"
+          - "[zet] [[de|het] <media_item> [op]] <name> [op] (pauze|stop)"
           - "[[de|het] <media_item> [op]] <name> (op (pauze|stop) zetten|pauzeren|stoppen)"
         requires_context:
           domain: media_player
       - sentences:
           - "(pauzeren|pauzeer|stoppen)"
-          - "[zet op] (pauze|stop)"
+          - "(pauzeer|stop) [de|het] <media_item>"
+          - "[de|het] <media_item> (pauzeren|stoppen)"
+          - "[zet [[de|het] <media_item>] op] (pauze|stop)"
         requires_context:
           area:
             slot: true
       - sentences:
           - "(pauzeer|stop) [[de|het] <media_item> [<in>]] <area>"
-          - "<area> pauze"
-          - "[zet] <area> [op] (pauze|stop)"
-          - "<area> (op (pauze|stop) zetten|pauzeren|stoppen)"
+          - "(pauzeer|stop) [<in>] <area>[ ]<media_item>"
+          - "<area>[[ ]<media_item>] pauze"
+          - "[zet] [[de|het] <media_item> <in>] <area> [op] (pauze|stop)"
+          - "[[de|het] <media_item> <in>] <area> (op (pauze|stop) zetten|pauzeren|stoppen)"

--- a/sentences/nl/media_player_HassMediaUnpause.yaml
+++ b/sentences/nl/media_player_HassMediaUnpause.yaml
@@ -10,6 +10,7 @@ intents:
         requires_context:
           domain: media_player
       - sentences:
+          - "hervat [[de|het] <media_item>] "
           - "[[de|het] <media_item>] hervat[ten]"
           - "[zet] [[de|het] <media_item>] [weer] [op] ([af]spelen|play)"
           - "ga verder met [de|het] <media_item>"

--- a/tests/nl/media_player_HassMediaPause.yaml
+++ b/tests/nl/media_player_HassMediaPause.yaml
@@ -13,11 +13,11 @@ tests:
     response: "Gepauzeerd"
   - sentences:
       - "pauze"
-      - "pauzeer"
+      - "pauzeer de muziek"
       - "pauzeren"
-      - "stoppen"
-      - "zet op pauze"
-      - "zet op stop"
+      - "de muziek stoppen"
+      - "zet muziek op pauze"
+      - "zet de muziek op stop"
     intent:
       name: HassMediaPause
       slots:

--- a/tests/nl/media_player_HassMediaUnpause.yaml
+++ b/tests/nl/media_player_HassMediaUnpause.yaml
@@ -11,6 +11,7 @@ tests:
         name: "TV"
     response: "Hervat"
   - sentences:
+      - "hervat de muziek"
       - "hervatten"
       - "liedjes hervatten"
       - "zet de muziek weer op afspelen"


### PR DESCRIPTION
Noticed that `hervat de muziek` was processed by the LLM fallback instead of locally, so had a closer look to the Pause and Unpause intents, and added `<meida_item>` optionally on several places.