### PR TITLE
Fix domain of timer intents

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -449,7 +449,7 @@ HassSetVolume:
 
 HassStartTimer:
   supported: true
-  domain: intent
+  domain: homeassistant
   description: "Starts a timer"
   slots:
     hours:
@@ -475,7 +475,7 @@ HassStartTimer:
 
 HassCancelAllTimers:
   supported: true
-  domain: intent
+  domain: homeassistant
   description: "Cancels all timers"
   slots:
     area:
@@ -484,7 +484,7 @@ HassCancelAllTimers:
 
 HassCancelTimer:
   supported: true
-  domain: intent
+  domain: homeassistant
   description: "Cancels a timer"
   slots:
     start_hours:
@@ -505,7 +505,7 @@ HassCancelTimer:
 
 HassIncreaseTimer:
   supported: true
-  domain: intent
+  domain: homeassistant
   description: "Adds time to a timer"
   slots:
     hours:
@@ -540,7 +540,7 @@ HassIncreaseTimer:
 
 HassDecreaseTimer:
   supported: true
-  domain: intent
+  domain: homeassistant
   description: "Removes time from a timer"
   slots:
     hours:
@@ -575,7 +575,7 @@ HassDecreaseTimer:
 
 HassPauseTimer:
   supported: true
-  domain: intent
+  domain: homeassistant
   description: "Pauses a running timer"
   slots:
     start_hours:
@@ -596,7 +596,7 @@ HassPauseTimer:
 
 HassUnpauseTimer:
   supported: true
-  domain: intent
+  domain: homeassistant
   description: "Resumes a paused timer"
   slots:
     start_hours:
@@ -617,7 +617,7 @@ HassUnpauseTimer:
 
 HassTimerStatus:
   supported: true
-  domain: intent
+  domain: homeassistant
   description: "Reports status of one or more timers"
   slots:
     start_hours:


### PR DESCRIPTION
Change domain of timer intents in `intents.yaml` from `intent` to `homeassistant`.
Addresses issue: https://github.com/home-assistant/intents/issues/2916