### PR TITLE
[ES] Support new sentence to set brightness of current area light

### DIFF
--- a/sentences/es/light_HassLightSet.yaml
+++ b/sentences/es/light_HassLightSet.yaml
@@ -19,6 +19,7 @@ intents:
 
       - sentences:
           - "[<establece_sube_baja>] [el] brillo [a|al] <brightness>"
+          - "[<establece_sube_baja>] [la] luz [a|al] <brightness>"
           - "[<establece_sube_baja>] [el] brillo (<de_aqui>;[a|al] <brightness>)"
         response: "brightness"
         requires_context:

--- a/tests/es/light_HassLightSet.yaml
+++ b/tests/es/light_HassLightSet.yaml
@@ -31,6 +31,10 @@ tests:
 
   - sentences:
       - "establece el brillo al 50%"
+      - "pon el brillo al 50%"
+      - "pon la luz al 50%"
+      - "ajusta la luz al 50%"
+      - "baja la luz al 50%"
       - "cambia el brillo en la habitación al 50 por ciento"
       - "ajustar brillo al 50% aquí"
     intent:

--- a/tests/es/light_HassLightSet.yaml
+++ b/tests/es/light_HassLightSet.yaml
@@ -37,6 +37,9 @@ tests:
       - "baja la luz al 50%"
       - "cambia el brillo en la habitación al 50 por ciento"
       - "ajustar brillo al 50% aquí"
+      - "sube el brillo al 50%"
+      - "ajusta el brillo a 50%"
+      - "establece la luz al 50%"
     intent:
       name: HassLightSet
       context:


### PR DESCRIPTION
This add support to the sentece it feels more natural to me to set the brightness of the light of the current area, which is a sentence at least alexa understands just fine.

"Pon la luz al 50" (and similar variations like "Baja/sube la luz al 50%" or "Ajusta la luz al 50%")