### PR TITLE
[DE] "zu Hause" for person_HassGetState

### DIFF
--- a/responses/de/HassGetState.yaml
+++ b/responses/de/HassGetState.yaml
@@ -64,7 +64,7 @@ responses:
 
       wo: |
         {% if state.state == "home" %}
-          {{ slots.name | capitalize }} ist Zuhause
+          {{ slots.name | capitalize }} ist zu Hause
         {% elif state.state == "not_home" %}
           {{ slots.name | capitalize }} ist unterwegs
         {% else %}

--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -594,6 +594,7 @@ expansion_rules:
   position: "{position}[ (Prozent|%)]"
   volume: "{volume_level}[ (Prozent|%)]"
   im_bereich: "[((in|auf)[ <artikel_bestimmt>]|im)] {zone:state}"
+  im_zuhause: "(zu Hause|[im ]Zuhause)"
 
   # Timers
   timer_set: "(starte|setze|stelle|erstelle)"

--- a/sentences/de/person_HassGetState.yaml
+++ b/sentences/de/person_HassGetState.yaml
@@ -22,8 +22,8 @@ intents:
           domain: person
 
       - sentences:
-          - "(ist|befindet sich) <name> [im ]zuhause"
-          - "hält sich <name> [im ]zuhause auf"
+          - "(ist|befindet sich) <name> <im_zuhause>"
+          - "hält sich <name> <im_zuhause> auf"
         response: einzeln_janein
         requires_context:
           domain: person
@@ -39,8 +39,8 @@ intents:
           domain: person
 
       - sentences:
-          - "(ist|befindet sich) [irgend]jemand [im ]zuhause"
-          - "hält sich [irgend]jemand [im ]zuhause auf"
+          - "(ist|befindet sich) [irgend]jemand <im_zuhause>"
+          - "hält sich [irgend]jemand <im_zuhause> auf"
         response: irgendeins
         slots:
           domain: person
@@ -54,8 +54,8 @@ intents:
           domain: person
 
       - sentences:
-          - "([ist|befindet sich] jeder|[sind|befinden sich] alle) [im ]zuhause"
-          - "halten sich alle zuhause auf"
+          - "([ist|befindet sich] jeder|[sind|befinden sich] alle) <im_zuhause>"
+          - "halten sich alle <im_zuhause> auf"
         response: alle
         slots:
           domain: person
@@ -69,8 +69,8 @@ intents:
           domain: person
 
       - sentences:
-          - "wer (ist|befindet sich) [im ]zuhause"
-          - "wer hält sich zuhause auf"
+          - "wer (ist|befindet sich) <im_zuhause>"
+          - "wer hält sich <im_zuhause> auf"
         response: wer
         slots:
           domain: person
@@ -84,8 +84,8 @@ intents:
           domain: person
 
       - sentences:
-          - "wie viele [(Leute|Personen) ](sind|befinden sich) [im ]zuhause"
-          - "wie viele [(Leute|Personen) ]halten sich [im ]zuhause auf"
+          - "wie viele [(Leute|Personen) ](sind|befinden sich) <im_zuhause>"
+          - "wie viele [(Leute|Personen) ]halten sich <im_zuhause> auf"
         response: wie_viele
         slots:
           domain: person

--- a/tests/de/person_HassGetState.yaml
+++ b/tests/de/person_HassGetState.yaml
@@ -9,7 +9,7 @@ tests:
       slots:
         domain: person
         name: Thomas
-    response: "Thomas ist Zuhause"
+    response: "Thomas ist zu Hause"
 
   - sentences:
       - "Wo ist Madlen"
@@ -40,6 +40,9 @@ tests:
       - "ist Thomas im Zuhause"
       - "befindet sich Thomas im Zuhause"
       - "hält sich Thomas im Zuhause auf"
+      - "ist Thomas zu Hause"
+      - "befindet sich Thomas zu Hause"
+      - "hält sich Thomas zu Hause auf"
     intent:
       name: HassGetState
       slots:
@@ -55,6 +58,9 @@ tests:
       - "ist Madlen im Zuhause"
       - "befindet sich Madlen im Zuhause"
       - "hält sich Madlen im Zuhause auf"
+      - "ist Madlen zu Hause"
+      - "befindet sich Madlen zu Hause"
+      - "hält sich Madlen zu Hause auf"
     intent:
       name: HassGetState
       slots:
@@ -91,6 +97,12 @@ tests:
       - "ist irgendjemand im Zuhause"
       - "befindet sich irgendjemand im Zuhause"
       - "hält sich irgendjemand im Zuhause auf"
+      - "ist jemand zu Hause"
+      - "befindet sich jemand zu Hause"
+      - "hält sich jemand zu Hause auf"
+      - "ist irgendjemand zu Hause"
+      - "befindet sich irgendjemand zu Hause"
+      - "hält sich irgendjemand zu Hause auf"
     intent:
       name: HassGetState
       slots:
@@ -104,6 +116,11 @@ tests:
       - "sind alle Zuhause"
       - "befinden sich alle Zuhause"
       - "halten sich alle Zuhause auf"
+      - "ist jeder zu Hause"
+      - "befindet sich jeder zu Hause"
+      - "sind alle zu Hause"
+      - "befinden sich alle zu Hause"
+      - "halten sich alle zu Hause auf"
     intent:
       name: HassGetState
       slots:
@@ -115,6 +132,9 @@ tests:
       - "wer ist Zuhause"
       - "wer befindet sich Zuhause"
       - "wer hält sich Zuhause auf"
+      - "wer ist zu Hause"
+      - "wer befindet sich zu Hause"
+      - "wer hält sich zu Hause auf"
     intent:
       name: HassGetState
       slots:
@@ -140,6 +160,12 @@ tests:
       - "wie viele Personen befinden sich Zuhause"
       - "wie viele Leute halten sich Zuhause auf"
       - "wie viele Personen halten sich Zuhause auf"
+      - "wie viele Leute sind zu Hause"
+      - "wie viele Personen sind zu Hause"
+      - "wie viele Leute befinden sich zu Hause"
+      - "wie viele Personen befinden sich zu Hause"
+      - "wie viele Leute halten sich zu Hause auf"
+      - "wie viele Personen halten sich zu Hause auf"
     intent:
       name: HassGetState
       slots:


### PR DESCRIPTION
fixes re-opened https://github.com/home-assistant/intents/issues/2952

- use adverb in response: `X ist Zuhause` -> `X ist zu Hause`
- allow querying for adverb and subject (`zu Hause`, `Zuhause`, `im Zuhause`)