### PR TITLE
[DE] more options to cancel a timer

### DIFF
--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -598,7 +598,7 @@ expansion_rules:
 
   # Timers
   timer_set: "(starte|setze|stelle|erstelle)"
-  timer_cancel: "(beende|stoppe)"
+  timer_cancel: "(beende|stopp[e]|lösch[e])"
   timer_duration_seconds: "{timer_seconds:seconds} Sekunde[n]"
   timer_duration_minutes: "{timer_minutes:minutes} Minute[n][ [und]{timer_seconds:seconds} Sekunde[n]]"
   timer_duration_hours: "{timer_hours:hours} Stunde[n][ [und]{timer_minutes:minutes} Minute[n]][ [und]{timer_seconds:seconds} Sekunde[n]]"

--- a/tests/de/homeassistant_HassCancelAllTimers.yaml
+++ b/tests/de/homeassistant_HassCancelAllTimers.yaml
@@ -7,6 +7,9 @@ tests:
       - "stoppe alle Timer"
       - "stoppe sämtliche Timer"
       - "stoppe alle meine Timer"
+      - "stopp alle meine Timer"
+      - "lösch alle Timer"
+      - "lösche sämtliche Timer"
     intent:
       name: HassCancelAllTimers
     response: 3 Timer gestoppt.
@@ -24,6 +27,9 @@ tests:
       - "stoppe im Wohnzimmer alle Timer"
       - "stoppe im Wohnzimmer sämtliche Timer"
       - "stoppe im Wohnzimmer alle meine Timer"
+      - "stopp alle Timer im Wohnzimmer"
+      - "lösch im Wohnzimmer sämtliche Timer"
+      - "lösche sämtliche Timer im Wohnzimmer"
     intent:
       name: HassCancelAllTimers
       slots:
@@ -67,6 +73,9 @@ tests:
       - "stoppe in diesem Raum alle Timer"
       - "stoppe in diesem Raum sämtliche Timer"
       - "stoppe in diesem Raum alle meine Timer"
+      - "stopp in diesem Raum alle Timer"
+      - "lösch hier alle Timer"
+      - "lösche in diesem Raum alle meine Timer"
     intent:
       name: HassCancelAllTimers
       context:

--- a/tests/de/homeassistant_HassCancelTimer.yaml
+++ b/tests/de/homeassistant_HassCancelTimer.yaml
@@ -4,6 +4,10 @@ tests:
       - "beende Timer"
       - "beende den Timer"
       - "stoppe meinen Timer"
+      - "stopp den Timer"
+      - "lösch den Timer"
+      - "lösche den Timer"
+      - "lösche meinen Timer"
     intent:
       name: HassCancelTimer
     response: Timer gestoppt
@@ -12,6 +16,9 @@ tests:
       - "beende den 5 Minuten Timer"
       - "stoppe Timer für 5 Minuten"
       - "stoppe 5 Minuten Timer"
+      - "stopp den 5 Minuten Timer"
+      - "lösche Timer für 5 Minuten"
+      - "lösch 5 Minuten Timer"
     intent:
       name: HassCancelTimer
       slots:
@@ -22,6 +29,9 @@ tests:
       - "stoppe Pizza Timer"
       - "beende meinen Pizza Timer"
       - "stoppe meinen Timer für Pizza"
+      - "stopp den Pizza Timer"
+      - "lösch meinen Pizza Timer"
+      - "lösche Pizza Timer"
     intent:
       name: HassCancelTimer
       slots:
@@ -32,6 +42,10 @@ tests:
   - sentences:
       - "beende Wohnzimmer Timer"
       - "beende den Timer im Wohnzimmer"
+      - "lösch meinen Wohnzimmer Timer"
+      - "lösche meinen Timer im Wohnzimmer"
+      - "stopp Wohnzimmer Timer"
+      - "stoppe den Wohnzimmer Timer"
     intent:
       name: HassCancelTimer
       slots:


### PR DESCRIPTION
The Imperative of stopp and lösch has two viable options, with and without an e.
 
The new word option lösch(e) isn't already used in any other common option, and is German for delete. So there shouldn't be any conflicts created by this change. 

It is also a variant to cancel a timer that is allowed on Google Home and possibly Alexa (I don't have one). Allowing it makes switching away from them easier, because you do not have to learn a now command word for the same action.