### PR TITLE
[HR] Pause timer: drop doubly-pausing sentences

### DIFF
--- a/sentences/hr/homeassistant_HassPauseTimer.yaml
+++ b/sentences/hr/homeassistant_HassPauseTimer.yaml
@@ -3,7 +3,11 @@ intents:
   HassPauseTimer:
     data:
       - sentences:
-          - "(pauziraj|privremeno zaustavi|stavi) [moj[u]] <timer> [na pauzu|na čekanje]"
-          - "(pauziraj|privremeno zaustavi|stavi) [moj[u]] ([od] <timer_start>; [<timer>]) [na pauzu|na čekanje]"
-          - "(pauziraj|privremeno zaustavi|stavi) [moj[u]] (<timer>; [u|na] <area>) [na pauzu|na čekanje]"
-          - "(pauziraj|privremeno zaustavi|stavi) [moj[u]] (<timer>; [nazvan|zvan|po imenu|po nazivu|za] {timer_name:name}) [na pauzu|na čekanje]"
+          - "(pauziraj|privremeno zaustavi) [moj[u]] <timer>"
+          - "(pauziraj|privremeno zaustavi) [moj[u]] ([od] <timer_start>; [<timer>])"
+          - "(pauziraj|privremeno zaustavi) [moj[u]] (<timer>; [u|na] <area>)"
+          - "(pauziraj|privremeno zaustavi) [moj[u]] (<timer>; [nazvan|zvan|po imenu|po nazivu|za] {timer_name:name})"
+          - "stavi [moj[u]] <timer> (na pauzu|na čekanje)"
+          - "stavi [moj[u]] ([od] <timer_start>; [<timer>]) (na pauzu|na čekanje)"
+          - "stavi [moj[u]] (<timer>; [u|na] <area>) (na pauzu|na čekanje)"
+          - "stavi [moj[u]] (<timer>; [nazvan|zvan|po imenu|po nazivu|za] {timer_name:name}) (na pauzu|na čekanje)"

--- a/tests/hr/homeassistant_HassPauseTimer.yaml
+++ b/tests/hr/homeassistant_HassPauseTimer.yaml
@@ -30,6 +30,7 @@ tests:
 
   - sentences:
       - "pauziraj kuhinjski timer"
+      - "stavi kuhinjski timer na čekanje"
       - "pauziraj timer u kuhinji"
     intent:
       name: HassPauseTimer


### PR DESCRIPTION
This change improves the accepted sentences by the grammar, by avoiding sentences that "pause" a timer twice. In particular, the grammar used to accepted sentences that would start with the verb "pause", followed by a timer specification, and ending in "to pause".