### PR TITLE
[PL] Add extra state forms for covers

### DIFF
--- a/sentences/pl/_common.yaml
+++ b/sentences/pl/_common.yaml
@@ -301,9 +301,9 @@ lists:
         out: "switch"
   cover_states:
     values:
-      - in: "(otw(órz|arta|arte|artych)|odsunięt(e|ych)|odsłonięt(e|ych))"
+      - in: "(otw(órz|arta|arte|arty|artych)|odsunięt(e|y|ych)|odsłonięt(e|y|ych))"
         out: "open"
-      - in: "(zamkni(j|ęta|ęte|ętych)|zasunięt(e|ych)|zasłonięt(e|ych))"
+      - in: "(zamkni(j|ęta|ęte|ęty|ętych)|zasunięt(e|y|ych)|zasłonięt(e|y|ych))"
         out: "closed"
       - in: "otwieranie"
         out: "opening"


### PR DESCRIPTION
This commit adds extra forms of open/closed state for covers, specifically ones ending in _-ty_ (ie. _otwarty_, _zamknięty_).

Thanks to that, a sentence like "Czy garaż jest otwarty?" is now getting parsed correctly.