### PR TITLE
[EN] Add HassBroadcast

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -149,6 +149,15 @@ HassRespond:
       description: "Text to respond with"
       required: false
 
+HassBroadcast:
+  supported: true
+  domain: assist_satellite
+  description: "Announces a message on other satellites."
+  slots:
+    message:
+      description: "Message to broadcast"
+      required: true
+
 HassSetPosition:
   supported: true
   domain: homeassistant

--- a/responses/en/assist_satellite_HassBroadcast.yaml
+++ b/responses/en/assist_satellite_HassBroadcast.yaml
@@ -1,0 +1,5 @@
+language: en
+responses:
+  intents:
+    HassBroadcast:
+      default: "Done"

--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -360,6 +360,9 @@ lists:
   timer_command:
     wildcard: true
 
+  message:
+    wildcard: true
+
 expansion_rules:
   the: "(the|my|our)"
   name: "[<the>] {name}"

--- a/sentences/en/assist_satellite_HassBroadcast.yaml
+++ b/sentences/en/assist_satellite_HassBroadcast.yaml
@@ -1,0 +1,6 @@
+language: "en"
+intents:
+  HassBroadcast:
+    data:
+      - sentences:
+          - "broadcast [that] {message}"

--- a/tests/en/assist_satellite_HassBroadcast.yaml
+++ b/tests/en/assist_satellite_HassBroadcast.yaml
@@ -1,0 +1,9 @@
+language: en
+tests:
+  - sentences:
+      - "broadcast that dinner is ready"
+    intent:
+      name: HassBroadcast
+      slots:
+        message: "dinner is ready"
+    response: "Done"


### PR DESCRIPTION
Adds support for `HassBroadcast` intent: https://github.com/home-assistant/core/pull/135337

This intent announces a message on every other Assist satellite (or all satellites if used through the web UI).