### PR TITLE
[HR] Decrease timer: Require a "remove" verb

### DIFF
--- a/sentences/hr/homeassistant_HassDecreaseTimer.yaml
+++ b/sentences/hr/homeassistant_HassDecreaseTimer.yaml
@@ -4,10 +4,10 @@ intents:
     data:
       # Ukloni...
       - sentences:
-          - "[ukloni|oduzmi] <timer_duration> s[a] [mog|mojeg] (<timer>|<timer_plural>)"
-          - "[ukloni|oduzmi] <timer_duration> s[a] [mog|mojeg] (<timer>|<timer_plural>) za <timer_start>"
-          - "[ukloni|oduzmi] <timer_duration> s[a] [mog|mojeg] (<timer>|<timer_plural>) (u|na) {area}"
-          - "[ukloni|oduzmi] <timer_duration> s[a] [mog|mojeg] (<timer>|<timer_plural>) nazvan[og] {timer_name:name}"
+          - "(ukloni|oduzmi) <timer_duration> s[a] [mog|mojeg] (<timer>|<timer_plural>)"
+          - "(ukloni|oduzmi) <timer_duration> s[a] [mog|mojeg] (<timer>|<timer_plural>) za <timer_start>"
+          - "(ukloni|oduzmi) <timer_duration> s[a] [mog|mojeg] (<timer>|<timer_plural>) (u|na) {area}"
+          - "(ukloni|oduzmi) <timer_duration> s[a] [mog|mojeg] (<timer>|<timer_plural>) nazvan[og] {timer_name:name}"
       # Smanji...
       - sentences:
           - "(smanji|umanji) [moj] <timer> za <timer_duration>"


### PR DESCRIPTION
The PR makes a "remove" verb mandatory when decreasing a timer, as it was optional in the Croatian translation before. Existing tests were already assuming the verb to be provided.