### PR TITLE
[IT] Cleanup in _common.yaml

### DIFF
--- a/sentences/it/_common.yaml
+++ b/sentences/it/_common.yaml
@@ -6,7 +6,7 @@ responses:
     handle_error: "Si è verificato un errore inatteso durante l'elaborazione"
 
     # Errori per quando un utente non ha effettuato l'accesso
-    no_area: "Non conosco nessuna area chiamata {{ area }}"
+    no_area: "Mi dispiace, non conosco nessuna area chiamata {{ area }}"
     no_floor: "Mi dispiace, non conosco nessun piano chiamato {{ floor }}"
     no_domain: "Mi dispiace, non conosco nessun dispositivo appartenente al dominio {{ domain }}"
     no_domain_in_area: "Mi dispiace, nell'area {{ area }} non conosco nessun dispositivo appartenente al dominio {{ domain }}"

--- a/sentences/it/_common.yaml
+++ b/sentences/it/_common.yaml
@@ -432,8 +432,8 @@ expansion_rules:
   # Posti, aree e luoghi
   in_here: "(qu(a|i)|in questa (stanza|camera))"
   home: "(casa|appartamento)"
-  area: "[<the>][area ]{area}"
-  floor: "[<the>][floor ]{floor}"
+  area: "[area ]{area}"
+  floor: "[floor ]{floor}"
   everywhere: "(dappertutto|ovunque|[in] tutt(a|o) [<the>]<home>)"
 
   # Altro

--- a/sentences/it/_common.yaml
+++ b/sentences/it/_common.yaml
@@ -390,7 +390,7 @@ lists:
 
 expansion_rules:
   # Parti del discorso
-  the: "(l(o |a |e )|i[l] |gli |l(`|’|')[ ]|in |a |(a|ne)(l |llo |lla |lle |ll(`|’|')[ ]|gli ))"
+  the: "(l(o |a |e )|i[l] |gli |l(`|’|')[ ])"
   in: "(all'interno |dentro |in | ne[l |i |gli |llo |lla |lle |ll(`|’|')[ ]])"
   "on": "su[l|lla]"
   of: "(de[l |llo |lla |lle |ll(`|’|')[ ]|i |gli ]|di )"

--- a/sentences/it/homeassistant_HassCancelAllTimers.yaml
+++ b/sentences/it/homeassistant_HassCancelAllTimers.yaml
@@ -6,6 +6,6 @@ intents:
           - "<timer_cancel> <all> [<the>] [miei] timer"
           - "<timer_cancel> i [miei] timer"
       - sentences:
-          - "<timer_cancel> <all> [<the>] [miei] timer <area>"
-          - "<timer_cancel> i [miei] timer <area>"
+          - "<timer_cancel> <all> [<the>] [miei] timer [<in>] <area>"
+          - "<timer_cancel> i [miei] timer [<in>] <area>"
         response: area


### PR DESCRIPTION
Removed redundancies in `<the>` expansion rule.
To allow for this, minor changes were needed in 'CancelAllTimers' sentences.