### PR TITLE
[HR] Decrease timer: require area preposition

### DIFF
--- a/sentences/hr/homeassistant_HassDecreaseTimer.yaml
+++ b/sentences/hr/homeassistant_HassDecreaseTimer.yaml
@@ -6,10 +6,10 @@ intents:
       - sentences:
           - "[ukloni|oduzmi] <timer_duration> s[a] [mog|mojeg] (<timer>|<timer_plural>)"
           - "[ukloni|oduzmi] <timer_duration> s[a] [mog|mojeg] (<timer>|<timer_plural>) za <timer_start>"
-          - "[ukloni|oduzmi] <timer_duration> s[a] [mog|mojeg] (<timer>|<timer_plural>) [u|na] {area}"
+          - "[ukloni|oduzmi] <timer_duration> s[a] [mog|mojeg] (<timer>|<timer_plural>) (u|na) {area}"
           - "[ukloni|oduzmi] <timer_duration> s[a] [mog|mojeg] (<timer>|<timer_plural>) nazvan[og] {timer_name:name}"
       # Smanji...
       - sentences:
           - "(smanji|umanji) [moj] <timer> za <timer_duration>"
-          - "(smanji|umanji) [moj] <timer> (za <timer_duration>;[u|na] {area})"
+          - "(smanji|umanji) [moj] <timer> (za <timer_duration>;(u|na) {area})"
           - "(smanji|umanji) [moj] <timer> [nazvan] {timer_name:name} za <timer_duration>"


### PR DESCRIPTION
This change makes an area preposition required when decreasing a timer and an area is given. Existing tests were already written assuming a preposition should be provided.