### PR TITLE
[en] Tighten the matching for general turn on and off statements

### DIFF
--- a/sentences/en/homeassistant_HassTurnOff.yaml
+++ b/sentences/en/homeassistant_HassTurnOff.yaml
@@ -3,9 +3,10 @@ intents:
   HassTurnOff:
     data:
       - sentences:
-          - "<turn> off (<area> <name>|<name> [in <area>])"
-          - "[<turn>] (<area> <name>|<name> [in <area>]) [to] off"
-          - "deactivate (<area> <name>|<name> [in <area>])"
+          - "(<turn> off|deactivate) <area_floor> {name}"
+          - "(<turn> off|deactivate) <name> [<in_area_floor>]"
+          - "<turn> <area_floor> {name} [to] off"
+          - "<turn> <name> [<in_area_floor>] [to] off"
         excludes_context:
           domain:
             - binary_sensor

--- a/sentences/en/homeassistant_HassTurnOn.yaml
+++ b/sentences/en/homeassistant_HassTurnOn.yaml
@@ -3,9 +3,10 @@ intents:
   HassTurnOn:
     data:
       - sentences:
-          - "<turn> on (<area> <name>|<name> [in <area>])"
-          - "[<turn>] (<area> <name>|<name> [in <area>]) [to] on"
-          - "activate (<area> <name>|<name> [in <area>])"
+          - "(<turn> on|activate) <area_floor> {name}"
+          - "(<turn> on|activate) <name> [<in_area_floor>]"
+          - "<turn> <area_floor> {name} [to] on"
+          - "<turn> <name> [<in_area_floor>] [to] on"
         excludes_context:
           domain:
             - binary_sensor

--- a/tests/en/homeassistant_HassTurnOff.yaml
+++ b/tests/en/homeassistant_HassTurnOff.yaml
@@ -5,7 +5,6 @@ tests:
       - "turn off the bedroom lamp"
       - "turn bedroom lamp off"
       - "turn the bedroom lamp off"
-      - "bedroom lamp off"
       - "deactivate bedroom lamp"
     intent:
       name: HassTurnOff

--- a/tests/en/homeassistant_HassTurnOn.yaml
+++ b/tests/en/homeassistant_HassTurnOn.yaml
@@ -5,7 +5,6 @@ tests:
       - "turn on the ceiling fan"
       - "turn ceiling fan on"
       - "turn the ceiling fan on"
-      - "ceiling fan on"
       - "activate ceiling fan"
     intent:
       name: HassTurnOn


### PR DESCRIPTION
This will prevent ambiguous sentences from being recognized as an turn on or off statement.

Eg. If you currently say 'Is the unknown device on', the '<area> <name> on' sentence was matched and the user recieved a confusing error suggesting there is no area called 'Is'. This will require an explicit request to 'turn|switch|etc' something on or off.