### PR TITLE
Update prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v3.0.0-alpha.4"
+    rev: "v4.0.0-alpha.8"
     hooks:
       - id: prettier
         types_or: [yaml]


### PR DESCRIPTION
Update prettier to [v4.0.0-alpha.8](https://github.com/pre-commit/mirrors-prettier/releases/tag/v4.0.0-alpha.8)