### PR TITLE
[DE] Fix HassGetWeather

### DIFF
--- a/responses/de/HassGetWeather.yaml
+++ b/responses/de/HassGetWeather.yaml
@@ -23,4 +23,4 @@ responses:
             'Schneefall': 'Schneefall',
             'Schneeregen': 'Schneeregen'
         } %}
-        {{ state.attributes.get('temperature') }} {{ state.attributes.get('temperature_unit') }} und {{ non_lower_cased.get(state.state) | default(state.state | lower, true) }}
+        {{ state.attributes.get('temperature') }} {{ state.attributes.get('temperature_unit') }} und {{ non_lower_cased.get(state.state, state.state | lower) }}

--- a/responses/de/HassGetWeather.yaml
+++ b/responses/de/HassGetWeather.yaml
@@ -23,4 +23,4 @@ responses:
             'Schneefall': 'Schneefall',
             'Schneeregen': 'Schneeregen'
         } %}
-        {{ state.attributes.get('temperature') }}{{ state.attributes.get('temperature_unit') }} und {{ non_lower_cased.get(state.state) | default(state.state | lower, true) }}
+        {{ state.attributes.get('temperature') }} {{ state.attributes.get('temperature_unit') }} und {{ non_lower_cased.get(state.state) | default(state.state | lower, true) }}

--- a/responses/de/HassGetWeather.yaml
+++ b/responses/de/HassGetWeather.yaml
@@ -3,22 +3,24 @@ responses:
   intents:
     HassGetWeather:
       default: >
-        {% set weather_condition = {
-          'clear': 'und klar',
-          'clear-night': 'und klare Nacht',
-          'cloudy': 'und bewölkt',
-          'exceptional': 'und außergewöhnlich',
-          'fog': 'mit Nebel',
-          'hail': 'mit Hagel',
-          'lightning': 'mit Gewitter',
-          'lightning-rainy': 'mit Gewitter und Regen',
-          'partlycloudy': 'und teilweise bewölkt',
-          'pouring': 'und strömender Regen',
-          'rainy': 'und regnerisch',
-          'snowy': 'und verschneit',
-          'snowy-rainy': 'mit Schnee und Regen',
-          'sunny': 'und sonnig',
-          'windy': 'und windig',
-          'windy-variant': 'mit Wind und Wolken'
+        {#
+          Note: The weather conditions in state.state have already been translated*, so we lowercase
+          most of them for correct spelling in the response. A dictionary is used for conditions that
+          must not be lowercased, require only partial lowercasing, or need to be transformed.
+
+          * This dictionary may become outdated and should be updated whenever there were changes for
+          weather conditions on lokalise.com. Translations for weather conditions are prefixed as follows:
+          component::weather::entity_component::_::state::<the-actual-condition>
+        #}
+        {% set non_lower_cased = {
+            'Klare Nacht': 'klare Nacht',
+            'Außergewöhnlich': 'außergewöhnliches Wetter',
+            'Nebel': 'Nebel',
+            'Hagel': 'Hagel',
+            'Gewitter': 'Gewitter',
+            'Gewitter, regnerisch': 'Gewitter, regnerisch',
+            'Strömender Regen': 'strömender Regen',
+            'Schneefall': 'Schneefall',
+            'Schneeregen': 'Schneeregen'
         } %}
-        {{ state.attributes.get('temperature') }} {{ state.attributes.get('temperature_unit') }} {{ weather_condition.get((state.state | string).lower(), "") }}
+        {{ state.attributes.get('temperature') }}{{ state.attributes.get('temperature_unit') }} und {{ non_lower_cased.get(state.state) | default(state.state | lower, true) }}

--- a/tests/de/_fixtures.yaml
+++ b/tests/de/_fixtures.yaml
@@ -263,14 +263,14 @@ entities:
 
   - name: "Berlin"
     id: "weather.berlin"
-    state: "rainy"
+    state: "Regnerisch"
     attributes:
       temperature: "8"
       temperature_unit: "°C"
 
   - name: "Los Angeles"
     id: "weather.los_angeles"
-    state: "clear"
+    state: "Strömender Regen"
     attributes:
       temperature: "25"
       temperature_unit: "°C"

--- a/tests/de/weather_HassGetWeather.yaml
+++ b/tests/de/weather_HassGetWeather.yaml
@@ -5,7 +5,7 @@ tests:
       - "wie ist Wetter"
     intent:
       name: HassGetWeather
-    response: 8°C und regnerisch
+    response: 8 °C und regnerisch
 
   - sentences:
       - "wie ist das Wetter in Berlin?"
@@ -18,7 +18,7 @@ tests:
       name: HassGetWeather
       slots:
         name: Berlin
-    response: 8°C und regnerisch
+    response: 8 °C und regnerisch
 
   - sentences:
       - "wie ist das Los Angeles Wetter?"
@@ -26,4 +26,4 @@ tests:
       name: HassGetWeather
       slots:
         name: Los Angeles
-    response: 25°C und strömender Regen
+    response: 25 °C und strömender Regen

--- a/tests/de/weather_HassGetWeather.yaml
+++ b/tests/de/weather_HassGetWeather.yaml
@@ -5,7 +5,7 @@ tests:
       - "wie ist Wetter"
     intent:
       name: HassGetWeather
-    response: 8 °C und regnerisch
+    response: 8°C und regnerisch
 
   - sentences:
       - "wie ist das Wetter in Berlin?"
@@ -18,7 +18,7 @@ tests:
       name: HassGetWeather
       slots:
         name: Berlin
-    response: 8 °C und regnerisch
+    response: 8°C und regnerisch
 
   - sentences:
       - "wie ist das Los Angeles Wetter?"
@@ -26,4 +26,4 @@ tests:
       name: HassGetWeather
       slots:
         name: Los Angeles
-    response: 25 °C und klar
+    response: 25°C und strömender Regen


### PR DESCRIPTION
as discussed on Discord regarding translation issues and similar to https://github.com/home-assistant/intents/pull/2901. contains some minor adjustments to not lowercase when this results in incorrect spelling or weird responses like:

- `23 °C und regen` -> `23 °C und Regen`
- `10 °C und hagel` -> `10 °C und Hagel`
- `12 °C und außergewöhnlich` -> `12 °C und außergewöhnliches Wetter`

Since this will not work (but not break!) once any of those special transformations changes over on lokalise.com, I added a comment for awareness.