### PR TITLE
[DE] fix ambiguities for covers

### DIFF
--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -107,7 +107,7 @@ responses:
         "door": "keine Tür",
         "garage": "kein Garagentor",
         "gate": "kein Tor",
-        "shade": "kein Rollo",
+        "shade": "kein Schirm",
         "shutter": "kein Rollladen",
         "window": "kein Fenster"
         } %}
@@ -124,7 +124,7 @@ responses:
         "door": "keine Tür",
         "garage": "kein Garagentor",
         "gate": "kein Tor",
-        "shade": "kein Rollo",
+        "shade": "kein Schirm",
         "shutter": "kein Rollladen",
         "window": "kein Fenster"
         } %}
@@ -141,7 +141,7 @@ responses:
         "door": "keine Tür",
         "garage": "kein Garagentor",
         "gate": "kein Tor",
-        "shade": "kein Rollo",
+        "shade": "kein Schirm",
         "shutter": "kein Rollladen",
         "window": "kein Fenster"
         } %}
@@ -258,7 +258,7 @@ responses:
         "door": "keine Tür",
         "garage": "kein Garagentor",
         "gate": "kein Tor",
-        "shade": "kein Rollo",
+        "shade": "kein Schirm",
         "shutter": "kein Rollladen",
         "window": "kein Fenster"
         } %}
@@ -275,7 +275,7 @@ responses:
         "door": "keine Tür",
         "garage": "kein Garagentor",
         "gate": "kein Tor",
-        "shade": "kein Rollo",
+        "shade": "kein Schirm",
         "shutter": "kein Rollladen",
         "window": "kein Fenster"
         } %}
@@ -292,7 +292,7 @@ responses:
         "door": "keine Tür",
         "garage": "kein Garagentor",
         "gate": "kein Tor",
-        "shade": "kein Rollo",
+        "shade": "kein Schirm",
         "shutter": "kein Rollladen",
         "window": "kein Fenster"
         } %}
@@ -356,9 +356,9 @@ lists:
         out: "closing"
   cover_classes:
     values:
-      - in: Markise[n]
+      - in: "(Markise[n]|Beschattung[en])"
         out: awning
-      - in: "(Jalousie[n]|Rollo[s]|Beschattung[en])"
+      - in: "(Jalousie[n]|Rollo[s])"
         out: blind
       - in: "(Gardine[n]|Vorhang|Vorhänge)"
         out: curtain
@@ -370,7 +370,7 @@ lists:
         out: gate
       - in: Schirm[e]
         out: shade
-      - in: "(Roll[l](a|ä)den|Rollo[s]|Beschattung[en])"
+      - in: "(Roll[l](a|ä)den)"
         out: shutter
       - in: Fenster
         out: window

--- a/tests/de/_fixtures.yaml
+++ b/tests/de/_fixtures.yaml
@@ -31,6 +31,9 @@ areas:
     floor: basement_id
   - name: Auffahrt
     id: driveway
+  - name: Terrasse
+    id: terrace
+    floor: ground_floor_id
 entities:
   - name: Schlafzimmerlampe
     id: light.bedroom_lamp
@@ -69,18 +72,12 @@ entities:
     state: "heat"
     attributes:
       current_temperature: 24
-  - name: "Vorhang links"
-    id: "cover.wohnzimmer_vorhang_links"
-    area: living_room
+  - name: "Markise Osten"
+    id: "cover.terrasse_markise"
+    area: terrace
     state: open
     attributes:
-      device_class: blind
-  - name: "Vorhang rechts"
-    id: "cover.wohnzimmer_vorhang_links"
-    area: living_room
-    state: open
-    attributes:
-      device_class: blind
+      device_class: awning
   - name: "Rollo links"
     id: "cover.wohnzimmer_rollo_links"
     area: living_room
@@ -100,6 +97,36 @@ entities:
     attributes:
       device_class: blind
       position: "0"
+  - name: "Vorhang links"
+    id: "cover.wohnzimmer_vorhang_links"
+    area: living_room
+    state: open
+    attributes:
+      device_class: curtain
+  - name: "Vorhang rechts"
+    id: "cover.wohnzimmer_vorhang_rechts"
+    area: living_room
+    state: open
+    attributes:
+      device_class: curtain
+  - name: "Garagentür"
+    id: "cover.garage_garagentuer"
+    area: garage
+    state: closed
+    attributes:
+      device_class: garage
+  - name: "Einfahrtstor"
+    id: "cover.einfahrt_tor"
+    area: driveway
+    state: closed
+    attributes:
+      device_class: gate
+  - name: "Schirm Westen"
+    id: "cover.terrasse_schirm"
+    area: terrace
+    state: closed
+    attributes:
+      device_class: shade
   - name: "Rollladen links"
     id: "cover.wohnzimmer_rollladen_links"
     area: living_room

--- a/tests/de/cover_HassGetState.yaml
+++ b/tests/de/cover_HassGetState.yaml
@@ -61,7 +61,7 @@ tests:
         area: "Wohnzimmer"
         device_class: blind
         state: "open"
-    response: "Ja, Rollo links, Vorhang links und Vorhang rechts"
+    response: "Ja, Rollo links"
   - sentences:
       - "sind irgendwelche Rollos geschlossen im Wohnzimmer?"
       - "sind irgendwelche Rollos im Wohnzimmer geschlossen?"
@@ -86,7 +86,7 @@ tests:
         floor: "Erdgeschoss"
         device_class: blind
         state: "open"
-    response: "Ja, Rollo links, Vorhang links und Vorhang rechts"
+    response: "Ja, Rollo links"
   - sentences:
       - "sind irgendwelche Rollos geschlossen im Erdgeschoss?"
       - "sind irgendwelche Rollos im Erdgeschoss geschlossen?"
@@ -128,6 +128,28 @@ tests:
 
   # response welches
   - sentences:
+      - "welche Markisen auf der Terrasse sind offen?"
+      - "welche Markisen auf der Terrasse sind geöffnet?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        area: "Terrasse"
+        device_class: awning
+        state: "open"
+    response: "Markise Osten"
+  - sentences:
+      - "welche Markisen im Erdgeschoss sind offen?"
+      - "welche Markisen im Erdgeschoss sind geöffnet?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        floor: "Erdgeschoss"
+        device_class: awning
+        state: "open"
+    response: "Markise Osten"
+  - sentences:
       - "welche Rollos im Wohnzimmer sind offen?"
       - "welche Rollos im Wohnzimmer sind geöffnet?"
     intent:
@@ -137,7 +159,7 @@ tests:
         area: "Wohnzimmer"
         device_class: blind
         state: "open"
-    response: "Rollo links, Vorhang links und Vorhang rechts"
+    response: "Rollo links"
   - sentences:
       - "welche Rollos im Wohnzimmer sind geschlossen?"
     intent:
@@ -158,7 +180,7 @@ tests:
         floor: "Erdgeschoss"
         device_class: blind
         state: "open"
-    response: "Rollo links, Vorhang links und Vorhang rechts"
+    response: "Rollo links"
   - sentences:
       - "welche Rollos im Erdgeschoss sind geschlossen?"
     intent:
@@ -169,8 +191,118 @@ tests:
         device_class: blind
         state: "closed"
     response: "Rollo rechts und Rollo vorn"
+  - sentences:
+      - "welche Vorhänge im Wohnzimmer sind offen?"
+      - "welche Vorhänge im Wohnzimmer sind geöffnet?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        area: "Wohnzimmer"
+        device_class: curtain
+        state: "open"
+    response: "Vorhang links und Vorhang rechts"
+  - sentences:
+      - "welche Vorhänge im Erdgeschoss sind offen?"
+      - "welche Vorhänge im Erdgeschoss sind geöffnet?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        floor: "Erdgeschoss"
+        device_class: curtain
+        state: "open"
+    response: "Vorhang links und Vorhang rechts"
+  - sentences:
+      - "welche Garagentüren sind geschlossen?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        device_class: garage
+        state: "closed"
+    response: "Garagentür"
+  - sentences:
+      - "welche Tore in der Auffahrt sind geschlossen?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        area: "Auffahrt"
+        device_class: gate
+        state: "closed"
+    response: "Einfahrtstor"
+  - sentences:
+      - "welche Schirme auf der Terrasse sind geschlossen?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        area: "Terrasse"
+        device_class: shade
+        state: "closed"
+    response: "Schirm Westen"
+  - sentences:
+      - "welche Schirme im Erdgeschoss sind geschlossen?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        floor: "Erdgeschoss"
+        device_class: shade
+        state: "closed"
+    response: "Schirm Westen"
+  - sentences:
+      - "welche Rollläden im Wohnzimmer sind geschlossen?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        area: "Wohnzimmer"
+        device_class: shutter
+        state: "closed"
+    response: "Rollladen links"
+  - sentences:
+      - "welche Rollläden im Erdgeschoss sind geschlossen?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        floor: "Erdgeschoss"
+        device_class: shutter
+        state: "closed"
+    response: "Rollladen links"
 
   # response wie_viele
+  - sentences:
+      - "Wie viele Markisen auf der Terrasse sind geöffnet?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        area: "Terrasse"
+        device_class: awning
+        state: "open"
+    response: "1"
+  - sentences:
+      - "Wie viele Markisen sind geöffnet?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        device_class: awning
+        state: "open"
+    response: "1"
+  - sentences:
+      - "Wie viele Markisen im Erdgeschoss sind geöffnet?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        floor: "Erdgeschoss"
+        device_class: awning
+        state: "open"
+    response: "1"
   - sentences:
       - "Wie viele Rollos im Wohnzimmer sind geschlossen?"
     intent:
@@ -200,3 +332,128 @@ tests:
         device_class: blind
         state: "closed"
     response: "2"
+  - sentences:
+      - "Wie viele Vorhänge im Wohnzimmer sind geöffnet?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        area: "Wohnzimmer"
+        device_class: curtain
+        state: "open"
+    response: "2"
+  - sentences:
+      - "Wie viele Vorhänge sind geöffnet?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        device_class: curtain
+        state: "open"
+    response: "2"
+  - sentences:
+      - "Wie viele Vorhänge im Erdgeschoss sind geöffnet?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        floor: "Erdgeschoss"
+        device_class: curtain
+        state: "open"
+    response: "2"
+  - sentences:
+      - "Wie viele Garagentüren sind geschlossen?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        device_class: garage
+        state: "closed"
+    response: "1"
+  - sentences:
+      - "Wie viele Tore in der Auffahrt sind geschlossen?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        area: "Auffahrt"
+        device_class: gate
+        state: "closed"
+    response: "1"
+  - sentences:
+      - "Wie viele Tore sind geschlossen?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        device_class: gate
+        state: "closed"
+    response: "1"
+  - sentences:
+      - "Wie viele Tore im Erdgeschoss sind geschlossen?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        floor: "Erdgeschoss"
+        device_class: gate
+        state: "closed"
+    response: "0"
+  - sentences:
+      - "Wie viele Schirme auf der Terrasse sind geschlossen?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        area: "Terrasse"
+        device_class: shade
+        state: "closed"
+    response: "1"
+  - sentences:
+      - "Wie viele Schirme sind geschlossen?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        device_class: shade
+        state: "closed"
+    response: "1"
+  - sentences:
+      - "Wie viele Schirme im Erdgeschoss sind geschlossen?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        floor: "Erdgeschoss"
+        device_class: shade
+        state: "closed"
+    response: "1"
+  - sentences:
+      - "Wie viele Rollläden im Wohnzimmer sind geschlossen?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        area: "Wohnzimmer"
+        device_class: shutter
+        state: "closed"
+    response: "1"
+  - sentences:
+      - "Wie viele Rollläden sind geschlossen?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        device_class: shutter
+        state: "closed"
+    response: "1"
+  - sentences:
+      - "Wie viele Rollläden im Erdgeschoss sind geschlossen?"
+    intent:
+      name: HassGetState
+      slots:
+        domain: cover
+        floor: "Erdgeschoss"
+        device_class: shutter
+        state: "closed"
+    response: "1"


### PR DESCRIPTION
Fixes some ambiguities for the `cover` device classes. As mentioned in https://github.com/home-assistant/intents/issues/3016, `Rollo` and `Beschattung` map to multiple device classes resulting in incorrect responses. Although these words are commonly used interchangeably, I propose to match those EXACTLY to their english variants. If we have precise device classes, then we should also expect users to provide those exact class names.

`Beschattung` -> `awning`
`Rollo` -> `blind`

Additionally, responses for device class `shade` were harmonized. If `Schirm` is used for querying this class, `Schirm` should be used for the corresponding responses.
