### PR TITLE
[SV] Translate percent into Swedish

### DIFF
--- a/sentences/sv/_common.yaml
+++ b/sentences/sv/_common.yaml
@@ -350,7 +350,7 @@ expansion_rules:
   vad: "(vad är | vad är det | vad är det för | vilken)"
   var: "(var | var är | vart | vart är)"
   är: "(är det | är)"
-  brightness: "{brightness}[%| percent]"
+  brightness: "{brightness}[%| procent]"
   slå_på: "(tänd | sätt (på | igång | fart på) | slå (på | till) | starta)"
   slå_av: "(slå (av | från | ifrån) | släck | stäng [av] | stoppa)"
   i_på: "(i | på | vid | bredvid)"

--- a/tests/sv/light_HassLightSet.yaml
+++ b/tests/sv/light_HassLightSet.yaml
@@ -2,6 +2,7 @@ language: sv
 tests:
   - sentences:
       - Sätt garagelampan till 50%
+      - Sätt garagelampan till 50 procent
       - Vrid upp garagelampa till 50%
       - Vrid ner garagelampans ljusstyrka till 50
       - Skruva ner garagelampans intensitet till 50%


### PR DESCRIPTION
During discussions on a Swedish home automation discord we figured out that controlling light levels didn't work and it turned out to be that the word for percent wasn't translated into Swedish.