### PR TITLE
[EN] Get HassClimateSetTemperature ready for support in core

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -241,7 +241,7 @@ HassLightSet:
 # -----------------------------------------------------------------------------
 
 HassClimateSetTemperature:
-  supported: false
+  supported: true
   domain: climate
   description: "Sets the desired temperature of a climate device or entity"
   slots:
@@ -251,12 +251,24 @@ HassClimateSetTemperature:
     area:
       description: "Name of an area"
       required: false
+    floor:
+      description: "Name of a floor"
+      required: false
     temperature:
       description: "Temperature in degrees"
-      required: false
-    temperature_unit:
-      description: "Temperature unit"
-      required: false
+      required: true
+  slot_combinations:
+    temperature_only:
+      - "temperature"
+    name:
+      - "temperature"
+      - "name"
+    area:
+      - "temperature"
+      - "area"
+    floor:
+      - "temperature"
+      - "floor"
 
 HassClimateGetTemperature:
   supported: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-hassil==2.1.0
+hassil==2.2.0
 PyYAML==6.0.2
 voluptuous==0.15.2
 regex==2024.11.6

--- a/responses/en/HassClimateSetTemperature.yaml
+++ b/responses/en/HassClimateSetTemperature.yaml
@@ -2,4 +2,7 @@ language: en
 responses:
   intents:
     HassClimateSetTemperature:
-      default: "Temperature set"
+      default: "Temperature set to {{ slots.temperature }} {{ 'degree' if (slots.temperature | float) == 1 else 'degrees' }}"
+      area: "{{ slots.area }} temperature set to {{ slots.temperature }} {{ 'degree' if (slots.temperature | float) == 1 else 'degrees' }}"
+      floor: "{{ slots.floor }} temperature set to {{ slots.temperature }} {{ 'degree' if (slots.temperature | float) == 1 else 'degrees' }}"
+      name: "{{ slots.name }} set to {{ slots.temperature }} {{ 'degree' if (slots.temperature | float) == 1 else 'degrees' }}"

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -205,6 +205,7 @@ SENTENCE_COMMON_SCHEMA = vol.Schema(
                         vol.Required("from"): int,
                         vol.Required("to"): int,
                         vol.Optional("step", default=1): int,
+                        vol.Optional("fractions"): vol.Any("halves", "tenths"),
                     },
                     "wildcard": bool,
                 }

--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -64,6 +64,7 @@ lists:
       type: "temperature"
       from: 0
       to: 100
+      fractions: "halves"
   temperature_unit:
     values:
       - "celsius"
@@ -383,7 +384,7 @@ expansion_rules:
   light: "(light|lights|lighting|lamp|lamps)"
   turn: "(turn|switch|change|bring)"
   temp: "(temp|temperature)"
-  temperature: "{temperature}[([ ]°[[ ]{temperature_unit}])|( degrees {temperature_unit})]"
+  temperature: "{temperature}[([ ]°)|( degree[s])]"
   open: "(open|raise|lift) [up]"
   close: "(close|shut|lower) [(up|down)]"
   set: "(set|make|change|turn)"

--- a/sentences/en/climate_HassClimateSetTemperature.yaml
+++ b/sentences/en/climate_HassClimateSetTemperature.yaml
@@ -2,6 +2,26 @@ language: "en"
 intents:
   HassClimateSetTemperature:
     data:
+      # Current area or floor
       - sentences:
-          - "(<numeric_value_set>|adjust) <temp> [in <area>] to <temperature>"
+          - "(<numeric_value_set>|adjust) [the] <temp> to <temperature>"
+
+      # By area name
+      - sentences:
+          - "(<numeric_value_set>|adjust) [the] <temp> in <area> to <temperature>"
           - "(<numeric_value_set>|adjust) <area> <temp> to <temperature>"
+        response: "area"
+
+      # By floor name
+      - sentences:
+          - "(<numeric_value_set>|adjust) [the] <temp> (of|on) <floor> to <temperature>"
+          - "(<numeric_value_set>|adjust) <floor> <temp> to <temperature>"
+        response: "floor"
+
+      # By climate entity name
+      - sentences:
+          - "(<numeric_value_set>|adjust) [the] <temp> of <name> to <temperature>"
+          - "(<numeric_value_set>|adjust) <name> [<temp>] to <temperature>"
+        requires_context:
+          domain: "climate"
+        response: "name"

--- a/tests/en/climate_HassClimateSetTemperature.yaml
+++ b/tests/en/climate_HassClimateSetTemperature.yaml
@@ -1,29 +1,63 @@
 language: en
 tests:
+  # Current area or floor
   - sentences:
       - "set temperature to 30°"
     intent:
       name: HassClimateSetTemperature
       slots:
         temperature: 30
-    response: "Temperature set"
+    response: "Temperature set to 30 degrees"
 
+  # By area name
   - sentences:
-      - "set temperature to 30° C"
-    intent:
-      name: HassClimateSetTemperature
-      slots:
-        temperature: 30
-        temperature_unit: celsius
-    response: "Temperature set"
-
-  - sentences:
-      - "set temp in bedroom to 50 degrees Fahrenheit"
-      - "set bedroom temp to 50 degrees Fahrenheit"
+      - "set temp in bedroom to 50 degrees"
+      - "set bedroom temp to 50 degrees"
     intent:
       name: HassClimateSetTemperature
       slots:
         area: Bedroom
         temperature: 50
-        temperature_unit: fahrenheit
-    response: "Temperature set"
+    response: "bedroom temperature set to 50 degrees"
+
+  # By floor name
+  - sentences:
+      - "set temp of the first floor to 50 degrees"
+      - "set first floor temp to 50 degrees"
+    intent:
+      name: HassClimateSetTemperature
+      slots:
+        floor: First Floor
+        temperature: 50
+    response: "first floor temperature set to 50 degrees"
+
+  # By climate entity name
+  - sentences:
+      - "set office thermostat to 1°"
+      - "set the temperature of the office thermostat to 1°"
+    intent:
+      name: HassClimateSetTemperature
+      slots:
+        name: "Office Thermostat"
+        temperature: 1
+    response: "office thermostat set to 1 degree"
+
+  # Fractional temperature (numeric)
+  - sentences:
+      - "set temperature to 20.5°"
+      - "set temperature to 20.5 °"
+      - "set temperature to 20.5 degrees"
+    intent:
+      name: HassClimateSetTemperature
+      slots:
+        temperature: 20.5
+    response: "Temperature set to 20.5 degrees"
+
+  # Fractional temperature (words)
+  - sentences:
+      - "set temperature to twenty point five degrees"
+    intent:
+      name: HassClimateSetTemperature
+      slots:
+        temperature: 20.5
+    response: "Temperature set to twenty point five degrees"

--- a/tests/en/sensor_HassGetState.yaml
+++ b/tests/en/sensor_HassGetState.yaml
@@ -297,7 +297,7 @@ tests:
         domain: sensor
         device_class: pm25
         name: "Living room PM2.5 sensor"
-    response: "Living room pm25 sensor is 50 µg/m³"
+    response: "Living room pm2.5 sensor is 50 µg/m³"
 
   # PM10
   - sentences:

--- a/tests/nl/sensor_HassGetState.yaml
+++ b/tests/nl/sensor_HassGetState.yaml
@@ -299,7 +299,7 @@ tests:
         domain: sensor
         device_class: pm25
         name: "Living room PM2.5 sensor"
-    response: "Living room pm25 sensor is 50 µg/m³"
+    response: "Living room pm2.5 sensor is 50 µg/m³"
 
   # PM10
   - sentences:

--- a/tests/vi/sensor_HassGetState.yaml
+++ b/tests/vi/sensor_HassGetState.yaml
@@ -308,7 +308,7 @@ tests:
         domain: sensor
         device_class: pm25
         name: "cảm biến PM2.5 phòng khách"
-    response: "Cảm biến pm25 phòng khách là 50 µg/m³"
+    response: "Cảm biến pm2.5 phòng khách là 50 µg/m³"
 
   # PM10
   - sentences:


### PR DESCRIPTION
Support for `HassClimateSetTemperature` in HA core: https://github.com/home-assistant/core/pull/136484

Some changes made to the sentences here:
* Allow halves of a degree (required [hassil bump](https://github.com/home-assistant/hassil/compare/v2.1.1...v2.2.0))
* Remove explicit `temperature_unit`
* Add sentences for targeting a `climate` device by name and floor