### PR TITLE
[CS] Fix failing tests due to same entity names across domains

### DIFF
--- a/sentences/cs/_common.yaml
+++ b/sentences/cs/_common.yaml
@@ -385,13 +385,15 @@ expansion_rules:
   y_e: "(ý|ej|á|é|ých|ejch|o)"
   ktere: "(kter<y_e>|jak[<y_e>])"
   nektere: "(někter<y_e>|nějak[<y_e>])"
-  je_jsou: "(byl[(a|o|i|y)]|je|jsou|bud(e|ou))"
-  jaky_je: "((<ktere>|kolik)[  <je_jsou>])"
+  byl: "byl[(a|o|i|y)]"
+  je: "(je|jsou)"
+  bude: "bud(e|ou)"
+  jaky_je: "(jak[<y_e>]|kolik) [<je>]"
   jaka_je_class_of_name: >
     (
-       <jaky_je> (<class>;[<je_jsou>];[[(na|z)]měřen<y_e>]) ([(na|na sen(z|s)oru|sen(z|s)orem) ]{name};[<area>])
-       |<jaky_je> <area> <class> [(na|z)měřen(á|ý) ][(na sen(z|s)oru|sen(z|s)orem) ]{name}
-     )
+      <jaky_je> (<class>;[[na|z]měřen<y_e>]) [<v>] [sen(z|s)or(u|em)] {name} [<area>]|
+      <jaky_je> <area> (<class>;[[na|z]měřen<y_e>]) [<v>] [sen(z|s)or(u|em)] {name}
+    )
 
 skip_words:
   - "prosím"

--- a/sentences/cs/binary_sensor_HassGetState.yaml
+++ b/sentences/cs/binary_sensor_HassGetState.yaml
@@ -10,7 +10,7 @@ intents:
       # Connectivity
       # Door
       - sentences:
-          - "<je_jsou> {name} {bs_door_states:state} [<area>]"
+          - "<je> {name} {bs_door_states:state} [<area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -21,7 +21,7 @@ intents:
 
       # Garage door
       - sentences:
-          - "<je_jsou> {name} {bs_garage_door_states:state} [<area>]"
+          - "<je> {name} {bs_garage_door_states:state} [<area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -36,7 +36,7 @@ intents:
       # # Lock
       # # Moisture
       - sentences:
-          - "<je_jsou> [sen(s|z)or] {name} {bs_moisture_states:state} [<area>]"
+          - "<je> [sen(s|z)or] {name} {bs_moisture_states:state} [<area>]"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -46,7 +46,7 @@ intents:
           device_class: moisture
 
       - sentences:
-          - "<je_jsou> (nějak|někter)(ý|é) sen(z|s)or[y] [vlhkosti] {bs_moisture_states:state} [<area>]"
+          - "<je> (nějak|někter)(ý|é) sen(z|s)or[y] [vlhkosti] {bs_moisture_states:state} [<area>]"
         response: any
         slots:
           domain: binary_sensor
@@ -78,7 +78,7 @@ intents:
 
       # Motion
       - sentences:
-          - "<je_jsou> [<area>] [na sen(z|s)oru {name}] {bs_motion_states:state} pohyb"
+          - "<je> [<area>] [na sen(z|s)oru {name}] {bs_motion_states:state} pohyb"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -88,7 +88,7 @@ intents:
           device_class: motion
 
       - sentences:
-          - "<je_jsou> [(některé|nějaké)] sen(s|z)ory pohybu [<area>] [ve stavu] {bs_motion_states:state}"
+          - "<je> [(některé|nějaké)] sen(s|z)ory pohybu [<area>] [ve stavu] {bs_motion_states:state}"
         response: any
         slots:
           domain: binary_sensor
@@ -125,7 +125,7 @@ intents:
 
       # Occupancy
       - sentences:
-          - "(<je_jsou>|detekuje) [sen(s|z)or] {name} {bs_occupancy_states:state} [<area>]"
+          - "(<je>|detekuje) [sen(s|z)or] {name} {bs_occupancy_states:state} [<area>]"
         response: one_yesno
         requires_context:
           domain: binary_sensor
@@ -135,7 +135,7 @@ intents:
           device_class: occupancy
 
       - sentences:
-          - "<je_jsou> (nějaké|některé) sen(s|z)ory obsazenosti [<area>] ve stavu {bs_occupancy_states:state}"
+          - "<je> (nějaké|některé) sen(s|z)ory obsazenosti [<area>] ve stavu {bs_occupancy_states:state}"
         response: any
         slots:
           domain: binary_sensor
@@ -172,7 +172,7 @@ intents:
 
       # # Opening
       - sentences:
-          - "<je_jsou> {name} [<area>] {bs_opening_states:state}"
+          - "<je> {name} [<area>] {bs_opening_states:state}"
         response: bs_yesno
         requires_context:
           domain: binary_sensor
@@ -182,7 +182,7 @@ intents:
           device_class: opening
 
       - sentences:
-          - "<je_jsou> někde [<area>] {bs_opening_states:state}"
+          - "<je> někde [<area>] {bs_opening_states:state}"
         response: any
         slots:
           domain: binary_sensor
@@ -222,7 +222,7 @@ intents:
       # # Vibration
       # # Window
       - sentences:
-          - "<je_jsou> {name} {bs_window_states:state} [<area>]"
+          - "<je> {name} {bs_window_states:state} [<area>]"
         response: one_yesno
         requires_context:
           domain: binary_sensor

--- a/sentences/cs/cover_HassGetState.yaml
+++ b/sentences/cs/cover_HassGetState.yaml
@@ -20,8 +20,8 @@ intents:
         response: one_cover
 
       - sentences:
-          - "(je|jsou) <nektere> {cover_classes:device_class} [<area_floor>] {cover_states:state}"
-          - "(je|jsou) ({cover_states:state} <nektere> {cover_classes:device_class};[<area_floor>])"
+          - "<je> <nektere> {cover_classes:device_class} [<area_floor>] {cover_states:state}"
+          - "<je> ({cover_states:state} <nektere> {cover_classes:device_class};[<area_floor>])"
           - "{cover_states:state} <nektere> {cover_classes:device_class}"
         slots:
           domain: cover
@@ -36,7 +36,7 @@ intents:
         response: all
 
       - sentences:
-          - "<ktere> {cover_classes:device_class} [<area_floor>] (je|jsou|se) {cover_states:state}"
+          - "<ktere> {cover_classes:device_class} [<area_floor>] (<je>|se) {cover_states:state}"
         slots:
           domain: cover
         response: which

--- a/sentences/cs/sensor_HassGetState.yaml
+++ b/sentences/cs/sensor_HassGetState.yaml
@@ -3,19 +3,6 @@ intents:
   HassGetState:
     data:
       # https://www.home-assistant.io/integrations/sensor/
-      # Teplota
-      - sentences:
-          - "<jaka_je_class_of_name>"
-          - "kolik stupňů [je|bylo] [(na|z)měřeno] [(na senzoru|senzorem)] {name} [<area>]"
-        requires_context:
-          domain: sensor
-          device_class: temperature
-        slots:
-          domain: sensor
-          device_class: temperature
-        expansion_rules:
-          class: "teplota"
-
       # Apparent power
       - sentences:
           - "<jaka_je_class_of_name>"
@@ -62,7 +49,7 @@ intents:
           domain: sensor
           device_class: battery
         expansion_rules:
-          class: "[(stav|úroveň|procento)] [nabití] baterie"
+          class: "(nabitá|[(stav|úroveň|procento)] [nabití]) baterie"
 
       # CO2
       - sentences:
@@ -122,12 +109,12 @@ intents:
           domain: sensor
           device_class: data_size
         expansion_rules:
-          class: "(velikost|objem) [dat]"
+          class: "(velikost (dat|souboru)|objem dat|velký soubor)"
 
       # Date
       - sentences:
           - "<jaka_je_class_of_name>"
-          - "kdy (je|bylo|bude|byli|budou) {name}"
+          - "kdy (<byl>|<je>|<bude>) {name}"
         response: one
         requires_context:
           domain: sensor
@@ -141,7 +128,7 @@ intents:
       # Distance
       - sentences:
           - "<jaka_je_class_of_name>"
-          - "jak (daleko|dlouh(ý|á)) je {name}"
+          - "jak (daleko|dlouh(<y_e>)) je {name}"
         response: one
         requires_context:
           domain: sensor
@@ -175,12 +162,11 @@ intents:
           domain: sensor
           device_class: energy
         expansion_rules:
-          class: "energie"
+          class: "[množství] energie"
 
       # Energy storage
       - sentences:
           - "<jaka_je_class_of_name>"
-        response: one
         requires_context:
           domain: sensor
           device_class: energy_storage
@@ -188,7 +174,7 @@ intents:
           domain: sensor
           device_class: energy_storage
         expansion_rules:
-          class: "[množství] uložen(é|á|ý) energie"
+          class: "[množství] uložen<y_e> energie"
 
       # Frequency
       - sentences:
@@ -217,7 +203,6 @@ intents:
       # Humidity
       - sentences:
           - "<jaka_je_class_of_name>"
-        response: one
         requires_context:
           domain: sensor
           device_class: humidity
@@ -225,12 +210,11 @@ intents:
           domain: sensor
           device_class: humidity
         expansion_rules:
-          class: "[relativní ]vlhkost[ vzduchu]"
+          class: "[relativní] vlhkost [vzduchu]"
 
       # Illuminance
       - sentences:
           - "<jaka_je_class_of_name>"
-        response: one
         requires_context:
           domain: sensor
           device_class: illuminance
@@ -243,7 +227,6 @@ intents:
       # Irradiance
       - sentences:
           - "<jaka_je_class_of_name>"
-        response: one
         requires_context:
           domain: sensor
           device_class: irradiance
@@ -251,7 +234,7 @@ intents:
           domain: sensor
           device_class: irradiance
         expansion_rules:
-          class: "[(množství|úroveň)] ozáření"
+          class: "[množství|úroveň] ozáření"
 
       # Moisture
       - sentences:
@@ -263,12 +246,12 @@ intents:
           domain: sensor
           device_class: moisture
         expansion_rules:
-          class: "[relativní ]vlhkost"
+          class: "[relativní] vlhkost"
 
       # Monetary
       - sentences:
           - "<jaka_je_class_of_name>"
-          - "kolik [peněz] (stojí|stál[(o|a)]) {name}"
+          - "kolik [peněz] (stojí|stál[o|a]) {name}"
         response: one
         requires_context:
           domain: sensor
@@ -277,7 +260,7 @@ intents:
           domain: sensor
           device_class: monetary
         expansion_rules:
-          class: "(náklady|[(množství|objem)] peněz|částka)"
+          class: "(náklady|[množství|objem] peněz|částka)"
 
       # Nitrogen dioxide
       - sentences:
@@ -313,7 +296,7 @@ intents:
           domain: sensor
           device_class: nitrous_oxide
         expansion_rules:
-          class: "<koncentrace> (oxidu dusnat<y_e>ho|N2O)"
+          class: "<koncentrace> (oxidu dusn<y_e>ho|N2O)"
 
       # Ozone
       - sentences:
@@ -397,7 +380,7 @@ intents:
           domain: sensor
           device_class: precipitation
         expansion_rules:
-          class: "[(souhrn[<y_e>]|úhrn[<y_e>]|celkov<y_e>)] [množství] [(dešťov<y_e>ch|sněhov<y_e>[ch])] (srážek|srážky)"
+          class: "[(sou|ú)hrn[<y_e>]|celkov<y_e>] [množství] [dešťov<y_e>ch|sněhov<y_e>ch] srážek"
 
       # Precipitation intensity
       - sentences:
@@ -482,6 +465,19 @@ intents:
           device_class: sulphur_dioxide
         expansion_rules:
           class: "<koncentrace> (oxidu siřičit<y_e>ho|SO2)"
+
+      # Teplota
+      - sentences:
+          - "<jaka_je_class_of_name>"
+          - "kolik stupňů [je|bylo] [(na|z)měřeno] [na] [senzor(u|em)] {name} [<area>]"
+        requires_context:
+          domain: sensor
+          device_class: temperature
+        slots:
+          domain: sensor
+          device_class: temperature
+        expansion_rules:
+          class: "teplota"
 
       # Volatile organic compounds
       - sentences:

--- a/sentences/cs/weather_HassGetWeather.yaml
+++ b/sentences/cs/weather_HassGetWeather.yaml
@@ -3,8 +3,8 @@ intents:
   HassGetWeather:
     data:
       - sentences:
-          - "<jaky_je> počasí"
+          - "jak[<y_e>] (<je>|<bude>) počasí"
       - sentences:
-          - "<jaky_je> počasí <v> {name}"
+          - "jak[<y_e>] (<je>|<bude>) počasí <v> {name}"
         requires_context:
           domain: weather

--- a/tests/cs/_fixtures.yaml
+++ b/tests/cs/_fixtures.yaml
@@ -108,12 +108,9 @@ entities:
       out: opening
     attributes:
       device_class: garage
-      domain: cover
 
   - name: "Párty"
     id: "scene.party"
-    attributes:
-      domain: scene
 
   - name: "Ovoce a zelenina"
     id: "todo.ovoce_a_zelenina"

--- a/tests/cs/_fixtures.yaml
+++ b/tests/cs/_fixtures.yaml
@@ -161,22 +161,14 @@ entities:
     attributes:
       current_temperature: 18.5
 
-  - name: "[teplota] v obýváku"
-    id: "sensor.teplota_obyvak"
-    area: living_room
-    state: "18"
-    attributes:
-      device_class: temperature
-      unit_of_measurement: "°C"
-
-  - name: "Hlavní přívod"
+  - name: "hlavní[m] přívod[u]"
     id: "sensor.aparent_power_mains"
     state: "2"
     attributes:
       device_class: apparent_power
       unit_of_measurement: "VA"
 
-  - name: "[kvalita vyduchu] v kuchyni"
+  - name: "kvalit(a|y) vzduchu"
     id: "sensor.air_quality"
     area: kitchen
     state: "50"
@@ -197,21 +189,23 @@ entities:
       device_class: battery
       unit_of_measurement: "%"
 
-  - name: "[co2] v obýváku"
+  - name: "CO2"
     id: "sensor.living_room_co2"
+    area: living_room
     state: "50"
     attributes:
       device_class: carbon_dioxide
       unit_of_measurement: "ppm"
 
-  - name: "[co] v obýváku"
+  - name: "CO"
     id: "sensor.living_room_co"
+    area: living_room
     state: "48"
     attributes:
       device_class: carbon_monoxide
       unit_of_measurement: "ppm"
 
-  - name: "[proud] nabíjení EV"
+  - name: "[proud] nabíjení auta"
     id: "sensor.EV_current"
     state: "15"
     attributes:
@@ -225,7 +219,7 @@ entities:
       device_class: data_rate
       unit_of_measurement: "Mbps"
 
-  - name: "[velikost] souboru"
+  - name: "[velikost] log[u]"
     id: "sensor.log_file_size"
     state: "106"
     attributes:
@@ -237,13 +231,6 @@ entities:
     state: "2024-04-01"
     attributes:
       device_class: date
-
-  - name: "[vzdalenost] do práce"
-    id: "sensor.distance_to_work"
-    state: "23"
-    attributes:
-      device_class: distance
-      unit_of_measurement: "km"
 
   - name: "dojezd elektromobilu"
     id: "sensor.ev_dojezd"
@@ -259,14 +246,14 @@ entities:
       device_class: duration
       unit_of_measurement: "min"
 
-  - name: "[denní produkce] solární elektrárny"
+  - name: "produkce solární elektrárny"
     id: "sensor.solar_production"
     state: "3.2"
     attributes:
       device_class: energy
       unit_of_measurement: "kWh"
 
-  - name: "[energie] v baterii"
+  - name: "akumulační bateri(e|i)"
     id: "sensor.powerwall_stored_energy"
     state: "6"
     attributes:
@@ -280,43 +267,46 @@ entities:
       device_class: frequency
       unit_of_measurement: "Hz"
 
-  - name: "[objem plynu] za měsíc"
+  - name: "spotřeb(a|ovaný) za měsíc"
     id: "sensor.monthly_gas_consumption"
     state: "12"
     attributes:
       device_class: gas
       unit_of_measurement: "m³"
 
-  - name: "[vlhkost vzduchu] v obýváku"
+  - name: "vlhkosti[i]"
     id: "sensor.living_room_humidity"
+    area: living_room
     state: "48"
     attributes:
       device_class: humidity
       unit_of_measurement: "%"
 
-  - name: "[intenzita světla] v obýváku"
+  - name: "intenzit(a|y) světla"
     id: "sensor.living_room_illuminance"
+    area: living_room
     state: "438"
     attributes:
       device_class: illuminance
       unit_of_measurement: "lux"
 
-  - name: "[úroveň ozáření] v obýváku"
+  - name: "radiace"
     id: "sensor.living_room_heater_irradiance"
+    area: living_room
     state: "155"
     attributes:
       device_class: irradiance
       unit_of_measurement: "W/m²"
 
   - name: "[vlhkost] půdy"
-    id: "sensor.bewery_mixer_moisture"
+    id: "sensor.soil_moisture"
     state: "83"
     attributes:
       device_class: moisture
       unit_of_measurement: "%"
 
   - name: "[peněz] na účtě"
-    id: "sensor.price_per_kW"
+    id: "sensor.money_on_account"
     state: "500"
     attributes:
       device_class: monetary
@@ -329,57 +319,61 @@ entities:
       device_class: monetary
       unit_of_measurement: "EUR"
 
-  - name: "[koncentrace NO2] v kotelně"
+  - name: "NO2 na čerpadle"
     id: "sensor.heat_pump_no2"
     state: "50"
     attributes:
       device_class: nitrogen_dioxide
       unit_of_measurement: "µg/m³"
 
-  - name: "[koncentrace NO] v kotelně"
+  - name: "NO na čerpadle"
     id: "sensor.heat_pump_no"
     state: "50"
     attributes:
       device_class: nitrogen_monoxide
       unit_of_measurement: "µg/m³"
 
-  - name: "[koncentrace N2O] v kotelně"
+  - name: "N2O na čerpadle"
     id: "sensor.heat_pump_n2o"
     state: "50"
     attributes:
       device_class: nitrous_oxide
       unit_of_measurement: "µg/m³"
 
-  - name: "[koncentrace ozonu] v obýváku"
+  - name: "ozon[u]"
     id: "sensor.living_room_ozone"
+    area: living_room
     state: "50"
     attributes:
       device_class: ozone
       unit_of_measurement: "µg/m³"
 
-  - name: "[koncentrace částic pm1] v obýváku"
+  - name: "množství částic pm1"
     id: "sensor.living_room_pm1"
+    area: living_room
     state: "50"
     attributes:
       device_class: pm1
       unit_of_measurement: "µg/m³"
 
-  - name: "[koncentrace částic pm2.5] v obýváku"
+  - name: "množství částic pm2.5"
     id: "sensor.living_room_pm25"
+    area: living_room
     state: "50"
     attributes:
       device_class: pm25
       unit_of_measurement: "µg/m³"
 
-  - name: "[koncentrace částic pm10] v obýváku"
+  - name: "množství částic pm10"
     id: "sensor.living_room_pm10"
+    area: living_room
     state: "50"
     attributes:
       device_class: pm10
       unit_of_measurement: "µg/m³"
 
-  - name: "[účiník] spotřeby domu"
-    id: "sensor.wall_plug_power_factor"
+  - name: "[účiník] lednice"
+    id: "sensor.refrigerator_power_factor"
     state: "2"
     attributes:
       device_class: power_factor
@@ -433,28 +427,36 @@ entities:
       device_class: sound_pressure
       unit_of_measurement: "dB"
 
-  - name: "[rychlost] EV"
+  - name: "[rychlost] auta"
     id: "sensor.traveling speed"
     state: "67"
     attributes:
       device_class: speed
       unit_of_measurement: "km/h"
 
-  - name: "[koncentrace SO2] ve vzduchu"
-    id: "sensor.heat_pump_so2"
+  - name: "SO2 ve vzduchu"
+    id: "sensor.air_so2"
     state: "50"
     attributes:
       device_class: sulphur_dioxide
       unit_of_measurement: "µg/m³"
 
-  - name: "[množství volných organických látek] ve vzduchu"
+  - name: "Teploměr[em]"
+    id: "sensor.teplota_obyvak"
+    area: living_room
+    state: "18"
+    attributes:
+      device_class: temperature
+      unit_of_measurement: "°C"
+
+  - name: "množství VOC ve vzduchu"
     id: "sensor.voc_sensor"
     state: "35"
     attributes:
       device_class: volatile_organic_compounds
       unit_of_measurement: "µg/m³"
 
-  - name: "[koncentrace volných organických látek] ve vzduchu"
+  - name: "koncentrace částic VOC ve vzduchu"
     id: "sensor.voc_sensor_parts"
     state: "35"
     attributes:
@@ -482,14 +484,14 @@ entities:
       device_class: volume_storage
       unit_of_measurement: "L"
 
-  - name: "voda"
+  - name: "spotřebovaná voda"
     id: "sensor.water_pump_usage"
     state: "5987"
     attributes:
       device_class: water
       unit_of_measurement: "L"
 
-  - name: "postel"
+  - name: "postel[i]"
     id: "sensor.bed_sensor_weight"
     state: "87"
     attributes:

--- a/tests/cs/_fixtures.yaml
+++ b/tests/cs/_fixtures.yaml
@@ -544,7 +544,7 @@ entities:
     attributes:
       device_class: moisture
 
-  - name: "Garáž"
+  - name: "pohyb v garáži"
     id: "binary_sensor.garage_motion"
     area: "garage"
     state:

--- a/tests/cs/binary_sensor_HassGetState.yaml
+++ b/tests/cs/binary_sensor_HassGetState.yaml
@@ -83,11 +83,11 @@ tests:
 
   # Motion
   - sentences:
-      - "je na senzoru Garáž detekován pohyb?"
+      - "je na senzoru pohyb v garáži detekován pohyb?"
     intent:
       name: HassGetState
       slots:
-        name: "Garáž"
+        name: "pohyb v garáži"
         domain: "binary_sensor"
         device_class: "motion"
         state: "on"
@@ -102,7 +102,7 @@ tests:
         domain: binary_sensor
         device_class: motion
         state: "on"
-    response: "Ano, Garáž"
+    response: "Ano, pohyb v garáži"
 
   - sentences:
       - "jsou všechny detektory pohybu ve stavu detekován?"
@@ -122,7 +122,7 @@ tests:
         domain: binary_sensor
         device_class: motion
         state: "on"
-    response: "Garáž"
+    response: "pohyb v garáži"
 
   - sentences:
       - "kolik detektorů pohybu je ve stavu detekován?"

--- a/tests/cs/sensor_HassGetState.yaml
+++ b/tests/cs/sensor_HassGetState.yaml
@@ -1,37 +1,26 @@
 language: cs
 tests:
-  # Teplota
-  - sentences:
-      - "Jaká je teplota naměřená v obýváku"
-      - "Kolik stupňů je naměřeno v obýváku"
-    intent:
-      name: HassGetState
-      slots:
-        domain: sensor
-        device_class: temperature
-        name: "v obýváku"
-    response: "18 °C"
-
   # Apparent power
   - sentences:
-      - "Jaký je zdánlivý výkon na senzoru Hlavní přívod?"
+      - "Jaký je zdánlivý výkon na hlavním přívodu?"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: apparent_power
-        name: "Hlavní přívod"
+        name: "hlavním přívodu"
     response: "2 VA"
 
   # AQI
   - sentences:
-      - "Jaká je kvalita vzduchu v kuchyni?"
+      - "Jaký je změřený index kvality vzduchu senzorem kvality vzduchu v kuchyni?"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: aqi
-        name: "v kuchyni"
+        name: "kvality vzduchu"
+        area: "Kuchyni"
     response: "50"
 
   # Atmospheric pressure
@@ -49,6 +38,7 @@ tests:
   - sentences:
       - "jaká je úroveň nabití baterie mého telefonu?"
       - "jaký je stav baterie mého telefonu?"
+      - "jak je nabitá baterie mého telefonu?"
     intent:
       name: HassGetState
       slots:
@@ -59,35 +49,39 @@ tests:
 
   # CO2
   - sentences:
-      - "jaká je úroveň CO2 v obýváku"
+      - "jaká je úroveň CO2 na senzoru CO2 v obýváku"
+      - "jaká je změřená koncentrace CO2 senzorem CO2 v obýváku"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: carbon_dioxide
-        name: "v obýváku"
+        name: "CO2"
+        area: "obýváku"
     response: "50 ppm"
 
   # CO
   - sentences:
-      - "jaká je úroveň CO v obýváku"
+      - "jaká je úroveň CO na senzoru CO v obýváku"
+      - "jaká je změřená koncentrace CO senzorem CO v obýváku"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: carbon_monoxide
-        name: "v obýváku"
+        name: "CO"
+        area: "obýváku"
     response: "48 ppm"
 
   # Current
   - sentences:
-      - "jaký je elektrický proud nabíjení EV?"
+      - "jaký je elektrický proud nabíjení auta?"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: current
-        name: "nabíjení EV"
+        name: "nabíjení auta"
     response: "15 A"
 
   # Data rate
@@ -103,17 +97,19 @@ tests:
 
   # Data size
   - sentences:
-      - "jaká je velikost souboru?"
+      - "jak je velký soubor log?"
+      - "jaká je velikost souboru log"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: data_size
-        name: "souboru"
+        name: "log"
     response: "106 kB"
 
   # Date
   - sentences:
+      - "jaké je datum svoz odpadu?"
       - "kdy bude svoz odpadu?"
     intent:
       name: HassGetState
@@ -124,16 +120,6 @@ tests:
     response: "Svoz odpadu je 2024-04-01"
 
   # Distance
-  - sentences:
-      - "jaká je vzdálenost do práce?"
-    intent:
-      name: HassGetState
-      slots:
-        domain: sensor
-        device_class: distance
-        name: "do práce"
-    response: "Do práce je 23 km"
-
   - sentences:
       - "jak dlouhý je dojezd elektromobilu?"
     intent:
@@ -157,25 +143,25 @@ tests:
 
   # Energy
   - sentences:
-      - "jaká je energie solární elektrárny?"
+      - "jaké je množství energie produkce solární elektrárny?"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: energy
-        name: "solární elektrárny"
+        name: "produkce solární elektrárny"
     response: "3.2 kWh"
 
   # Energy storage
   - sentences:
-      - "Kolik je uložené energie v baterii?"
+      - "Kolik je uložené energie v akumulační baterii?"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: energy_storage
-        name: "v baterii"
-    response: "V baterii je 6 kWh"
+        name: "akumulační baterii"
+    response: "6 kWh"
 
   # Frequency
   - sentences:
@@ -190,47 +176,50 @@ tests:
 
   # Gas
   - sentences:
-      - "jaký je objem plynu za měsíc?"
+      - "jaký je objem plynu spotřebovaný za měsíc?"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: gas
-        name: "za měsíc"
+        name: "spotřebovaný za měsíc"
     response: "12 m³"
 
   # Humidity
   - sentences:
-      - "jaká je vlhkost vzduchu v obýváku?"
+      - "jaká je změřená vlhkost vzduchu na senzoru vlhkosti v obýváku?"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: humidity
-        name: "v obýváku"
-    response: "V obýváku je 48 %"
+        name: "vlhkosti"
+        area: "obýváku"
+    response: "48 %"
 
   # Illuminance
   - sentences:
-      - "jaká je intenzita světla v obýváku?"
+      - "jaká je změřená intenzita osvětlení senzorem intenzity světla v obýváku?"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: illuminance
-        name: "v obýváku"
-    response: "V obýváku je 438 lux"
+        name: "intenzity světla"
+        area: "obýváku"
+    response: "438 lux"
 
   # Irradiance
   - sentences:
-      - "jaká je úroveň ozáření v obýváku?"
+      - "jaká je úroveň ozáření na senzoru radiace v obýváku?"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: irradiance
-        name: "v obýváku"
-    response: "V obýváku je 155 W/m²"
+        name: "radiace"
+        area: "obýváku"
+    response: "155 W/m²"
 
   # Moisture
   - sentences:
@@ -245,7 +234,7 @@ tests:
 
   # Monetary
   - sentences:
-      - "kolik peněz je na účtě?"
+      - "kolik je peněz na účtě?"
     intent:
       name: HassGetState
       slots:
@@ -266,90 +255,94 @@ tests:
 
   # Nitrogen dioxide
   - sentences:
-      - "jaká je koncentrace NO2 v kotelně?"
+      - "jaká je změřená koncentrace oxidu dusičitého na senzoru NO2 na čerpadle?"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: nitrogen_dioxide
-        name: "v kotelně"
+        name: "NO2 na čerpadle"
     response: "50 µg/m³"
 
   # Nitrogen monoxide
   - sentences:
-      - "jaká je koncentrace NO v kotelně?"
+      - "jaká je změřená koncentrace oxidu dusnatého na senzoru NO na čerpadle?"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: nitrogen_monoxide
-        name: "v kotelně"
+        name: "NO na čerpadle"
     response: "50 µg/m³"
 
   # Nitrogen oxide
   - sentences:
-      - "jaká je koncentrace N2O v kotelně?"
+      - "jaká je změřená koncentrace oxidu dusného na senzoru N2O na čerpadle?"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: nitrous_oxide
-        name: "v kotelně"
+        name: "N2O na čerpadle"
     response: "50 µg/m³"
 
   # Ozone
   - sentences:
-      - "jaká je koncentrace ozonu v obýváku?"
+      - "jaká je naměřená koncentrace ozonu senzorem ozonu v obýváku?"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: ozone
-        name: "v obýváku"
+        name: "ozonu"
+        area: "obýváku"
     response: "50 µg/m³"
 
   # PM1
   - sentences:
-      - "jaká je koncentrace částic pm1 v obýváku?"
+      - "jaká je naměřená koncentrace částic pm1 na senzoru množství částic pm1 v obýváku?"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: pm1
-        name: "v obýváku"
+        name: "množství částic pm1"
+        area: "obýváku"
     response: "50 µg/m³"
 
   # PM2.5
   - sentences:
-      - "jaká je koncentrace částic pm2.5 v obýváku?"
+      - "jaká je naměřená koncentrace částic pm2.5 na senzoru množství částic pm2.5 v obýváku?"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: pm25
-        name: "v obýváku"
+        name: "množství částic pm2.5"
+        area: "obýváku"
     response: "50 µg/m³"
 
   # PM10
   - sentences:
-      - "jaká je koncentrace částic pm10 v obýváku?"
+      - "jaká je naměřená koncentrace částic pm10 na senzoru množství částic pm10 v obýváku?"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: pm10
-        name: "v obýváku"
+        name: "množství částic pm10"
+        area: "obýváku"
     response: "50 µg/m³"
 
   # Power factor
   - sentences:
-      - "jaký je účiník spotřeby domu?"
+      - "jaký je účiník lednice?"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: power_factor
-        name: "spotřeby domu"
+        name: "lednice"
     response: "2"
 
   # Power
@@ -431,46 +424,59 @@ tests:
 
   # Speed
   - sentences:
-      - "jaká je rychlost EV?"
+      - "jaká je rychlost auta?"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: speed
-        name: "EV"
+        name: "auta"
     response: "67 km/h"
 
   # Sulphur dioxide
   - sentences:
-      - "jaká je koncentrace SO2 ve vzduchu?"
+      - "jaká je změřená koncentrace oxidu siřičitého na senzoru SO2 ve vzduchu?"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: sulphur_dioxide
-        name: "ve vzduchu"
+        name: "SO2 ve vzduchu"
     response: "50 µg/m³"
+
+  # Teplota
+  - sentences:
+      - "Jaká je teplota naměřená teploměrem v obýváku"
+      - "Kolik stupňů je změřeno teploměrem v obýváku"
+    intent:
+      name: HassGetState
+      slots:
+        domain: sensor
+        device_class: temperature
+        name: "Teploměrem"
+        area: obýváku
+    response: "18 °C"
 
   # VOC
   - sentences:
-      - "jaké je množství volných organických látek ve vzduchu?"
+      - "jaké je změřené množství volných organických látek senzorem množství VOC ve vzduchu?"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: volatile_organic_compounds
-        name: "ve vzduchu"
+        name: "množství VOC ve vzduchu"
     response: "35 µg/m³"
 
   # VOC in parts
   - sentences:
-      - "jaká je koncentrace volných organických látek ve vzduchu?"
+      - "jaká je změřená koncentrace volných organických látek senzorem koncentrace částic VOC ve vzduchu?"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: volatile_organic_compounds_parts
-        name: "ve vzduchu"
+        name: "koncentrace částic VOC ve vzduchu"
     response: "35 ppm"
 
   # Voltage
@@ -508,24 +514,24 @@ tests:
 
   # Water
   - sentences:
-      - "jaký je objem vody naměřený senzorem voda?"
+      - "jaký je objem vody naměřený senzorem spotřebovaná voda?"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: water
-        name: "voda"
+        name: "spotřebovaná voda"
     response: "5987 L"
 
   # Weight
   - sentences:
-      - "jaká je hmotnost na senzoru postel?"
+      - "jaká je naměřená váha na posteli?"
     intent:
       name: HassGetState
       slots:
         domain: sensor
         device_class: weight
-        name: "postel"
+        name: "posteli"
     response: "87 kg"
 
   # Wind speed


### PR DESCRIPTION
Tests started to fail because many fixture entities had effectively same names. E.g.

- "[koncentrace NO2] v kotelně"
- "[koncentrace NO] v kotelně"
- "[koncentrace N2O] v kotelně"

Due to some change upstream now the engine can't match it correctly because it will try it only with the mandatory part.
Renamed entity names to something unique when necessary. Plus done some cleaning.