### PR TITLE
[EN] Remove say from English

### DIFF
--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -360,9 +360,6 @@ lists:
   timer_command:
     wildcard: true
 
-  response:
-    wildcard: true
-
 expansion_rules:
   the: "(the|my|our)"
   name: "[<the>] {name}"

--- a/sentences/en/homeassistant_HassRespond.yaml
+++ b/sentences/en/homeassistant_HassRespond.yaml
@@ -3,9 +3,6 @@ intents:
   HassRespond:
     data:
       - sentences:
-          - "say {response}"
-
-      - sentences:
           - "(hello|hi) [home assistant]"
         response: hello
 

--- a/tests/en/homeassistant_HassRespond.yaml
+++ b/tests/en/homeassistant_HassRespond.yaml
@@ -1,14 +1,6 @@
 language: en
 tests:
   - sentences:
-      - "say I'm a little teapot"
-    intent:
-      name: HassRespond
-      slots:
-        response: "I'm a little teapot"
-    response: "I'm a little teapot"
-
-  - sentences:
       - "hi home assistant"
     intent:
       name: HassRespond


### PR DESCRIPTION
Remove "say {message}" from English sentences. This interacts poorly with skip words and LLMs, for example "can you say that again" will respond with "that again" instead of being processed by the LLM.