### PR TITLE
[PT-BR] Support controlling shades

### DIFF
--- a/sentences/pt-br/cover_HassTurnOff.yaml
+++ b/sentences/pt-br/cover_HassTurnOff.yaml
@@ -15,6 +15,7 @@ intents:
           device_class:
             - blind
             - curtain
+            - shade
             - shutter
           domain: cover
 
@@ -25,6 +26,7 @@ intents:
           device_class:
             - blind
             - curtain
+            - shade
             - shutter
           domain: cover
 
@@ -36,6 +38,7 @@ intents:
           device_class:
             - blind
             - curtain
+            - shade
             - shutter
           domain: cover
         requires_context:

--- a/sentences/pt-br/cover_HassTurnOn.yaml
+++ b/sentences/pt-br/cover_HassTurnOn.yaml
@@ -16,6 +16,7 @@ intents:
           device_class:
             - blind
             - curtain
+            - shade
             - shutter
           domain: cover
 
@@ -26,6 +27,7 @@ intents:
           device_class:
             - blind
             - curtain
+            - shade
             - shutter
           domain: cover
 
@@ -37,6 +39,7 @@ intents:
           device_class:
             - blind
             - curtain
+            - shade
             - shutter
           domain: cover
         requires_context:


### PR DESCRIPTION
Includes "shade" `device_class` to the sentences which already include "blind", "curtain" and "shutter".