### PR TITLE
[HR] Decrease timer: support a female gender timer noun

### DIFF
--- a/sentences/hr/homeassistant_HassDecreaseTimer.yaml
+++ b/sentences/hr/homeassistant_HassDecreaseTimer.yaml
@@ -4,12 +4,12 @@ intents:
     data:
       # Ukloni...
       - sentences:
-          - "(ukloni|oduzmi) <timer_duration> s[a] [mog|mojeg] (<timer>|<timer_plural>)"
-          - "(ukloni|oduzmi) <timer_duration> s[a] [mog|mojeg] (<timer>|<timer_plural>) za <timer_start>"
-          - "(ukloni|oduzmi) <timer_duration> s[a] [mog|mojeg] (<timer>|<timer_plural>) (u|na) {area}"
-          - "(ukloni|oduzmi) <timer_duration> s[a] [mog|mojeg] (<timer>|<timer_plural>) nazvan[og] {timer_name:name}"
+          - "(ukloni|oduzmi) <timer_duration> s[a] [mog|mojeg|moje] (<timer>|<timer_plural>)"
+          - "(ukloni|oduzmi) <timer_duration> s[a] [mog|mojeg|moje] (<timer>|<timer_plural>) za <timer_start>"
+          - "(ukloni|oduzmi) <timer_duration> s[a] [mog|mojeg|moje] (<timer>|<timer_plural>) (u|na) {area}"
+          - "(ukloni|oduzmi) <timer_duration> s[a] [mog|mojeg|moje] (<timer>|<timer_plural>) [na]zvan[og|e] {timer_name:name}"
       # Smanji...
       - sentences:
-          - "(smanji|umanji) [moj] <timer> za <timer_duration>"
-          - "(smanji|umanji) [moj] <timer> (za <timer_duration>;(u|na) {area})"
-          - "(smanji|umanji) [moj] <timer> [nazvan] {timer_name:name} za <timer_duration>"
+          - "(smanji|umanji) [moj[u]] <timer> za <timer_duration>"
+          - "(smanji|umanji) [moj[u]] <timer> (za <timer_duration>;(u|na) {area})"
+          - "(smanji|umanji) [moj[u]] <timer> [[na]zvan[u]] {timer_name:name} za <timer_duration>"

--- a/tests/hr/homeassistant_HassDecreaseTimer.yaml
+++ b/tests/hr/homeassistant_HassDecreaseTimer.yaml
@@ -2,8 +2,11 @@ language: hr
 tests:
   - sentences:
       - "ukloni 5 minuta s timera"
+      - "ukloni 5 minuta sa štoperice"
+      - "ukloni 5 minuta sa moje štoperice"
       - "ukloni 5 minuta s mog timera"
       - "smanji moj timer za 5 minuta"
+      - "smanji moju štopericu za 5 minuta"
     intent:
       name: HassDecreaseTimer
       slots:
@@ -23,6 +26,8 @@ tests:
   - sentences:
       - "ukloni 5 minuta s timera nazvanog pizza"
       - "smanji timer nazvan pizza za 5 minuta"
+      - "smanji štopericu nazvanu pizza za 5 minuta"
+      - "ukloni 5 minuta sa štoperice nazvane pizza"
     intent:
       name: HassDecreaseTimer
       slots:


### PR DESCRIPTION
This change supports a female gender timer noun that has been present in `_common.yaml`, but was not supported in the decrease timer intent.