### PR TITLE
[EN] Add floor support to HassClimateGetTemperature

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -260,6 +260,9 @@ HassClimateGetTemperature:
     area:
       description: "Name of an area"
       required: false
+    floor:
+      description: "Name of a floor"
+      required: false
   response_variables:
     state:
       description: "State of the entity that contains the temperature"

--- a/sentences/en/climate_HassClimateGetTemperature.yaml
+++ b/sentences/en/climate_HassClimateGetTemperature.yaml
@@ -13,7 +13,7 @@ intents:
       # Get temperature of a climate in an area or with a name
       - sentences:
           - "<what_is> [the] [current] <temp> [of] <name>"
-          - "<what_is> [the] [current] <temp> <in> <area>"
+          - "<what_is> [the] [current] <temp> <in_area_floor>"
           - "<what_is> <area> [current] <temp>"
           - "<what_is> <name> [current] <temp>"
-          - "how (hot|cold|warm|cool) is (<name>|[it <in>] <area>)"
+          - "how (hot|cold|warm|cool) is (<name>|[it] <in_area_floor>)"

--- a/tests/en/climate_HassClimateGetTemperature.yaml
+++ b/tests/en/climate_HassClimateGetTemperature.yaml
@@ -29,6 +29,15 @@ tests:
     response: "68 degrees"
 
   - sentences:
+      - "what's the temperature in the basement?"
+      - "how hot is it in the basement?"
+    intent:
+      name: HassClimateGetTemperature
+      slots:
+        floor: Basement
+    response: "1 degree"
+
+  - sentences:
       - "what is the temperature of the office thermostat?"
       - "what's the office thermostat temperature?"
       - "how hot is the office thermostat?"


### PR DESCRIPTION
English equivalent of #2788. Fixes https://github.com/home-assistant/core/issues/133733.

I removed `is it (hot|cold|warm|cool) [in <area>]`, as it didn't seem to work and doesn't really make much sense considering the response ("N degrees"). Happy to add it back (and fix it) if it's still wanted.