### PR TITLE
[HR] Cancel timer: support a female gender timer noun

### DIFF
--- a/sentences/hr/homeassistant_HassCancelTimer.yaml
+++ b/sentences/hr/homeassistant_HassCancelTimer.yaml
@@ -4,10 +4,10 @@ intents:
   HassCancelTimer:
     data:
       - sentences:
-          - "<timer_cancel> [moj] <timer>"
-          - "<timer_cancel> [moj] <timer_start> <timer>"
-          - "<timer_cancel> [moj] <timer> (za | na) <timer_start>"
-          - "<timer_cancel> [moj] {area} <timer>"
-          - "<timer_cancel> [moj] <timer> u {area}"
-          - "<timer_cancel> [moj] {timer_name:name} <timer>"
-          - "<timer_cancel> [moj] <timer> za {timer_name:name}"
+          - "<timer_cancel> [moj[u]] <timer>"
+          - "<timer_cancel> [moj[u]] <timer_start> <timer>"
+          - "<timer_cancel> [moj[u]] <timer> (za | na) <timer_start>"
+          - "<timer_cancel> [moj[u]] {area} <timer>"
+          - "<timer_cancel> [moj[u]] <timer> u {area}"
+          - "<timer_cancel> [moj[u]] {timer_name:name} <timer>"
+          - "<timer_cancel> [moj[u]] <timer> za {timer_name:name}"

--- a/tests/hr/homeassistant_HassCancelTimer.yaml
+++ b/tests/hr/homeassistant_HassCancelTimer.yaml
@@ -3,6 +3,7 @@ language: hr
 tests:
   - sentences:
       - "otkaži timer"
+      - "otkaži moju štopericu"
       - "zaustavi moj timer"
       - "zaustavi timer"
       - "prekini timer"
@@ -13,6 +14,7 @@ tests:
   - sentences:
       - "otkaži timer za 5 minuta"
       - "otkaži timer na 5 minuta"
+      - "otkaži moju štopericu za 5 minuta"
       - "zaustavi timer za 5 minuta"
     intent:
       name: HassCancelTimer
@@ -24,6 +26,7 @@ tests:
       - "otkaži pizza timer"
       - "zaustavi moj pizza timer"
       - "zaustavi moj timer za pizzu"
+      - "zaustavi moju štopericu za pizzu"
     intent:
       name: HassCancelTimer
       slots:
@@ -36,6 +39,7 @@ tests:
   - sentences:
       - "otkaži kuhinjski timer"
       - "zaustavi timer u kuhinji"
+      - "zaustavi moju štopericu u kuhinji"
     intent:
       name: HassCancelTimer
       slots:


### PR DESCRIPTION
This change supports a female gender timer noun that has been present in `_common.yaml`, but was not supported in the cancel timer intent.