### PR TITLE
Revert "[NL] Fix HassGetWeather"

### DIFF
--- a/responses/nl/HassGetWeather.yaml
+++ b/responses/nl/HassGetWeather.yaml
@@ -3,4 +3,22 @@ responses:
   intents:
     HassGetWeather:
       default: >
-        {{ state.attributes.get('temperature') }} graden en {{ state.state | lower }}
+        {% set weather_condition = {
+          'clear': 'en helder',
+          'clear-night': 'en helder',
+          'cloudy': 'en bewolkt',
+          'exceptional': 'en extreem',
+          'fog': 'met mist',
+          'hail': 'met hagel',
+          'lightning': 'met onweer',
+          'lightning-rainy': 'met onweer en regen',
+          'partlycloudy': 'en gedeeltelijk bewolkt',
+          'pouring': 'met stortregen',
+          'rainy': 'met regen',
+          'snowy': 'met sneeuw',
+          'snowy-rainy': 'met sneeuw en regen',
+          'sunny': 'en zonnig',
+          'windy': 'met wind',
+          'windy-variant': 'met wind en bewolking'
+        } %}
+        {{ state.attributes.get('temperature') }} graden {{ weather_condition.get((state.state | string).lower(), "") }}

--- a/tests/nl/_fixtures.yaml
+++ b/tests/nl/_fixtures.yaml
@@ -746,14 +746,14 @@ entities:
 
   - name: "Tilburg"
     id: "weather.tilburg"
-    state: "Zonnig"
+    state: "sunny"
     attributes:
       temperature: "20"
       temperature_unit: "°C"
 
   - name: "Amsterdam"
     id: "weather.london"
-    state: "Regenachtig"
+    state: "rainy"
     attributes:
       temperature: "12"
       temperature_unit: "°C"

--- a/tests/nl/weather_HassGetWeather.yaml
+++ b/tests/nl/weather_HassGetWeather.yaml
@@ -16,4 +16,4 @@ tests:
       name: HassGetWeather
       slots:
         name: Amsterdam
-    response: 12 graden en regenachtig
+    response: 12 graden met regen


### PR DESCRIPTION
Reverts home-assistant/intents#2901

Revert PR as https://github.com/home-assistant/core/pull/136382 will result in the untranslated states being used.
So then the original approach will work.