### PR TITLE
[DE] say xyz

### DIFF
--- a/responses/de/HassRespond.yaml
+++ b/responses/de/HassRespond.yaml
@@ -2,6 +2,7 @@ language: de
 responses:
   intents:
     HassRespond:
+      default: ""
       hello: "Hallo vom Home Assistant."
       listening: "Nein, ich höre nur zu, wenn du das Signalwort sprichst."
       data: "Deine Daten liegen auf deinem Home Assistant server."

--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -535,6 +535,8 @@ lists:
     wildcard: true
   timer_command:
     wildcard: true
+  response:
+    wildcard: true
 
 expansion_rules:
   artikel_bestimmt: "[(der|die|das|dem|den|des)]"

--- a/sentences/de/homeassistant_HassRespond.yaml
+++ b/sentences/de/homeassistant_HassRespond.yaml
@@ -3,6 +3,9 @@ intents:
   HassRespond:
     data:
       - sentences:
+          - "Sag[e] {response}"
+
+      - sentences:
           - "(Hallo|Hi|Hey|Guten Tag) [Home Assistant]"
         response: hello
 

--- a/tests/de/homeassistant_HassRespond.yaml
+++ b/tests/de/homeassistant_HassRespond.yaml
@@ -1,6 +1,14 @@
 language: de
 tests:
   - sentences:
+      - "Sage Ich bin ein Berliner"
+    intent:
+      name: HassRespond
+      slots:
+        response: "Ich bin ein Berliner"
+    response: "Ich bin ein Berliner"
+
+  - sentences:
       - "hallo home assistant"
       - "hi home assistant"
       - "hey home assistant"


### PR DESCRIPTION
DE version of https://github.com/home-assistant/intents/pull/2750

@synesthesiam Not sure if this is known/intentional, but the tests for the response does not work actually (I tested in both DE and EN). The slot is tested but the actual response sentence is never tested. The following validates just fine.

```yaml
tests:
  - sentences:
      - "say I'm a little teapot"
    intent:
      name: HassRespond
      slots:
        response: "I'm a little teapot"
    response: "I'm something completely different"
```