### PR TITLE
[EN] Add area-awareness to HassClimateGetTemperature

### DIFF
--- a/sentences/en/climate_HassClimateGetTemperature.yaml
+++ b/sentences/en/climate_HassClimateGetTemperature.yaml
@@ -2,18 +2,18 @@ language: "en"
 intents:
   HassClimateGetTemperature:
     data:
-      # What is...
+      # Get temperature of a climate in the same area as a satellite device
+      - sentences:
+          - "<what_is> [the] [current] <temp> [<here>]"
+          - "how (hot|cold|warm|cool) is it [<here>]"
+        requires_context:
+          area:
+            slot: true
+
+      # Get temperature of a climate in an area or with a name
       - sentences:
           - "<what_is> [the] [current] <temp> [of] <name>"
-          - "<what_is> [the] [current] <temp> [in <area>]"
+          - "<what_is> [the] [current] <temp> <in> <area>"
           - "<what_is> <area> [current] <temp>"
           - "<what_is> <name> [current] <temp>"
-      # How...
-      - sentences:
-          - "how (hot|cold|warm|cool) is it [in <area>]"
-          - "how (hot|cold|warm|cool) is <name>"
-      # Is it...
-      - sentences:
-          - "is it (hot|cold|warm|cool) [in <area>]"
-        requires_context:
-          domain: "climate"
+          - "how (hot|cold|warm|cool) is (<name>|[it <in>] <area>)"

--- a/tests/en/climate_HassClimateGetTemperature.yaml
+++ b/tests/en/climate_HassClimateGetTemperature.yaml
@@ -1,17 +1,22 @@
 language: en
 tests:
   - sentences:
-      - "what's the temperature?"
-      - "what's the temp?"
+      - "what is the temperature in here?"
       - "what is the temperature?"
-      - "what is the temp?"
+      - "how warm is it in here?"
+      - "how warm is it?"
     intent:
       name: HassClimateGetTemperature
-    response: "68 degrees"
+      context:
+        area: Office
+      slots:
+        area: Office
+    response: "1 degree"
 
   - sentences:
       - "what is the temperature in the living room?"
       - "how hot is it in the living room?"
+      - "how hot is the living room?"
       - "what is the living room temperature?"
       - "what's the temperature in the living room?"
       - "what's the living room temperature?"


### PR DESCRIPTION
Split from #2790 as floor awareness requires core changes.

English equivalent of #2788. Fixes https://github.com/home-assistant/core/issues/133733.

I removed `is it (hot|cold|warm|cool) [in <area>]`, as it didn't seem to work and doesn't really make much sense considering the response ("N degrees"). Happy to add it back (and fix it) if it's still wanted.