### PR TITLE
[HR] Cancel timer: support an adjective form

### DIFF
--- a/sentences/hr/_common.yaml
+++ b/sentences/hr/_common.yaml
@@ -202,8 +202,8 @@ expansion_rules:
   timer_duration: "<timer_duration_seconds>|<timer_duration_minutes>|<timer_duration_hours>"
 
   timer_start_seconds: "{timer_seconds:start_seconds} sekund(a|e|i|ni)"
-  timer_start_minutes: "{timer_minutes:start_minutes} minut(a|e|i)[ [i ]{timer_seconds:start_seconds} sekund(a|e|i|ni)]"
-  timer_start_hours: "{timer_hours:start_hours} sat[a|i|ni|nog|nom][ [i ]{timer_minutes:start_minutes} minut(a|e|i)][ [i ]{timer_seconds:start_seconds} sekund(a|e|i|ni)]"
+  timer_start_minutes: "{timer_minutes:start_minutes} minut(a|e|i|ni)[ [i ]{timer_seconds:start_seconds} sekund(a|e|i|ni)]"
+  timer_start_hours: "{timer_hours:start_hours} sat[a|i|ni|nog|nom][ [i ]{timer_minutes:start_minutes} minut(a|e|i|ni)][ [i ]{timer_seconds:start_seconds} sekund(a|e|i|ni)]"
   timer_start: "<timer_start_seconds>|<timer_start_minutes>|<timer_start_hours>"
 
 skip_words:

--- a/tests/hr/homeassistant_HassCancelTimer.yaml
+++ b/tests/hr/homeassistant_HassCancelTimer.yaml
@@ -15,6 +15,7 @@ tests:
       - "otkaži timer za 5 minuta"
       - "otkaži timer na 5 minuta"
       - "otkaži moju štopericu za 5 minuta"
+      - "Otkaži moj 5 minutni timer"
       - "zaustavi timer za 5 minuta"
     intent:
       name: HassCancelTimer
@@ -46,4 +47,13 @@ tests:
         area:
           - kuhinji
           - kuhinjski
+    response: Timer je zaustavljen
+
+  - sentences:
+      - "Otkaži moj 2 satni i 5 minutni timer"
+    intent:
+      name: HassCancelTimer
+      slots:
+        start_minutes: 5
+        start_hours: 2
     response: Timer je zaustavljen


### PR DESCRIPTION
The PR supports an adjective form in Croatian when canceling a timer. The intent itself did not need a change and it was incorrect grammar before this change to how a `timer_start` is constructed.