### PR TITLE
[en] Enable the use of possessives for some nouns

### DIFF
--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -364,22 +364,23 @@ lists:
     wildcard: true
 
 expansion_rules:
-  name: "[the] {name}"
-  area: "[the] {area}"
-  floor: "[the] {floor} [floor]"
+  the: "(the|my|our)"
+  name: "[<the>] {name}"
+  area: "[<the>] {area}"
+  floor: "[<the>] {floor} [floor]"
   area_floor: "(<area>|<floor>)"
   in_area_floor: "[<in>] <area_floor>"
-  what_is: "(what's|whats|what is|tell me) [the]"
-  lockable: "[(the|my)] (lock|door|window|gate|garage door|shutter)[s]"
+  what_is: "(what's|whats|what is|tell me) [<the>]"
+  lockable: "[<the>] (lock|door|window|gate|garage door|shutter)[s]"
   where_is: "(where's|wheres|where is)"
-  which: "(which|what) [of the]"
-  is: "(is|are) [(there|the)]"
+  which: "(which|what) [of <the>]"
+  is: "(is|are) [(there|<the>)]"
   are: "<is>"
-  any: "(any|some) [of the]"
+  any: "(any|some) [of <the>]"
   are_any: "[<are>] <any>"
-  how_many: "how many [of the]"
+  how_many: "how many [of <the>]"
   brightness: "{brightness}[([ ]%)| percent]"
-  light: "[the] (light|lights|lighting|lamp|lamps)"
+  light: "[<the>] (light|lights|lighting|lamp|lamps)"
   turn: "(turn|switch|change|bring)"
   temp: "(temp|temperature)"
   temperature: "{temperature}[([ ]°[[ ]{temperature_unit}])|( degrees {temperature_unit})]"
@@ -395,11 +396,11 @@ expansion_rules:
   clean: (vacuum|clean)
 
   # Context awareness expansion rules
-  all: "(all [[of] the]|every [single]|each [and every])"
+  all: "(all [[of] <the>]|every [single]|each [and every])"
   are_all: "[<are>] <all>"
   home: "(home|house|apartment|flat)"
-  everywhere: "(everywhere|all over|[<in>] the [(entire|whole)] <home>|[<in>] <all> (room|area|floor)[s])"
-  here: "([in] here|[in] (this|the) (room|area|space))"
+  everywhere: "(everywhere|all over|[<in>] <the> [(entire|whole)] <home>|[<in>] <all> (room|area|floor)[s])"
+  here: "([in] here|[in] (this|<the>) (room|area|space))"
 
   # Questions
   what_is_the_class_of_name: "(<what_is> the <class> (of|in|from|(indicated|measured) by) <name> [in <area>]|<what_is> <name>['s] <class> [in <area>]|<what_is> <area> <name>['s] <class>)"

--- a/sentences/en/homeassistant_HassGetCurrentDate.yaml
+++ b/sentences/en/homeassistant_HassGetCurrentDate.yaml
@@ -3,5 +3,5 @@ intents:
   HassGetCurrentDate:
     data:
       - sentences:
-          - "(<what_is>|tell me) (todays|today's|the current) date"
-          - "(<what_is>|tell me) the date [today]"
+          - "<what_is> (todays|today's|the current) date"
+          - "<what_is> the date [today]"

--- a/sentences/en/homeassistant_HassGetCurrentTime.yaml
+++ b/sentences/en/homeassistant_HassGetCurrentTime.yaml
@@ -3,5 +3,5 @@ intents:
   HassGetCurrentTime:
     data:
       - sentences:
-          - "(<what_is>|tell me) the [current] time"
+          - "<what_is> the [current] time"
           - "what time is it [[right] now]"

--- a/tests/en/homeassistant_HassGetState.yaml
+++ b/tests/en/homeassistant_HassGetState.yaml
@@ -122,6 +122,7 @@ tests:
 
   - sentences:
       - "how many lights are on in the kitchen?"
+      - "how many lights are on in my kitchen?"
     intent:
       name: HassGetState
       slots:
@@ -132,6 +133,7 @@ tests:
 
   - sentences:
       - "how many lights are on at the first floor?"
+      - "how many lights are on at my first floor?"
     intent:
       name: HassGetState
       slots:

--- a/tests/en/homeassistant_HassTurnOn.yaml
+++ b/tests/en/homeassistant_HassTurnOn.yaml
@@ -7,6 +7,7 @@ tests:
       - "turn the ceiling fan on"
       - "ceiling fan on"
       - "activate ceiling fan"
+      - "turn my ceiling fan on"
     intent:
       name: HassTurnOn
       slots:


### PR DESCRIPTION
Rather than only accepting `the`, many sentences should also accept a possessive like `my`.

This doesn't make sense for all instances of `<light>`, so I'll make another refactor commit after this one