### PR TITLE
[CS] Add intents for locks

### DIFF
--- a/responses/cs/HassTurnOff.yaml
+++ b/responses/cs/HassTurnOff.yaml
@@ -12,3 +12,4 @@ responses:
       garage: "Vrata zavřena"
       curtain: "Zataženo"
       valve: "Zavřeno"
+      lock: "Odemčeno"

--- a/responses/cs/HassTurnOn.yaml
+++ b/responses/cs/HassTurnOn.yaml
@@ -13,3 +13,4 @@ responses:
       curtain: "Roztaženo"
       scene: "Scéna aktivována"
       valve: "Otevřeno"
+      lock: "Zamčeno"

--- a/sentences/cs/_common.yaml
+++ b/sentences/cs/_common.yaml
@@ -112,9 +112,9 @@ lists:
 
   lock_states:
     values:
-      - in: "zamčeno"
+      - in: "(zamčen|zamknut)(é|a|á|y|ý)"
         out: "locked"
-      - in: "odemčeno"
+      - in: "(odemčen|odemknut)(é|a|á|y|ý)"
         out: "unlocked"
 
   # binary_sensor
@@ -378,6 +378,8 @@ expansion_rules:
   roztahnout: "(roz|vy|od)táhn(out|i)"
   zatahnout: "(za|s)táhn(out|i)"
   prejit: "přej(ít|di)"
+  zamknout: "zamk(ni|nout|či)"
+  odemknout: "odem(kni|knout|či)"
   koncentrace: "(úroveň|množství|koncentrace)"
   predchozi: "(předchozí|poslední|minul[á|ou|ý])"
   dalsi: "(další|následující)"

--- a/sentences/cs/lock_HassGetState.yaml
+++ b/sentences/cs/lock_HassGetState.yaml
@@ -1,0 +1,40 @@
+language: cs
+intents:
+  HassGetState:
+    data:
+      - sentences:
+          - "<je> ({name};{lock_states:state}) [<area_floor>]"
+        requires_context:
+          domain: lock
+        slots:
+          domain: lock
+        response: one_yesno
+
+      - sentences:
+          - "<jaky_je> (stav;(je|má|mají)) {name} [<area_floor>]"
+        requires_context:
+          domain: lock
+        slots:
+          domain: lock
+        response: one_cover
+
+      - sentences:
+          - "<je> <nektere> (dveře|zámky|zámek) [<area_floor>] {lock_states:state}"
+          - "<je> ({lock_states:state} <nektere> (dveře|zámky|zámek);[<area_floor>])"
+        slots:
+          domain: lock
+        response: any
+
+      - sentences:
+          - "jsou všechn(a|y) (dveře|zámky) [<area_floor>] {lock_states:state}"
+          - "jsou ({lock_states:state} všechn(a|y) (dveře|zámky);[<area_floor>])"
+          - "{lock_states:state} všechn(a|y) (dveře|zámky)"
+        slots:
+          domain: lock
+        response: all
+
+      - sentences:
+          - "<ktere> (dveře|zámky|zámek) [<area_floor>] <je> {lock_states:state}"
+        slots:
+          domain: lock
+        response: which

--- a/sentences/cs/lock_HassTurnOff.yaml
+++ b/sentences/cs/lock_HassTurnOff.yaml
@@ -1,0 +1,26 @@
+language: cs
+intents:
+  HassTurnOff:
+    data:
+      - sentences:
+          - "<odemknout> {name} [<area>]"
+        requires_context:
+          domain: lock
+        response: lock
+
+      - sentences:
+          - "<odemknout> [všechny] (zámek|zámky) <area>"
+        slots:
+          domain: lock
+          name: all
+        response: lock
+
+      - sentences:
+          - "<odemknout> [tady] [všechny] (zámek|zámky)"
+        requires_context:
+          area:
+            slot: true
+        slots:
+          domain: lock
+          name: all
+        response: lock

--- a/sentences/cs/lock_HassTurnOn.yaml
+++ b/sentences/cs/lock_HassTurnOn.yaml
@@ -1,0 +1,26 @@
+language: cs
+intents:
+  HassTurnOn:
+    data:
+      - sentences:
+          - "<zamknout> {name} [<area>]"
+        requires_context:
+          domain: lock
+        response: lock
+
+      - sentences:
+          - "<zamknout> [všechny] (zámek|zámky) <area>"
+        slots:
+          domain: lock
+          name: all
+        response: lock
+
+      - sentences:
+          - "<zamknout> [tady] [všechny] (zámek|zámky)"
+        requires_context:
+          area:
+            slot: true
+        slots:
+          domain: lock
+          name: all
+        response: lock

--- a/tests/cs/_fixtures.yaml
+++ b/tests/cs/_fixtures.yaml
@@ -20,7 +20,7 @@ areas:
   - name: Garáž[i]
     id: garage
     floor: ground_floor_id
-  - name: Předsíň[i]
+  - name: Předsí(ň|ni)
     id: entrance
     floor: ground_floor_id
   - name: Zahrad[a|ě]
@@ -588,3 +588,10 @@ entities:
   - name: "vysavač"
     id: "vacuum.rover"
     state: "idle"
+
+  - name: "vstupní dveře"
+    id: "lock.main_door"
+    area: "entrance"
+    state:
+      in: zamčeno
+      out: locked

--- a/tests/cs/lock_HassGetState.yaml
+++ b/tests/cs/lock_HassGetState.yaml
@@ -1,0 +1,76 @@
+language: cs
+tests:
+  - sentences:
+      - "jsou vstupní dveře odemčené?"
+      - "jsou vstupní dveře odemknuty?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: lock
+        name: vstupní dveře
+        state: unlocked
+    response: "Ne, zamčeno"
+
+  - sentences:
+      - "jaký stav mají vstupní dveře?"
+      - "jaký mají stav vstupní dveře?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: lock
+        name: vstupní dveře
+    response: "Vstupní dveře je zamčeno"
+
+  - sentences:
+      - "jsou některé zámky zamknuté?"
+      - "jsou nějaké dveře zamčeny?"
+      - "jsou zamčený některé dveře?"
+      - "jsou zamknuty nějaké zámky?"
+      - "je nějaký zámek zamčený?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: lock
+        state: locked
+    response: "Ano, vstupní dveře"
+
+  - sentences:
+      - "jsou některé dveře v předsíni zamčené?"
+      - "jsou nějaké zámky v předsíni zamknuté?"
+      - "jsou zamknuté některé dveře v předsíni?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: lock
+        area: Předsíni
+        state: locked
+    response: "Ano, vstupní dveře"
+
+  - sentences:
+      - "jsou všechny dveře zamknuté?"
+      - "jsou zamknuté všechny dveře?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: lock
+        state: locked
+    response: "Ano"
+
+  - sentences:
+      - "jsou všechny dveře odemčené?"
+      - "jsou odemknutý všechny dveře?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: lock
+        state: locked
+    response: "Ano"
+
+  - sentences:
+      - "které dveře jsou zamknuté?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: lock
+        state: locked
+    response: "vstupní dveře"

--- a/tests/cs/lock_HassTurnOff.yaml
+++ b/tests/cs/lock_HassTurnOff.yaml
@@ -1,0 +1,49 @@
+language: cs
+tests:
+  - sentences:
+      - "odemkni vstupní dveře"
+      - "odemknout vstupní dveře"
+    intent:
+      name: HassTurnOff
+      context:
+        domain: lock
+      slots:
+        name: vstupní dveře
+    response: Odemčeno
+
+  - sentences:
+      - "odemkni vstupní dveře v předsíni"
+    intent:
+      name: HassTurnOff
+      context:
+        domain: lock
+      slots:
+        name: vstupní dveře
+        area: Předsíni
+    response: Odemčeno
+
+  - sentences:
+      - "odemkni všechny zámky v kuchyni"
+      - "odemkni zámky v kuchyni"
+      - "odemkni zámek v kuchyni"
+    intent:
+      name: HassTurnOff
+      slots:
+        domain: lock
+        area:
+          - Kuchyni
+          - Kuchyňské
+        name: all
+    response: Odemčeno
+
+  - sentences:
+      - "odemkni tady všechny zámky"
+    intent:
+      name: HassTurnOff
+      context:
+        area: Předsíň
+      slots:
+        domain: lock
+        area: Předsíň
+        name: all
+    response: Odemčeno

--- a/tests/cs/lock_HassTurnOn.yaml
+++ b/tests/cs/lock_HassTurnOn.yaml
@@ -1,0 +1,49 @@
+language: cs
+tests:
+  - sentences:
+      - "zamkni vstupní dveře"
+      - "zamknout vstupní dveře"
+    intent:
+      name: HassTurnOn
+      context:
+        domain: lock
+      slots:
+        name: vstupní dveře
+    response: Zamčeno
+
+  - sentences:
+      - "zamkni vstupní dveře v předsíni"
+    intent:
+      name: HassTurnOn
+      context:
+        domain: lock
+      slots:
+        name: vstupní dveře
+        area: Předsíni
+    response: Zamčeno
+
+  - sentences:
+      - "zamkni všechny zámky v kuchyni"
+      - "zamkni zámky v kuchyni"
+      - "zamkni zámek v kuchyni"
+    intent:
+      name: HassTurnOn
+      slots:
+        domain: lock
+        area:
+          - Kuchyni
+          - Kuchyňské
+        name: all
+    response: Zamčeno
+
+  - sentences:
+      - "zamkni tady všechny zámky"
+    intent:
+      name: HassTurnOn
+      context:
+        area: Předsíň
+      slots:
+        domain: lock
+        area: Předsíň
+        name: all
+    response: Zamčeno


### PR DESCRIPTION
Add these intents for lock domain:
* HassTurnOn
* HassTurnOff
* HassGetState

## Notes
* The state responses use the terms "Odemčeno" and "Zamčeno", consistent with Home Assistant's terminology for the lock domain.
* While functional, the responses for `HassGetState` could benefit from refinement to improve natural language output. For example, the sentence:
"Ne, vstupní dveře není zamčeno"
is grammatically awkward and should be revised to:
"Ne, vstupní dveře jsou zamčené."