### PR TITLE
[FR] weather state is now exposed raw and untranslated

### DIFF
--- a/responses/fr/HassGetWeather.yaml
+++ b/responses/fr/HassGetWeather.yaml
@@ -102,11 +102,11 @@ responses:
           'kn': 'nœuds',
         }.get(wind_speed_unit, wind_speed_unit) %}
 
-        {% if beaufort_scale and wind_bearing_text and wind_gust_speed is number %}
+        {% if beaufort_scale and wind_bearing_text and wind_gust_speed %}
           {{ beaufort_scale }} de {{ wind_speed | int }} {{ wind_speed_unit }} {{ wind_bearing_text }}, avec des rafales à {{ wind_gust_speed | int }} {{ wind_speed_unit }}.
         {% elif beaufort_scale and wind_bearing_text %}
           {{ beaufort_scale }} de {{ wind_speed | int }} {{ wind_speed_unit }} {{ wind_bearing_text }}.
-        {% elif beaufort_scale and wind_gust_speed is number %}
+        {% elif beaufort_scale and wind_gust_speed %}
           {{ beaufort_scale }} de {{ wind_speed | int }} {{ wind_speed_unit }}, avec des rafales à {{ wind_gust_speed | int }} {{ wind_speed_unit }}.
         {% elif beaufort_scale %}
           {{ beaufort_scale }} de {{ wind_speed | int }} {{ wind_speed_unit }}.
@@ -209,14 +209,14 @@ responses:
           'kn': 'nœuds',
         }.get(wind_speed_unit, wind_speed_unit) %}
 
-        {% if beaufort_force and wind_gust_speed is number %}
+        {% if beaufort_force and wind_gust_speed %}
           Vent de force : {{ beaufort_force }}, avec des rafales.
         {% elif beaufort_force %}
           Vent de force : {{ beaufort_force }}.
-        {% elif wind_speed is number and wind_gust_speed is number %}
+        {% elif wind_speed and wind_gust_speed %}
           Vent de {{ wind_speed | int }} {{ wind_speed_unit }}, avec des rafales.
-        {% elif wind_speed is number %}
+        {% elif wind_speed %}
           Vent de {{ wind_speed | int }} {{ wind_speed_unit }}.
-        {% elif wind_gust_speed is number %}
+        {% elif wind_gust_speed %}
           Rafales de {{ wind_gust_speed | int }} {{ wind_speed_unit }}.
         {% endif %}

--- a/responses/fr/HassGetWeather.yaml
+++ b/responses/fr/HassGetWeather.yaml
@@ -3,9 +3,24 @@ responses:
   intents:
     HassGetWeather:
       default: >
-        {# Reuse weather condition already formatted and translated #}
-        {# just invert telling the condition then temperature #}
-        {{ state.state }}
+        {% set weather_condition = {
+          'clear-night': 'Nuit dégagée',
+          'cloudy': 'Nuageux',
+          'exceptional': 'Conditions exceptionnelles',
+          'fog': 'Brouillard',
+          'hail': 'Grêle',
+          'lightning': 'Orageux',
+          'lightning-rainy': 'Orageux avec de la pluie',
+          'partlycloudy': 'Éclaircies',
+          'pouring': 'Averses',
+          'rainy': 'Pluvieux',
+          'snowy': 'Neigeux',
+          'snowy-rainy': 'Neigeux avec pluie mêlée',
+          'sunny': 'Ensoleillé',
+          'windy': 'Venteux',
+          'windy-variant': 'Venteux et nuageux',
+        } %}
+        {{ weather_condition.get(state.state | string, "") }}
 
         {% set temperature = state.attributes.get('temperature') %}
         {% if temperature is number %}
@@ -131,8 +146,24 @@ responses:
         {% endif %}
 
       detailed_weather: >
-        {# Reuse weather condition already formatted and translated #}
-        {{ state.state }}
+        {% set weather_condition = {
+          'clear-night': 'Nuit dégagée',
+          'cloudy': 'Nuageux',
+          'exceptional': 'Conditions exceptionnelles',
+          'fog': 'Brouillard',
+          'hail': 'Grêle',
+          'lightning': 'Orageux',
+          'lightning-rainy': 'Orageux avec de la pluie',
+          'partlycloudy': 'Éclaircies',
+          'pouring': 'Averses',
+          'rainy': 'Pluvieux',
+          'snowy': 'Neigeux',
+          'snowy-rainy': 'Neigeux avec pluie mêlée',
+          'sunny': 'Ensoleillé',
+          'windy': 'Venteux',
+          'windy-variant': 'Venteux et nuageux'
+        } %}
+        {{ weather_condition.get(state.state | string, "") }}
 
         {% set temperature = state.attributes.get('temperature') %}
         {% if temperature is number %}

--- a/tests/fr/_fixtures.yaml
+++ b/tests/fr/_fixtures.yaml
@@ -781,7 +781,7 @@ entities:
 
   - name: "Paris"
     id: "weather.paris"
-    state: Pluvieux
+    state: rainy
     attributes:
       temperature: 10.3
       temperature_unit: "°C"
@@ -791,7 +791,7 @@ entities:
 
   - name: "Brest"
     id: "weather.brest"
-    state: Ensoleillé
+    state: sunny
     attributes:
       temperature: 24.9
       temperature_unit: "°C"


### PR DESCRIPTION
As it goes for every exposed entity of any domain from now on.

This concludes uncertainty about the content of "state.state", and will have the nice side effect of putting the development environment on par with the production behaviour.

Fixes #2899