### PR TITLE
Add response to HassRespond

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -144,6 +144,10 @@ HassRespond:
   supported: true
   domain: homeassistant
   description: "Returns response but takes no action."
+  slots:
+    response:
+      description: "Text to respond with"
+      required: false
 
 HassSetPosition:
   supported: true

--- a/responses/en/HassRespond.yaml
+++ b/responses/en/HassRespond.yaml
@@ -2,6 +2,7 @@ language: en
 responses:
   intents:
     HassRespond:
+      default: ""
       hello: "Hello from Home Assistant."
       listening: "No, I only record when you speak the wake word."
       data: "Your data is sent to your Home Assistant server."

--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -360,6 +360,9 @@ lists:
   timer_command:
     wildcard: true
 
+  response:
+    wildcard: true
+
 expansion_rules:
   name: "[the] {name}"
   area: "[the] {area}"

--- a/sentences/en/homeassistant_HassRespond.yaml
+++ b/sentences/en/homeassistant_HassRespond.yaml
@@ -3,6 +3,9 @@ intents:
   HassRespond:
     data:
       - sentences:
+          - "say {response}"
+
+      - sentences:
           - "(hello|hi) [home assistant]"
         response: hello
 

--- a/tests/en/homeassistant_HassRespond.yaml
+++ b/tests/en/homeassistant_HassRespond.yaml
@@ -1,6 +1,14 @@
 language: en
 tests:
   - sentences:
+      - "say I'm a little teapot"
+    intent:
+      name: HassRespond
+      slots:
+        response: "I'm a little teapot"
+    response: "I'm a little teapot"
+
+  - sentences:
       - "hi home assistant"
     intent:
       name: HassRespond

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -238,6 +238,11 @@ def do_test_language_sentences_file(
 
                 # Verify response
                 if expected_response_texts:
+                    if (result.intent.name == "HassRespond") and (
+                        "response" in result.entities
+                    ):
+                        return result.entities["response"].value
+
                     actual_response_key = result.response
                     assert actual_response_key, f"Expected a response for: {sentence}"
 


### PR DESCRIPTION
Adds a `response` slot to `HassRespond` intent to mirror: https://github.com/home-assistant/core/pull/133162

This allows us to create a sentence like "say xyz" and have a voice satellite respond with "xyz".
This PR also adds this sentence to English.