### PR TITLE
[DE] comma as decimal separator

### DIFF
--- a/responses/de/HassGetState.yaml
+++ b/responses/de/HassGetState.yaml
@@ -3,7 +3,7 @@ responses:
   intents:
     HassGetState:
       einzeln: |
-        {{ slots.name | capitalize }} ist {{ state.state_with_unit }}
+        {{ slots.name | capitalize }} ist {{ state.state_with_unit | replace(".", ",") if state.state|float(state.state) is number else state.state_with_unit }}
 
       einzeln_janein: |
         {% if query.matched %}

--- a/tests/de/_fixtures.yaml
+++ b/tests/de/_fixtures.yaml
@@ -110,7 +110,7 @@ entities:
   - name: "Außentemperatur"
     id: "sensor.outside_temperature"
     area: "garage"
-    state: "21"
+    state: "21.47"
     attributes:
       unit_of_measurement: "°C"
   - name: "Haustür"

--- a/tests/de/homeassistant_HassGetState.yaml
+++ b/tests/de/homeassistant_HassGetState.yaml
@@ -6,7 +6,15 @@ tests:
       name: HassGetState
       slots:
         name: "Außentemperatur"
-    response: "Außentemperatur ist 21 °C"
+    response: "Außentemperatur ist 21,47 °C"
+
+  - sentences:
+      - "wie ist die Wohnzimmertemperatur?"
+    intent:
+      name: HassGetState
+      slots:
+        name: "Wohnzimmertemperatur"
+    response: "Wohnzimmertemperatur ist 23 °C"
 
   - sentences:
       - "ist die Schlafzimmerlampe aus?"


### PR DESCRIPTION
Use german decimal separator (`,` not `.`) in HassGetState responses. "Außentemperatur ist 24,5°C" instead of "Außentemperatur ist 24.5°C".

This will improve readability for German users and also provide the cleanest input for TTS. HA Cloud TTS (=Microsoft Azure based) correctly pronounces numbers with either decimal separator, but who knows how other TTS services handle numbers.