### PR TITLE
Enable support for `HassClimateSetTemperature` intent

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -232,7 +232,7 @@ HassLightSet:
 # -----------------------------------------------------------------------------
 
 HassClimateSetTemperature:
-  supported: false
+  supported: true
   domain: climate
   description: "Sets the desired temperature of a climate device or entity"
   slots:


### PR DESCRIPTION
- ~~needs: https://github.com/home-assistant/core/pull/134316~~
- needs: https://github.com/home-assistant/core/pull/136484

At the moment the action `climate.set_temperature` does not support the `temperature_unit` argument -> an [architectural discussion](https://github.com/home-assistant/architecture/discussions/1177) has been started, but it most properly results in a more broader and generic solution, than just add the argument to this single action call.

So even the intent supports the `temperature_unit` argument, the underlying action call doesn't.
Can we keep `temperature_unit` argument in the existing sentences or should we remove it for now?

