### PR TITLE
[CA] Add typo variant and new word case for StartTimer

### DIFF
--- a/sentences/ca/_common.yaml
+++ b/sentences/ca/_common.yaml
@@ -168,7 +168,7 @@ expansion_rules:
   lluentor: "{brightness}[<percent>]"
   al_stt_typo: "(del|el|en|o)"
   engega: "(encén|encendre|engega|posa|activa|<engega_stt_typo>)[r|t]"
-  engega_stt_typo: "((en|em)[ ](geguen|gendra|llega|sembla))|(Àngela|posen|posem|General)"
+  engega_stt_typo: "((en|em)[ ](geguen|gendra|llega|sembla))|(Àngela|cosa|posen|posem|General)"
   apaga: "(apaga|atura|desconnecta|para)[r|t]|<apaga_stt_typo>"
   apaga_stt_typo: "((potser|a) paga[r]|aparga|apaguen|apa ara|a part [de])"
   tanca: "tanca[r|t]"
@@ -197,8 +197,9 @@ expansion_rules:
   can_you: "[pots|podries]"
 
   # Timers
-  temporitzador: "(temporitzador|compte enrere|minuter)"
-  timer_set: "(posa|crea|comença|inicia|activa|programa|fixa|estableix|engega)[r|t|'m]"
+  temporitzador: "(temporitzador|compte enrere|minuter|cronòmetre)"
+  timer_set: "(posa|crea|comença|inicia|activa|programa|fixa|estableix|engega|<timer_set_typos>)[r|t|'m]"
+  timer_set_typos: "(cosa)"
   timer_cancel: "(cancel[·l]a|atura|para|deixa|elimina)[r|t]"
   timer_duration_seconds: "{timer_seconds:seconds} segon[s]"
   timer_duration_minutes: "({timer_minutes:minutes} minut[s][ [i ]{timer_seconds:seconds} segon[s]])|({timer_minutes:minutes} minut[s] i {timer_half:seconds})|({timer_half:seconds} minut[s])"

--- a/sentences/ca/homeassistant_HassStartTimer.yaml
+++ b/sentences/ca/homeassistant_HassStartTimer.yaml
@@ -5,9 +5,9 @@ intents:
     data:
       - sentences:
           - <temporitzador> [<of>]<timer_duration>
-          - <timer_set> [un] <temporitzador> [<of>]<timer_duration>
-          - <timer_set> [un] <temporitzador> [<of>]<timer_duration> [amb nom|anomenat|denominat] {timer_name:name}
-          - <timer_set> [un] <temporitzador> [amb nom|anomenat|denominat] {timer_name:name} [<of>]<timer_duration>
+          - <timer_set> [el|un] <temporitzador> [<of>]<timer_duration>
+          - <timer_set> [el|un] <temporitzador> [<of>]<timer_duration> [amb nom|anomenat|denominat] {timer_name:name}
+          - <timer_set> [el|un] <temporitzador> [amb nom|anomenat|denominat] {timer_name:name} [<of>]<timer_duration>
         expansion_rules:
           of: "en |de |d'"
 


### PR DESCRIPTION
Adding new word 🕑  `stopwatch` (cronòmetre) adds `15.797.346` variants (**+30.6%** ❕ )