### PR TITLE
[ES] Add more test sentences to close the blinds of the current room

### DIFF
--- a/tests/es/cover_HassTurnOff.yaml
+++ b/tests/es/cover_HassTurnOff.yaml
@@ -56,6 +56,8 @@ tests:
   - sentences:
       - "cierra las cortinas"
       - "cierra las cortinas de la habitación"
+      - cierra la persiana
+      - Baja la persiana
     intent:
       name: HassTurnOff
       context:


### PR DESCRIPTION
IDK why but locally the sentence "Baja la persiana" is not recognized and needs to be handled by my local LLM instead of being handled fast.

Maybe it was fixed recenty? Either way, it does no harm to add more tests examples.