### PR TITLE
[RO] Fix HassClimateSetTemperature

### DIFF
--- a/sentences/ro/_common.yaml
+++ b/sentences/ro/_common.yaml
@@ -683,7 +683,7 @@ expansion_rules:
   area: "{area}"
   floor: "[(etajul|nivelul) ]{floor}"
   brightness: "{brightness}[<la_suta>]"
-  temperature: "{temperature}[ (grad|[de ]grade)]"
+  temperature: "{temperature}[ (°|grad|[de ]grade)]"
   position: "{position}[<la_suta>]"
   volume: "{volume:volume_level}[<la_suta>]"
   name: "({name})"


### PR DESCRIPTION
STTs would sometimes produce the degree symbol (°) which was missing from the sentence definition, making matching not work