### PR TITLE
[NL] Fix HassGetWeather

### DIFF
--- a/responses/nl/HassGetWeather.yaml
+++ b/responses/nl/HassGetWeather.yaml
@@ -3,22 +3,4 @@ responses:
   intents:
     HassGetWeather:
       default: >
-        {% set weather_condition = {
-          'clear': 'en helder',
-          'clear-night': 'en helder',
-          'cloudy': 'en bewolkt',
-          'exceptional': 'en extreem',
-          'fog': 'met mist',
-          'hail': 'met hagel',
-          'lightning': 'met onweer',
-          'lightning-rainy': 'met onweer en regen',
-          'partlycloudy': 'en gedeeltelijk bewolkt',
-          'pouring': 'met stortregen',
-          'rainy': 'met regen',
-          'snowy': 'met sneeuw',
-          'snowy-rainy': 'met sneeuw en regen',
-          'sunny': 'en zonnig',
-          'windy': 'met wind',
-          'windy-variant': 'met wind en bewolking'
-        } %}
-        {{ state.attributes.get('temperature') }} graden {{ weather_condition.get((state.state | string).lower(), "") }}
+        {{ state.attributes.get('temperature') }} graden en {{ state.state | lower }}

--- a/tests/nl/_fixtures.yaml
+++ b/tests/nl/_fixtures.yaml
@@ -746,14 +746,14 @@ entities:
 
   - name: "Tilburg"
     id: "weather.tilburg"
-    state: "sunny"
+    state: "Zonnig"
     attributes:
       temperature: "20"
       temperature_unit: "°C"
 
   - name: "Amsterdam"
     id: "weather.london"
-    state: "rainy"
+    state: "Regenachtig"
     attributes:
       temperature: "12"
       temperature_unit: "°C"

--- a/tests/nl/weather_HassGetWeather.yaml
+++ b/tests/nl/weather_HassGetWeather.yaml
@@ -16,4 +16,4 @@ tests:
       name: HassGetWeather
       slots:
         name: Amsterdam
-    response: 12 graden met regen
+    response: 12 graden en regenachtig


### PR DESCRIPTION
After getting some reports that HassGetWeather didn't return the current state, I did some testing on my local instance.

Apparantly ` state.state`  already returns the translated weather state for the weather entity, so the template using the mapping didn't return anything (as it expects the original untranslated entity state).

This way it will return a weather condition, and not only the temperature.