### PR TITLE
[DA] chnage wording for timer in Danish in Update _common.yaml

### DIFF
--- a/sentences/da/_common.yaml
+++ b/sentences/da/_common.yaml
@@ -37,9 +37,9 @@ responses:
     duplicate_entities_in_floor: "Undskyld, er er flere enheder med navnet {{ entity }} på {{ floor }} etage"
 
     # Errors for timers / Fejl for nedtælling
-    timer_not_found: "Undskyld, den timer kunne jeg ikke finde"
-    multiple_timers_matched: "Undskyld, jeg kan ikke håndtere flere timer"
-    no_timer_support: "Undskyld, timer er ikk eunderstøttet på denne enhed"
+    timer_not_found: "Undskyld, den nedtælling kunne jeg ikke finde"
+    multiple_timers_matched: "Undskyld, jeg kan ikke håndtere flere nedtællinger"
+    no_timer_support: "Undskyld, nedtælling er ikke eunderstøttet på denne enhed"
 
 lists:
   brightness:
@@ -370,8 +370,8 @@ expansion_rules:
   i: "(i|[oppe ]på)"
 
   # Timers
-  timer: "(timer | nedtælling)"
-  timers: "(timere | nedtællinger)"
+  timer: "(nedtælling | timer)"
+  timers: "(nedtællinger | timere)"
   timer_pause: "(pause|[midlertidig ](stop|stands)[e])"
   timer_unpause: "(fortsæt|genoptage)"
   timer_add: "(læg til|øge)"


### PR DESCRIPTION
"Timer" is not pronounce correctly in Danish, it should be "nedtælling" as the default.