### PR TITLE
[EN] Update commands URL

### DIFF
--- a/responses/en/HassRespond.yaml
+++ b/responses/en/HassRespond.yaml
@@ -6,5 +6,5 @@ responses:
       hello: "Hello from Home Assistant."
       listening: "No, I only record when you speak the wake word."
       data: "Your data is sent to your Home Assistant server."
-      commands: "To learn what you can ask, visit H.A. dot I.O. slash voice."
+      commands: "To learn what you can ask, visit home dash assistant dot I.O. slash voice."
       creator: "I was created by the wonderful Home Assistant community, made up of tinkerers world wide."

--- a/tests/en/homeassistant_HassRespond.yaml
+++ b/tests/en/homeassistant_HassRespond.yaml
@@ -30,7 +30,7 @@ tests:
       - "what can I say?"
     intent:
       name: HassRespond
-    response: "To learn what you can ask, visit H.A. dot I.O. slash voice."
+    response: "To learn what you can ask, visit home dash assistant dot I.O. slash voice."
 
   - sentences:
       - "who made you?"


### PR DESCRIPTION
Changed to the full Home Assistant URL to avoid confusion with visiting ha.io. home-assistant/home-assistant.io#36804 adds the redirect for this.