### PR TITLE
Add cloud to stt in language support

### DIFF
--- a/languages.yaml
+++ b/languages.yaml
@@ -51,6 +51,7 @@ en:
       speech-to-text:
         speech-to-phrase: true
         whisper: true
+        cloud: true
       text-to-speech:
         piper: true
         cloud: true

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -87,6 +87,7 @@ LANGUAGES_SCHEMA = vol.Schema(
                     vol.Optional("speech-to-text"): {
                         vol.Optional("speech-to-phrase"): bool,
                         vol.Optional("whisper"): bool,
+                        vol.Optional("cloud"): bool,
                     },
                     vol.Optional("text-to-speech"): {
                         vol.Optional("piper"): bool,


### PR DESCRIPTION
Adds a `cloud` key to `speech-to-text` for languages YAML file.