### PR TITLE
Language support data (Initial v0)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
       - id: prettier
         args: ["--log-level", "debug"]
         types_or: [yaml]
+        exclude: "languages.yaml"
   - repo: local
     hooks:
       - id: format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: "v4.0.0-alpha.8"
     hooks:
       - id: prettier
+        args: ["--log-level", "debug"]
         types_or: [yaml]
   - repo: local
     hooks:

--- a/languages.yaml
+++ b/languages.yaml
@@ -1,3 +1,5 @@
+%YAML 1.2
+---
 af:
   nativeName: Afrikaans
   support:
@@ -479,7 +481,7 @@ nb:
   leaders:
     - LaStrada
   support:
-    NB:
+    NO:
       speech-to-text:
         speech-to-phrase: false
         whisper: false

--- a/languages.yaml
+++ b/languages.yaml
@@ -1,4 +1,3 @@
----
 af:
   nativeName: Afrikaans
   support:
@@ -16,129 +15,40 @@ ar:
   leaders:
     - Ahmed-farag36
     - Natfaji
-  support:
-    JO:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 bg:
   nativeName: Български
   leaders:
     - hristo-atanasov
-  support:
-    BG:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: false
-        cloud: true
 bn:
   nativeName: বাংলা
-  support:
-    BD:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: false
-      text-to-speech:
-        piper: false
-        cloud: true
-    IN:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: false
-        cloud: true
 ca:
   nativeName: Català
   leaders:
     - duhow
-  support:
-    ES:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 cs:
   nativeName: Čeština
   leaders:
     - halecivo
     - schizza
-  support:
-    CZ:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 da:
   nativeName: Dansk
   leaders:
     - fadamsen
     - MTrab
-  support:
-    DK:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 de:
   nativeName: Deutsch
   leaders:
     - andreasbrett
     - easterapps
     - mib1185
-  support:
-    DE:
-      speech-to-text:
-        speech-to-phrase: true
-        whisper: true
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 de-CH:
   nativeName: Schwyzerdütsch
   leaders:
     - dontinelli
-  support:
-    CH:
-      speech-to-text:
-        speech-to-phrase: true
-        whisper: true
-        cloud: true
-      text-to-speech:
-        piper: false
-        cloud: true
 el:
   nativeName: Ελληνικά
   leaders:
     - chatziko
-  support:
-    GR:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 en:
   nativeName: English
   leaders:
@@ -158,478 +68,146 @@ es:
   nativeName: Español
   leaders:
     - davefx
-  support:
-    MX:
-      speech-to-text:
-        speech-to-phrase: true
-        whisper: true
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 et:
   nativeName: Eesti
-  support:
-    EE:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: false
-        cloud: true
 eu:
   nativeName: Euskara
   leaders:
     - urtzai
-  support:
-    ES:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: false
-        cloud: true
 fa:
   nativeName: فارسی
   isRTL: true
-  support:
-    IR:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 fi:
   nativeName: Suomi
   leaders:
     - Arkkimaagi
     - salleq
-  support:
-    FI:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 fr:
   nativeName: Français
   leaders:
     - jlpouffier
     - piitaya
-  support:
-    FR:
-      speech-to-text:
-        speech-to-phrase: true
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 gl:
   nativeName: Galician
   leaders:
     - cibernox
-  support:
-    ES:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: false
-        cloud: true
 gu:
   nativeName: Gujarati
-  support:
-    IN:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: false
-        cloud: true
 he:
   nativeName: עברית
   isRTL: true
   leaders:
     - leranp
     - haim-b
-  support:
-    IL:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: false
-        cloud: true
 hi:
   nativeName: हिन्दी
-  support:
-    IN:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: false
-        cloud: true
 hr:
   nativeName: Hrvatski
   leaders:
     - spuljko
-  support:
-    HR:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: false
-        cloud: true
 hu:
   nativeName: Magyar
   leaders:
     - nagyrobi
     - v1k70rk4
-  support:
-    HU:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 id:
   nativeName: Bahasa Indonesia
-  support:
-    ID:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: false
-        cloud: true
 is:
   nativeName: íslenska
   leaders:
     - thdg
-  support:
-    IS:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 it:
   nativeName: Italiano
   leaders:
     - auanasgheps
     - xraver
-  support:
-    IT:
-      speech-to-text:
-        speech-to-phrase: true
-        whisper: true
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 ka:
   nativeName: ქართული
   leaders:
     - hertzg
-  support:
-    GE:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 kn:
   nativeName: ಕನ್ನಡ
-  support:
-    IN:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: false
-        cloud: true
 ko:
   nativeName: 한국어
   leaders:
     - limitless00net
-  support:
-    KR:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: false
-        cloud: true
 kw:
   nativeName: kernewek
 lb:
   nativeName: Lëtzebuergesch
   leaders:
     - mojikosu
-  support:
-    LU:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: false
-      text-to-speech:
-        piper: true
-        cloud: false
 lt:
   nativeName: Lietuvių
   leaders:
     - ErnestStaug
-  support:
-    LT:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: false
-        cloud: true
 lv:
   nativeName: Latviešu
   leaders:
     - makstech
     - klejejs
-  support:
-    LV:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 ml:
   nativeName: മലയാളം
   leaders:
     - arunshekher
-  support:
-    IN:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: false
-        cloud: true
 mn:
   nativeName: монгол хэл
   leaders:
     - chuk-a
-  support:
-    MN:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: false
-        cloud: true
 mr:
   nativeName: Marathi
-  support:
-    IN:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: false
-        cloud: true
 ms:
   nativeName: Bahasa Melayu
   leaders:
     - zubir2k
-  support:
-    MY:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: false
-        cloud: true
 nb:
   nativeName: Norsk Bokmål
   leaders:
     - LaStrada
-  support:
-    "NO":
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: false
-        cloud: true
 ne:
   nativeName: नेपाली
-  support:
-    NP:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 nl:
   nativeName: Nederlands
   leaders:
     - TheFes
-  support:
-    BE:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: false
-        cloud: true
-    NL:
-      speech-to-text:
-        speech-to-phrase: true
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 pl:
   nativeName: Polski
   leaders:
     - Uriziel01
     - witold-gren
-  support:
-    PL:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 pt:
   nativeName: Português
   leaders:
     - joaorgoncalves
     - nikito7
     - abmantis
-  support:
-    PT:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: true
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 pt-br:
   nativeName: Português (Brasil)
   leaders:
     - mhentschke
     - luyzfernando08
-  support:
-    BR:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: true
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 ro:
   nativeName: Română
   leaders:
     - tetele
     - gabimarchidan
-  support:
-    RO:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 ru:
   nativeName: Русский
   leaders:
     - HepoH3
-  support:
-    RU:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 sk:
   nativeName: Slovenčina
   leaders:
     - LubosKadasi
-  support:
-    SK:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 sl:
   nativeName: Slovenščina
   leaders:
     - andrejs2
-  support:
-    SI:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 sr:
   nativeName: Српски
   leaders:
     - cvladan
     - ddxic
-  support:
-    RS:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 sr-Latn:
   nativeName: Srpski
   leaders:
@@ -638,128 +216,38 @@ sv:
   nativeName: Svenska
   leaders:
     - larsdunemark
-  support:
-    SE:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 sw:
   nativeName: Kiswahili
   leaders:
     - BCorbeek
-  support:
-    KE:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: false
-        cloud: true
 te:
   nativeName: తెలుగు
-  support:
-    IN:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: false
-        cloud: true
 th:
   nativeName: ภาษาไทย
-  support:
-    TH:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: false
-        cloud: true
 tr:
   nativeName: Türkçe
   leaders:
     - alpdmrel
-  support:
-    TR:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 uk:
   nativeName: Українська
   leaders:
     - skynetua
-  support:
-    UA:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 ur:
   nativeName: اُردُو
   leaders:
     - AalianKhan
-  support:
-    IN:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: false
-      text-to-speech:
-        piper: false
-        cloud: true
 vi:
   nativeName: Tiếng Việt
   leaders:
     - dinhchinh82
-  support:
-    VN:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 zh-cn:
   nativeName: 简体中文
   leaders:
     - al-one
-  support:
-    CN:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: true
-        cloud: true
 zh-hk:
   nativeName: 繁體中文（香港）
   leaders:
     - swonge
-  support:
-    HK:
-      speech-to-text:
-        speech-to-phrase: false
-        whisper: false
-        cloud: true
-      text-to-speech:
-        piper: false
-        cloud: true
 zh-tw:
   nativeName: 繁體中文（台灣）
   leaders:

--- a/languages.yaml
+++ b/languages.yaml
@@ -157,98 +157,323 @@ es:
   nativeName: Español
   leaders:
     - davefx
+  support:
+    MX:
+      speech-to-text:
+        speech-to-phrase: true
+        whisper: true
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 et:
   nativeName: Eesti
+  support:
+    EE:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 eu:
   nativeName: Euskara
   leaders:
     - urtzai
+  support:
+    ES:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 fa:
   nativeName: فارسی
   isRTL: true
+  support:
+    IR:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 fi:
   nativeName: Suomi
   leaders:
     - Arkkimaagi
     - salleq
+  support:
+    FI:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 fr:
   nativeName: Français
   leaders:
     - jlpouffier
     - piitaya
+  support:
+    FR:
+      speech-to-text:
+        speech-to-phrase: true
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 gl:
   nativeName: Galician
   leaders:
     - cibernox
+  support:
+    ES:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 gu:
   nativeName: Gujarati
+  support:
+    IN:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 he:
   nativeName: עברית
   isRTL: true
   leaders:
     - leranp
     - haim-b
+  support:
+    IL:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 hi:
   nativeName: हिन्दी
+  support:
+    IN:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 hr:
   nativeName: Hrvatski
   leaders:
     - spuljko
+  support:
+    HR:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 hu:
   nativeName: Magyar
   leaders:
     - nagyrobi
     - v1k70rk4
+  support:
+    HU:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 id:
   nativeName: Bahasa Indonesia
+  support:
+    ID:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 is:
   nativeName: íslenska
   leaders:
     - thdg
+  support:
+    IS:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 it:
   nativeName: Italiano
   leaders:
     - auanasgheps
     - xraver
+  support:
+    IT:
+      speech-to-text:
+        speech-to-phrase: true
+        whisper: true
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 ka:
   nativeName: ქართული
   leaders:
     - hertzg
+  support:
+    GE:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 kn:
   nativeName: ಕನ್ನಡ
+  support:
+    IN:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 ko:
   nativeName: 한국어
   leaders:
     - limitless00net
+  support:
+    KR:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 kw:
   nativeName: kernewek
 lb:
   nativeName: Lëtzebuergesch
   leaders:
     - mojikosu
+  support:
+    LU:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: false
+      text-to-speech:
+        piper: true
+        cloud: false
 lt:
   nativeName: Lietuvių
   leaders:
     - ErnestStaug
+  support:
+    LT:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 lv:
   nativeName: Latviešu
   leaders:
     - makstech
     - klejejs
+  support:
+    LV:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 ml:
   nativeName: മലയാളം
   leaders:
     - arunshekher
+  support:
+    IN:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 mn:
   nativeName: монгол хэл
   leaders:
     - chuk-a
+  support:
+    MN:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 mr:
   nativeName: Marathi
+  support:
+    IN:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 ms:
   nativeName: Bahasa Melayu
   leaders:
     - zubir2k
+  support:
+    MY:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 nb:
   nativeName: Norsk Bokmål
   leaders:

--- a/languages.yaml
+++ b/languages.yaml
@@ -479,7 +479,7 @@ nb:
   leaders:
     - LaStrada
   support:
-    "NO ": # avoid yes/no garbage from YAML 1.1
+    "NO":
       speech-to-text:
         speech-to-phrase: false
         whisper: false

--- a/languages.yaml
+++ b/languages.yaml
@@ -478,50 +478,157 @@ nb:
   nativeName: Norsk Bokmål
   leaders:
     - LaStrada
+  support:
+    "NO":
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 ne:
   nativeName: नेपाली
+  support:
+    NP:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 nl:
   nativeName: Nederlands
   leaders:
     - TheFes
+  support:
+    BE:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
+    NL:
+      speech-to-text:
+        speech-to-phrase: true
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 pl:
   nativeName: Polski
   leaders:
     - Uriziel01
     - witold-gren
+  support:
+    PL:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 pt:
   nativeName: Português
   leaders:
     - joaorgoncalves
     - nikito7
     - abmantis
+  support:
+    PT:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: true
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 pt-br:
   nativeName: Português (Brasil)
   leaders:
     - mhentschke
     - luyzfernando08
+  support:
+    BR:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: true
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 ro:
   nativeName: Română
   leaders:
     - tetele
     - gabimarchidan
+  support:
+    RO:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 ru:
   nativeName: Русский
   leaders:
     - HepoH3
+  support:
+    RU:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 sk:
   nativeName: Slovenčina
   leaders:
     - LubosKadasi
+  support:
+    SK:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 sl:
   nativeName: Slovenščina
   leaders:
     - andrejs2
+  support:
+    SI:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 sr:
   nativeName: Српски
   leaders:
     - cvladan
     - ddxic
+  support:
+    RS:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 sr-Latn:
   nativeName: Srpski
   leaders:
@@ -530,38 +637,128 @@ sv:
   nativeName: Svenska
   leaders:
     - larsdunemark
+  support:
+    SE:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 sw:
   nativeName: Kiswahili
   leaders:
     - BCorbeek
+  support:
+    KE:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 te:
   nativeName: తెలుగు
+  support:
+    IN:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 th:
   nativeName: ภาษาไทย
+  support:
+    TH:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 tr:
   nativeName: Türkçe
   leaders:
     - alpdmrel
+  support:
+    TR:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 uk:
   nativeName: Українська
   leaders:
     - skynetua
+  support:
+    UA:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 ur:
   nativeName: اُردُو
   leaders:
     - AalianKhan
+  support:
+    IN:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: false
+      text-to-speech:
+        piper: false
+        cloud: true
 vi:
   nativeName: Tiếng Việt
   leaders:
     - dinhchinh82
+  support:
+    VN:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 zh-cn:
   nativeName: 简体中文
   leaders:
     - al-one
+  support:
+    CN:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 zh-hk:
   nativeName: 繁體中文（香港）
   leaders:
     - swonge
+  support:
+    HK:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 zh-tw:
   nativeName: 繁體中文（台灣）
   leaders:

--- a/languages.yaml
+++ b/languages.yaml
@@ -1,45 +1,143 @@
 af:
   nativeName: Afrikaans
+  support:
+    ZA:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 ar:
   nativeName: العربية
   isRTL: true
   leaders:
     - Ahmed-farag36
     - Natfaji
+  support:
+    JO:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 bg:
   nativeName: Български
   leaders:
     - hristo-atanasov
+  support:
+    BG:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 bn:
   nativeName: বাংলা
+  support:
+    BD:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: false
+      text-to-speech:
+        piper: false
+        cloud: true
+    IN:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 ca:
   nativeName: Català
   leaders:
     - duhow
+  support:
+    ES:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 cs:
   nativeName: Čeština
   leaders:
     - halecivo
     - schizza
+  support:
+    CZ:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 da:
   nativeName: Dansk
   leaders:
     - fadamsen
     - MTrab
+  support:
+    DK:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 de:
   nativeName: Deutsch
   leaders:
     - andreasbrett
     - easterapps
     - mib1185
+  support:
+    DE:
+      speech-to-text:
+        speech-to-phrase: true
+        whisper: true
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 de-CH:
   nativeName: Schwyzerdütsch
   leaders:
     - dontinelli
+  support:
+    CH:
+      speech-to-text:
+        speech-to-phrase: true
+        whisper: true
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 el:
   nativeName: Ελληνικά
   leaders:
     - chatziko
+  support:
+    GR:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 en:
   nativeName: English
   leaders:
@@ -59,146 +157,478 @@ es:
   nativeName: Español
   leaders:
     - davefx
+  support:
+    MX:
+      speech-to-text:
+        speech-to-phrase: true
+        whisper: true
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 et:
   nativeName: Eesti
+  support:
+    EE:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 eu:
   nativeName: Euskara
   leaders:
     - urtzai
+  support:
+    ES:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 fa:
   nativeName: فارسی
   isRTL: true
+  support:
+    IR:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 fi:
   nativeName: Suomi
   leaders:
     - Arkkimaagi
     - salleq
+  support:
+    FI:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 fr:
   nativeName: Français
   leaders:
     - jlpouffier
     - piitaya
+  support:
+    FR:
+      speech-to-text:
+        speech-to-phrase: true
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 gl:
   nativeName: Galician
   leaders:
     - cibernox
+  support:
+    ES:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 gu:
   nativeName: Gujarati
+  support:
+    IN:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 he:
   nativeName: עברית
   isRTL: true
   leaders:
     - leranp
     - haim-b
+  support:
+    IL:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 hi:
   nativeName: हिन्दी
+  support:
+    IN:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 hr:
   nativeName: Hrvatski
   leaders:
     - spuljko
+  support:
+    HR:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 hu:
   nativeName: Magyar
   leaders:
     - nagyrobi
     - v1k70rk4
+  support:
+    HU:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 id:
   nativeName: Bahasa Indonesia
+  support:
+    ID:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 is:
   nativeName: íslenska
   leaders:
     - thdg
+  support:
+    IS:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 it:
   nativeName: Italiano
   leaders:
     - auanasgheps
     - xraver
+  support:
+    IT:
+      speech-to-text:
+        speech-to-phrase: true
+        whisper: true
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 ka:
   nativeName: ქართული
   leaders:
     - hertzg
+  support:
+    GE:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 kn:
   nativeName: ಕನ್ನಡ
+  support:
+    IN:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 ko:
   nativeName: 한국어
   leaders:
     - limitless00net
+  support:
+    KR:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 kw:
   nativeName: kernewek
 lb:
   nativeName: Lëtzebuergesch
   leaders:
     - mojikosu
+  support:
+    LU:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: false
+      text-to-speech:
+        piper: true
+        cloud: false
 lt:
   nativeName: Lietuvių
   leaders:
     - ErnestStaug
+  support:
+    LT:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 lv:
   nativeName: Latviešu
   leaders:
     - makstech
     - klejejs
+  support:
+    LV:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 ml:
   nativeName: മലയാളം
   leaders:
     - arunshekher
+  support:
+    IN:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 mn:
   nativeName: монгол хэл
   leaders:
     - chuk-a
+  support:
+    MN:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 mr:
   nativeName: Marathi
+  support:
+    IN:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 ms:
   nativeName: Bahasa Melayu
   leaders:
     - zubir2k
+  support:
+    MY:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 nb:
   nativeName: Norsk Bokmål
   leaders:
     - LaStrada
+  support:
+    NO:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 ne:
   nativeName: नेपाली
+  support:
+    NP:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 nl:
   nativeName: Nederlands
   leaders:
     - TheFes
+  support:
+    BE:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
+    NL:
+      speech-to-text:
+        speech-to-phrase: true
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 pl:
   nativeName: Polski
   leaders:
     - Uriziel01
     - witold-gren
+  support:
+    PL:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 pt:
   nativeName: Português
   leaders:
     - joaorgoncalves
     - nikito7
     - abmantis
+  support:
+    PT:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: true
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 pt-br:
   nativeName: Português (Brasil)
   leaders:
     - mhentschke
     - luyzfernando08
+  support:
+    BR:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: true
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 ro:
   nativeName: Română
   leaders:
     - tetele
     - gabimarchidan
+  support:
+    RO:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 ru:
   nativeName: Русский
   leaders:
     - HepoH3
+  support:
+    RU:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 sk:
   nativeName: Slovenčina
   leaders:
     - LubosKadasi
+  support:
+    SK:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 sl:
   nativeName: Slovenščina
   leaders:
     - andrejs2
+  support:
+    SI:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 sr:
   nativeName: Српски
   leaders:
     - cvladan
     - ddxic
+  support:
+    RS:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 sr-Latn:
   nativeName: Srpski
   leaders:
@@ -207,38 +637,128 @@ sv:
   nativeName: Svenska
   leaders:
     - larsdunemark
+  support:
+    SE:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 sw:
   nativeName: Kiswahili
   leaders:
     - BCorbeek
+  support:
+    KE:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 te:
   nativeName: తెలుగు
+  support:
+    IN:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 th:
   nativeName: ภาษาไทย
+  support:
+    TH:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 tr:
   nativeName: Türkçe
   leaders:
     - alpdmrel
+  support:
+    TR:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 uk:
   nativeName: Українська
   leaders:
     - skynetua
+  support:
+    UA:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 ur:
   nativeName: اُردُو
   leaders:
     - AalianKhan
+  support:
+    IN:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: false
+      text-to-speech:
+        piper: false
+        cloud: true
 vi:
   nativeName: Tiếng Việt
   leaders:
     - dinhchinh82
+  support:
+    VN:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 zh-cn:
   nativeName: 简体中文
   leaders:
     - al-one
+  support:
+    CN:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 zh-hk:
   nativeName: 繁體中文（香港）
   leaders:
     - swonge
+  support:
+    HK:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 zh-tw:
   nativeName: 繁體中文（台灣）
   leaders:

--- a/languages.yaml
+++ b/languages.yaml
@@ -1,5 +1,3 @@
-%YAML 1.2
----
 af:
   nativeName: Afrikaans
   support:
@@ -481,7 +479,7 @@ nb:
   leaders:
     - LaStrada
   support:
-    NO:
+    "NO ": # avoid yes/no garbage from YAML 1.1
       speech-to-text:
         speech-to-phrase: false
         whisper: false

--- a/languages.yaml
+++ b/languages.yaml
@@ -479,7 +479,7 @@ nb:
   leaders:
     - LaStrada
   support:
-    "NO":
+    NB:
       speech-to-text:
         speech-to-phrase: false
         whisper: false

--- a/languages.yaml
+++ b/languages.yaml
@@ -479,7 +479,7 @@ nb:
   leaders:
     - LaStrada
   support:
-    NO:
+    "NO":
       speech-to-text:
         speech-to-phrase: false
         whisper: false

--- a/languages.yaml
+++ b/languages.yaml
@@ -1,3 +1,4 @@
+---
 af:
   nativeName: Afrikaans
   support:

--- a/languages.yaml
+++ b/languages.yaml
@@ -15,40 +15,129 @@ ar:
   leaders:
     - Ahmed-farag36
     - Natfaji
+  support:
+    JO:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 bg:
   nativeName: Български
   leaders:
     - hristo-atanasov
+  support:
+    BG:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 bn:
   nativeName: বাংলা
+  support:
+    BD:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: false
+      text-to-speech:
+        piper: false
+        cloud: true
+    IN:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 ca:
   nativeName: Català
   leaders:
     - duhow
+  support:
+    ES:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 cs:
   nativeName: Čeština
   leaders:
     - halecivo
     - schizza
+  support:
+    CZ:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 da:
   nativeName: Dansk
   leaders:
     - fadamsen
     - MTrab
+  support:
+    DK:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 de:
   nativeName: Deutsch
   leaders:
     - andreasbrett
     - easterapps
     - mib1185
+  support:
+    DE:
+      speech-to-text:
+        speech-to-phrase: true
+        whisper: true
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 de-CH:
   nativeName: Schwyzerdütsch
   leaders:
     - dontinelli
+  support:
+    CH:
+      speech-to-text:
+        speech-to-phrase: true
+        whisper: true
+        cloud: true
+      text-to-speech:
+        piper: false
+        cloud: true
 el:
   nativeName: Ελληνικά
   leaders:
     - chatziko
+  support:
+    GR:
+      speech-to-text:
+        speech-to-phrase: false
+        whisper: false
+        cloud: true
+      text-to-speech:
+        piper: true
+        cloud: true
 en:
   nativeName: English
   leaders:

--- a/script/lint
+++ b/script/lint
@@ -30,4 +30,4 @@ mypy "${python_files[@]}"
 python3 -m script.intentfest validate
 
 # prettier
-pre-commit run --all-files
+pre-commit run prettier --all-files --verbose


### PR DESCRIPTION
Filled all the data for the support per language.

- speech-to-phrase comes from: https://github.com/OHF-voice/speech-to-phrase
- cloud comes from what NAbu Casa supports on HA Cloud using Microsoft Azure 
- Piper comes from available voices here: https://github.com/rhasspy/piper/blob/master/VOICES.md
- Whisper comes from having a WER (Word Error Rate) smaller than 20% on the FLEURS benchmark on the base model: https://paperswithcode.com/paper/robust-speech-recognition-via-large-scale-1/review/?hl=103869