### PR TITLE
Fix apartment typo in sentences-en-_common.yaml

### DIFF
--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -394,7 +394,7 @@ expansion_rules:
   # Context awareness expansion rules
   all: "(all [[of] the]|every [single]|each [and every])"
   are_all: "[<are>] <all>"
-  home: "(home|house|appartment|flat)"
+  home: "(home|house|apartment|flat)"
   everywhere: "(everywhere|all over|[<in>] the [(entire|whole)] <home>|[<in>] <all> (room|area|floor)[s])"
   here: "([in] here|[in] (this|the) (room|area|space))"
 

--- a/tests/en/light_HassTurnOff.yaml
+++ b/tests/en/light_HassTurnOff.yaml
@@ -62,7 +62,7 @@ tests:
       - switch off the lights in every room
       - turn all lighting off
       - turn all lights off
-      - turn all lights off in the appartment
+      - turn all lights off in the apartment
       - turn every light off across the house
       - turn off all lights across every room
       - turn off all lights in the entire home

--- a/tests/en/light_HassTurnOn.yaml
+++ b/tests/en/light_HassTurnOn.yaml
@@ -64,7 +64,7 @@ tests:
       - switch on the lights in every room
       - turn all lighting on
       - turn all lights on
-      - turn all lights on in the appartment
+      - turn all lights on in the apartment
       - turn every light on across the house
       - turn on all lights across every room
       - turn on all lights in the entire home


### PR DESCRIPTION
"appartment" should be "apartment"