### PR TITLE
Allow storing TTS and STT support

### DIFF
--- a/languages.yaml
+++ b/languages.yaml
@@ -46,6 +46,14 @@ en:
     - mrdarrengriffin
     - tetele
     - vividboarder
+  support:
+    US:
+      speech-to-text:
+        speech-to-phrase: true
+        whisper-wer: 8.9
+      text-to-speech:
+        piper: true
+        cloud: true
 es:
   nativeName: Español
   leaders:

--- a/languages.yaml
+++ b/languages.yaml
@@ -50,7 +50,7 @@ en:
     US:
       speech-to-text:
         speech-to-phrase: true
-        whisper-wer: 8.9
+        whisper: true
       text-to-speech:
         piper: true
         cloud: true

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -86,7 +86,7 @@ LANGUAGES_SCHEMA = vol.Schema(
                 str: {
                     vol.Optional("speech-to-text"): {
                         vol.Optional("speech-to-phrase"): bool,
-                        vol.Optional("whisper-wer"): vol.Any(float, int),
+                        vol.Optional("whisper"): bool,
                     },
                     vol.Optional("text-to-speech"): {
                         vol.Optional("piper"): bool,

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -82,6 +82,18 @@ LANGUAGES_SCHEMA = vol.Schema(
             vol.Required("nativeName"): str,
             vol.Optional("isRTL"): bool,
             vol.Optional("leaders"): [str],
+            vol.Optional("support"): {
+                str: {
+                    vol.Optional("speech-to-text"): {
+                        vol.Optional("speech-to-phrase"): bool,
+                        vol.Optional("whisper-wer"): vol.Any(float, int),
+                    },
+                    vol.Optional("text-to-speech"): {
+                        vol.Optional("piper"): bool,
+                        vol.Optional("cloud"): bool,
+                    },
+                }
+            },
         }
     }
 )


### PR DESCRIPTION
The goal is to store all data that backs the widget at https://www.home-assistant.io/voice_control/#supported-languages-and-sentences in this repository. The first step is to allow documenting the support for speech-to-phrase, whisper and cloud for each language.

Since we note that support based on region, we organize support by region.