### PR TITLE
[HR] Start timer: fix logic for count and cases

### DIFF
--- a/responses/hr/HassStartTimer.yaml
+++ b/responses/hr/HassStartTimer.yaml
@@ -4,23 +4,76 @@ responses:
   intents:
     HassStartTimer:
       default: >
-        {% set h = slots.hours if slots.hours is defined else none %}
-        {% set m = slots.minutes if slots.minutes is defined else none %}
-        {% set s = slots.seconds if slots.seconds is defined else none %}
-        {% set h_text = h ~ (' sat'  if h in [ "1", 'jedan'] else ' sata') if h else '' %}
-        {% set m_text = (30 if m in ['pola', 'pol', '1/2'] else m) ~ (' minuta' if m in [ "1", 'jedna'] else ' minuta') if m else '' %}
-        {% set s_text = (30 if s in ['pola', 'pol', '1/2'] else s) ~ (' sekunda' if s in [ "1", 'jedna'] else ' sekundi') if s else '' %}
-        {% set text_list = [ h_text, m_text, s_text] | select() | list %}
-        {% set text = text_list[:-1] | join(', ') ~ ' i ' ~ text_list[-1] if text_list | count > 2 else text_list | join(' i ') %}
+        {% macro format_time(value, singular, few, many) -%}
+          {% if value is not none %}
+            {% set number = 30 if value in ['pola', 'pol', '1/2'] else value | int(0) %}
+            {% if number % 10 == 1 and number % 100 != 11 %}
+              {{ number }} {{ singular }}
+            {% elif number % 10 in [2, 3, 4] and number % 100 not in [12, 13, 14] %}
+              {{ number }} {{ few }}
+            {% else %}
+              {{ number }} {{ many }}
+            {% endif %}
+          {% else %}
+            {{ '' }}
+          {% endif %}
+        {%- endmacro %}
+
         {% set name = (' nazvan ' ~ slots.name | trim) if slots.name is defined else '' %}
+
+        {% set h = slots.get('hours') %}
+        {% set m = slots.get('minutes') %}
+        {% set s = slots.get('seconds') %}
+
+        {% set h_text = format_time(h, 'sat', 'sata', 'sati') %}
+        {% set m_text = format_time(m, 'minutu', 'minute', 'minuta') %}
+        {% set s_text = format_time(s, 'sekundu', 'sekunde', 'sekundi') %}
+
+        {% set text_list = (h_text if h_text.strip() else '') ~ ',' ~ (m_text if m_text.strip() else '') ~ ',' ~ (s_text if s_text.strip() else '') %}
+        {% set text_list = text_list.split(',') | select('string') | map('trim') | reject('equalto', '') | list %}
+
+        {% if text_list | length == 1 %}
+          {% set text = text_list[0] %}
+        {% elif text_list | length == 2 %}
+          {% set text = text_list | join(' i ') %}
+        {% else %}
+          {% set text = text_list[:-1] | join(', ') ~ ' i ' ~ text_list[-1] %}
+        {% endif %}
+
         Timer postavljen na {{ text }}{{ name }}
       command: >
-        {% set h = slots.hours if slots.hours is defined else none %}
-        {% set m = slots.minutes if slots.minutes is defined else none %}
-        {% set s = slots.seconds if slots.seconds is defined else none %}
-        {% set h_text = h ~ (' sat'  if h in [ "1", 'jedan'] else ' sata') if h else '' %}
-        {% set m_text = (30 if m in ['pola', '1/2'] else m) ~ (' minuta' if m in [ "1", 'jedna'] else ' minuta') if m else '' %}
-        {% set s_text = (30 if s in ['pola', '1/2'] else s) ~ (' sekunda' if s in [ "1", 'jedna'] else ' sekundi') if s else '' %}
-        {% set text_list = [ h_text, m_text, s_text] | select() | list %}
-        {% set text = text_list[:-1] | join(', ') ~ ' i ' ~ text_list[-1] if text_list | count > 2 else text_list | join(' i ') %}
+        {% macro format_time(value, singular, few, many) -%}
+          {% if value is not none %}
+            {% set number = 30 if value in ['pola', 'pol', '1/2'] else value | int(0) %}
+            {% if number % 10 == 1 and number % 100 != 11 %}
+              {{ number }} {{ singular }}
+            {% elif number % 10 in [2, 3, 4] and number % 100 not in [12, 13, 14] %}
+              {{ number }} {{ few }}
+            {% else %}
+              {{ number }} {{ many }}
+            {% endif %}
+          {% else %}
+            {{ '' }}
+          {% endif %}
+        {%- endmacro %}
+
+        {% set h = slots.get('hours') %}
+        {% set m = slots.get('minutes') %}
+        {% set s = slots.get('seconds') %}
+
+        {% set h_text = format_time(h, 'sat', 'sata', 'sati') %}
+        {% set m_text = format_time(m, 'minutu', 'minute', 'minuta') %}
+        {% set s_text = format_time(s, 'sekundu', 'sekunde', 'sekundi') %}
+
+        {% set text_list = (h_text if h_text.strip() else '') ~ ',' ~ (m_text if m_text.strip() else '') ~ ',' ~ (s_text if s_text.strip() else '') %}
+        {% set text_list = text_list.split(',') | select('string') | map('trim') | reject('equalto', '') | list %}
+
+        {% if text_list | length == 1 %}
+          {% set text = text_list[0] %}
+        {% elif text_list | length == 2 %}
+          {% set text = text_list | join(' i ') %}
+        {% else %}
+          {% set text = text_list[:-1] | join(', ') ~ ' i ' ~ text_list[-1] %}
+        {% endif %}
+
         Naredba će se izvršiti za {{ text }}

--- a/sentences/hr/_common.yaml
+++ b/sentences/hr/_common.yaml
@@ -192,13 +192,13 @@ expansion_rules:
 
   # Timers
   timer: "timer[u]|tajmer|štoperic(a|u)|brojač vremena|mjerač vremena|sat za vrijeme|podsjetnik|minutnik(a)"
-  timer_plural: "timer(a|e|ima)|tajmer(a|e|ima)|štoperic(e|a|ima)|brojač(a|e|ima) vremena|mjerač(a|i|e) vremena|sat(|a|e|ovima) za vrijeme|podsjet(nicimai|ka|ke)|minutni[ci|ke]"
+  timer_plural: "timer(a|e|ima)|tajmer(a|e|ima)|štoperic(e|a|ima)|brojač(a|e|ima) vremena|mjerač(a|i|e) vremena|sat(|a|e|ovima) za vrijeme|podsjet(nicima|ka|ke)"
   timer_set: "(postavi|pokreni|napravi|započni)"
   timer_cancel: "(otkaži|zaustavi|stop[iraj]|prekini|isključi|prekini|poništi)"
   timer_state: "(status|stanje|preostalo vrijeme|ostalo vrijeme)"
-  timer_duration_seconds: "{timer_seconds:seconds} sekund(a|e|i|ni)"
-  timer_duration_minutes: "({timer_minutes:minutes} minut(a|e|i)[ [i ]{timer_seconds:seconds} sekund(a|e|i|ni)])|({timer_minutes:minutes} [i] {timer_half:seconds} minut(a|e|i|ni|nu))|({timer_half:seconds} minut(a|e|i|ni|nu))"
-  timer_duration_hours: "({timer_hours:hours} sat[a|i|ni|nog|nom][ [i ]{timer_minutes:minutes} minut(a|e|i|ni|nu)][ [i ]{timer_seconds:seconds} sekund(a|e|i|ni)])|({timer_hours:hours} i {timer_half:minutes} sat[a|i|ni|nog|nom])|({timer_half:minutes} sat[a|i|ni|nog|nom])"
+  timer_duration_seconds: "{timer_seconds:seconds} sekund(a|e|i|u|ni)"
+  timer_duration_minutes: "({timer_minutes:minutes} minut(a|e|i|u|ni|nu) [[i] {timer_seconds:seconds} sekund(a|e|i|u|ni)])|({timer_minutes:minutes} i {timer_half:seconds} minut(a|e|i|u|ni|nu))|({timer_half:seconds} minut(e|ni|nu))"
+  timer_duration_hours: "({timer_hours:hours} sat[a|i|ni|nog|nom] [[i] {timer_minutes:minutes} minut(a|e|i|u|ni|nu)] [[i] {timer_seconds:seconds} sekund(a|e|i|u|ni)])|({timer_hours:hours} i {timer_half:minutes} sat[a|i|ni|nog|nom])|({timer_half:minutes} sat[a|ni|nog|nom])"
   timer_duration: "<timer_duration_seconds>|<timer_duration_minutes>|<timer_duration_hours>"
 
   timer_start_seconds: "{timer_seconds:start_seconds} sekund(a|e|i|ni)"

--- a/tests/hr/homeassistant_HassStartTimer.yaml
+++ b/tests/hr/homeassistant_HassStartTimer.yaml
@@ -16,7 +16,7 @@ tests:
       name: HassStartTimer
       slots:
         hours: 21
-    response: Timer postavljen na 21 sata #TODO
+    response: Timer postavljen na 21 sat
 
   - sentences:
       - "timer za 22 minuta"
@@ -24,7 +24,7 @@ tests:
       name: HassStartTimer
       slots:
         minutes: 22
-    response: Timer postavljen na 22 minuta #TODO
+    response: Timer postavljen na 22 minute
 
   - sentences:
       - "postavi timer za 1 sat"
@@ -132,7 +132,7 @@ tests:
         area: Dnevna soba
       slots:
         minutes: 4
-    response: Timer postavljen na 4 minuta #TODO
+    response: Timer postavljen na 4 minute
 
   - sentences:
       - "postavi timer za 5 minuta nazvan pizza"

--- a/tests/hr/homeassistant_HassStartTimer.yaml
+++ b/tests/hr/homeassistant_HassStartTimer.yaml
@@ -11,6 +11,63 @@ tests:
     response: Timer postavljen na 10 minuta
 
   - sentences:
+      - "timer za 11 minuta"
+      - "podsjetnik za 11 minuta"
+    intent:
+      name: HassStartTimer
+      slots:
+        minutes: 11
+    response: Timer postavljen na 11 minuta
+
+  - sentences:
+      - "timer za 12 minuta"
+      - "podsjetnik za 12 minuta"
+    intent:
+      name: HassStartTimer
+      slots:
+        minutes: 12
+    response: Timer postavljen na 12 minuta
+
+  - sentences:
+      - "timer za 13 minuta"
+      - "podsjetnik za 13 minuta"
+    intent:
+      name: HassStartTimer
+      slots:
+        minutes: 13
+    response: Timer postavljen na 13 minuta
+
+  - sentences:
+      - "Postavi timer na 14 minuta"
+      - "podsjetnik za 14 minuta"
+    intent:
+      name: HassStartTimer
+      slots:
+        minutes: 14
+    response: Timer postavljen na 14 minuta
+
+  - sentences:
+      - "Postavi brojač vremena na 41 minutu"
+      - "Postavi 41 minutnu štopericu"
+      - "podsjetnik za 41 minutu"
+      - "štoperica na 41 minutu"
+    intent:
+      name: HassStartTimer
+      slots:
+        minutes: 41
+    response: Timer postavljen na 41 minutu
+
+  - sentences:
+      - "Postavi timer na 21 minutu"
+      - "Postavi mjerač vremena na 21 minutu"
+      - "podsjetnik za 21 minutu"
+    intent:
+      name: HassStartTimer
+      slots:
+        minutes: 21
+    response: Timer postavljen na 21 minutu
+
+  - sentences:
       - "timer za 21 sat"
     intent:
       name: HassStartTimer
@@ -19,7 +76,7 @@ tests:
     response: Timer postavljen na 21 sat
 
   - sentences:
-      - "timer za 22 minuta"
+      - "timer za 22 minute"
     intent:
       name: HassStartTimer
       slots:
@@ -62,6 +119,30 @@ tests:
     response: Timer postavljen na 30 sekundi
 
   - sentences:
+      - "postavi timer na 11 i pol minuta"
+      - "postavi timer na 11 i 1/2 minuta"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Dnevna soba
+      slots:
+        seconds: 30
+        minutes: 11
+    response: Timer postavljen na 11 minuta i 30 sekundi
+
+  - sentences:
+      - "postavi timer na 1 i pol minutu"
+      - "postavi timer na 1 i 1/2 minutu"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Dnevna soba
+      slots:
+        seconds: 30
+        minutes: 1
+    response: Timer postavljen na 1 minutu i 30 sekundi
+
+  - sentences:
       - "postavi timer za 1 i pol sat"
       - "postavi timer za 1 i 1/2 sat"
     intent:
@@ -83,6 +164,17 @@ tests:
       slots:
         minutes: 30
     response: Timer postavljen na 30 minuta
+
+  - sentences:
+      - "postavi pola minutni timer"
+      - "postavi pola minutnu štopericu"
+    intent:
+      name: HassStartTimer
+      context:
+        area: Dnevna soba
+      slots:
+        seconds: 30
+    response: Timer postavljen na 30 sekundi
 
   - sentences:
       - "postavi 1 satni i 15 minutni timer"


### PR DESCRIPTION
The logic for determining the case was simplistic, hence incorrect for example when a timer is set to 3 minutes. This PR fixes it and reuses the logic when determining the case for hours and seconds as well.