### PR TITLE
[EN] Add queries for multiple door and window states

### DIFF
--- a/sentences/en/binary_sensor_HassGetState.yaml
+++ b/sentences/en/binary_sensor_HassGetState.yaml
@@ -214,6 +214,34 @@ intents:
           domain: binary_sensor
           device_class: door
 
+      - sentences:
+          - "(is|are) any door[s] {bs_door_states:state} [in <area>]"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: door
+
+      - sentences:
+          - "are all [the] door[s] {bs_door_states:state} [in <area>]"
+        response: all
+        slots:
+          domain: binary_sensor
+          device_class: door
+
+      - sentences:
+          - "(which|what) door[s] (is|are) {bs_door_states:state} [in <area>]"
+        response: which
+        slots:
+          domain: binary_sensor
+          device_class: door
+
+      - sentences:
+          - "how many door[s] (is|are) {bs_door_states:state} [in <area>]"
+        response: how_many
+        slots:
+          domain: binary_sensor
+          device_class: door
+
       # Garage door
       - sentences:
           - "(is|are) <name> {bs_garage_door_states:state} [in <area>]"
@@ -221,6 +249,34 @@ intents:
         requires_context:
           domain: binary_sensor
           device_class: garage_door
+        slots:
+          domain: binary_sensor
+          device_class: garage_door
+
+      - sentences:
+          - "(is|are) any garage door[s] {bs_door_states:state} [in <area>]"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: garage_door
+
+      - sentences:
+          - "are all [the] garage door[s] {bs_door_states:state} [in <area>]"
+        response: all
+        slots:
+          domain: binary_sensor
+          device_class: garage_door
+
+      - sentences:
+          - "(which|what) garage door[s] (is|are) {bs_door_states:state} [in <area>]"
+        response: which
+        slots:
+          domain: binary_sensor
+          device_class: garage_door
+
+      - sentences:
+          - "how many garage door[s] (is|are) {bs_door_states:state} [in <area>]"
+        response: how_many
         slots:
           domain: binary_sensor
           device_class: garage_door
@@ -890,6 +946,34 @@ intents:
         requires_context:
           domain: binary_sensor
           device_class: window
+        slots:
+          domain: binary_sensor
+          device_class: window
+
+      - sentences:
+          - "(is|are) any window[s] {bs_window_states:state} [in <area>]"
+        response: any
+        slots:
+          domain: binary_sensor
+          device_class: window
+
+      - sentences:
+          - "are all [the] window[s] {bs_window_states:state} [in <area>]"
+        response: all
+        slots:
+          domain: binary_sensor
+          device_class: window
+
+      - sentences:
+          - "(which|what) window[s] (is|are) {bs_window_states:state} [in <area>]"
+        response: which
+        slots:
+          domain: binary_sensor
+          device_class: window
+
+      - sentences:
+          - "how many window[s] (is|are) {bs_window_states:state} [in <area>]"
+        response: how_many
         slots:
           domain: binary_sensor
           device_class: window

--- a/tests/en/_fixtures.yaml
+++ b/tests/en/_fixtures.yaml
@@ -218,11 +218,27 @@ entities:
     attributes:
       device_class: door
 
+  - name: "Front Door"
+    id: "binary_sensor.front_door"
+    state:
+      in: "opened"
+      out: "on"
+    attributes:
+      device_class: door
+
   - name: "Secondary Garage Door"
     id: "binary_sensor.garage_door"
     state:
       in: "closed"
       out: "off"
+    attributes:
+      device_class: garage_door
+
+  - name: "Side Garage Door"
+    id: "binary_sensor.side_garage_door"
+    state:
+      in: "opened"
+      out: "on"
     attributes:
       device_class: garage_door
 
@@ -390,6 +406,22 @@ entities:
     state:
       in: "open"
       out: "on"
+    attributes:
+      device_class: window
+
+  - name: "Office Window"
+    id: "binary_sensor.office_window"
+    state:
+      in: "closed"
+      out: "off"
+    attributes:
+      device_class: window
+
+  - name: "Kitchen Window"
+    id: "binary_sensor.kitchen_window"
+    state:
+      in: "closed"
+      out: "off"
     attributes:
       device_class: window
 

--- a/tests/en/binary_sensor_HassGetState.yaml
+++ b/tests/en/binary_sensor_HassGetState.yaml
@@ -286,7 +286,123 @@ tests:
         state: "on"
     response: "No, closed"
 
+  - sentences:
+      - "is the pet door closed?"
+      - "is the pet door shut?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "binary_sensor"
+        device_class: "door"
+        name: "Pet Door"
+        state: "off"
+    response: "Yes"
+
+  - sentences:
+      - "are any doors open?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: door
+        state: "on"
+    response: "Yes, Front Door"
+
+  - sentences:
+      - "are any doors closed?"
+      - "are any doors shut?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: door
+        state: "off"
+    response: "Yes, Pet Door"
+
+  - sentences:
+      - "are all doors open?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: door
+        state: "on"
+    response: "No, Pet Door is not open"
+
+  - sentences:
+      - "are all doors closed?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: door
+        state: "off"
+    response: "No, Front Door is not closed"
+
+  - sentences:
+      - "are all doors shut?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: door
+        state: "off"
+    response: "No, Front Door is not shut"
+
+  - sentences:
+      - "which doors are open?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: door
+        state: "on"
+    response: "Front Door"
+
+  - sentences:
+      - "which doors are closed?"
+      - "which doors are shut?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: door
+        state: "off"
+    response: "Pet Door"
+
+  - sentences:
+      - "how many doors are open?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: door
+        state: "on"
+    response: "1"
+
+  - sentences:
+      - "how many doors are closed?"
+      - "how many doors are shut?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: door
+        state: "off"
+    response: "1"
+
   # Garage door
+  - sentences:
+      - "is the secondary garage door open?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: "binary_sensor"
+        device_class: "garage_door"
+        name: "Secondary Garage Door"
+        state: "on"
+    response: "No, closed"
+
   - sentences:
       - "is the secondary garage door closed?"
       - "is the secondary garage door shut?"
@@ -298,6 +414,99 @@ tests:
         name: "Secondary Garage Door"
         state: "off"
     response: "Yes"
+
+  - sentences:
+      - "are any garage doors open?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: garage_door
+        state: "on"
+    response: "Yes, Side Garage Door"
+
+  - sentences:
+      - "are any garage doors closed?"
+      - "are any garage doors shut?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: garage_door
+        state: "off"
+    response: "Yes, Secondary Garage Door"
+
+  - sentences:
+      - "are all garage doors open?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: garage_door
+        state: "on"
+    response: "No, Secondary Garage Door is not open"
+
+  - sentences:
+      - "are all garage doors closed?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: garage_door
+        state: "off"
+    response: "No, Side Garage Door is not closed"
+
+  - sentences:
+      - "are all garage doors shut?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: garage_door
+        state: "off"
+    response: "No, Side Garage Door is not shut"
+
+  - sentences:
+      - "which garage doors are open?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: garage_door
+        state: "on"
+    response: "Side Garage Door"
+
+  - sentences:
+      - "which garage doors are closed?"
+      - "which garage doors are shut?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: garage_door
+        state: "off"
+    response: "Secondary Garage Door"
+
+  - sentences:
+      - "how many garage doors are open?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: garage_door
+        state: "on"
+    response: "1"
+
+  - sentences:
+      - "how many garage doors are closed?"
+      - "how many garage doors are shut?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: garage_door
+        state: "off"
+    response: "1"
 
   # Gas
   - sentences:
@@ -1190,3 +1399,96 @@ tests:
         name: "Shed Window"
         state: "off"
     response: "No, open"
+
+  - sentences:
+      - "are any windows open?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: window
+        state: "on"
+    response: "Yes, Shed Window"
+
+  - sentences:
+      - "are any windows closed?"
+      - "are any windows shut?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: window
+        state: "off"
+    response: "Yes, Kitchen Window and Office Window"
+
+  - sentences:
+      - "are all windows open?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: window
+        state: "on"
+    response: "No, Kitchen Window and Office Window are not open"
+
+  - sentences:
+      - "are all windows closed?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: window
+        state: "off"
+    response: "No, Shed Window is not closed"
+
+  - sentences:
+      - "are all windows shut?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: window
+        state: "off"
+    response: "No, Shed Window is not shut"
+
+  - sentences:
+      - "which windows are open?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: window
+        state: "on"
+    response: "Shed Window"
+
+  - sentences:
+      - "which windows are closed?"
+      - "which windows are shut?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: window
+        state: "off"
+    response: "Kitchen Window and Office Window"
+
+  - sentences:
+      - "how many windows are open?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: window
+        state: "on"
+    response: "1"
+
+  - sentences:
+      - "how many windows are closed?"
+      - "how many windows are shut?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: binary_sensor
+        device_class: window
+        state: "off"
+    response: "2"


### PR DESCRIPTION
Add queries for "how many", "which", and "are any/all" states for
`door`, `garage_door`, and `window` devices.

For example, can now ask "How many doors are opened".
Previously Assist would always respond with "0".