### PR TITLE
Add start mowing and dock intents for lawn mower

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -1791,3 +1791,40 @@ HassTimerStatus:
           - start_hours: hours that the timer was started with
           - start_minutes: minutes that the timer was started with
           - start_seconds: seconds that the timer was started with
+
+# -----------------------------------------------------------------------------
+# lawn mower
+# -----------------------------------------------------------------------------
+
+HassLawnMowerStartMowing:
+  supported: true
+  domain: lawn_mower
+  description: "Starts a lawn mower"
+  importance: "complete"
+  slots:
+    name:
+      description: "Name of a device or entity"
+      required: false
+    area:
+      description: "Name of an area"
+      required: false
+  slot_combinations:
+    - slots: "name"
+      example: "start rover"
+    - slots: "area"
+      example: "mows the lawn in the garden"
+
+HassLawnMowerDock:
+  supported: true
+  domain: lawn_mower
+  description: "Sends a lawn mower to dock"
+  importance: "complete"
+  slots:
+    name:
+      description: "Name of a device or entity"
+      required: false
+  slot_combinations:
+    - slots: "name"
+      example: "return lawn mower to base"
+    - slots: "area"
+      example: "return garden lawn mower to base"

--- a/responses/fr/HassLawnMowerDock.yaml
+++ b/responses/fr/HassLawnMowerDock.yaml
@@ -1,0 +1,5 @@
+language: fr
+responses:
+  intents:
+    HassLawnMowerDock:
+      default: "Retour à la base"

--- a/responses/fr/HassLawnMowerStartMowing.yaml
+++ b/responses/fr/HassLawnMowerStartMowing.yaml
@@ -1,0 +1,5 @@
+language: fr
+responses:
+  intents:
+    HassLawnMowerStartMowing:
+      default: "Tonte lancée"

--- a/sentences/fr/homeassistant_HassTurnOff.yaml
+++ b/sentences/fr/homeassistant_HassTurnOff.yaml
@@ -9,6 +9,7 @@ intents:
           domain:
             - binary_sensor
             - cover
+            - lawn_mower
             - lock
             - scene
             - script

--- a/sentences/fr/homeassistant_HassTurnOn.yaml
+++ b/sentences/fr/homeassistant_HassTurnOn.yaml
@@ -9,6 +9,7 @@ intents:
           domain:
             - binary_sensor
             - cover
+            - lawn_mower
             - lock
             - scene
             - script

--- a/sentences/fr/lawn_mower_HassLawnMowerDock.yaml
+++ b/sentences/fr/lawn_mower_HassLawnMowerDock.yaml
@@ -1,0 +1,8 @@
+language: fr
+intents:
+  HassLawnMowerDock:
+    data:
+      - sentences:
+          - "<renvoie> [<le>]{name} [(à|sur) (sa|la) base]"
+        requires_context:
+          domain: lawn_mower

--- a/sentences/fr/lawn_mower_HassLawnMowerStartMowing.yaml
+++ b/sentences/fr/lawn_mower_HassLawnMowerStartMowing.yaml
@@ -1,0 +1,8 @@
+language: fr
+intents:
+  HassLawnMowerStartMowing:
+    data:
+      - sentences:
+          - "<demarre> [<le>]{name}"
+        requires_context:
+          domain: lawn_mower

--- a/tests/fr/_fixtures.yaml
+++ b/tests/fr/_fixtures.yaml
@@ -29,6 +29,9 @@ areas:
     id: "bathroom"
     floor: ground_floor_id
 
+  - name: "Jardin"
+    id: "garden"
+    floor: ground_floor_id
 entities:
   - name: "lumière du plafond"
     id: "light.bedroom_lamp"
@@ -836,6 +839,11 @@ entities:
     id: "vacuum.nestor"
     area: "kitchen"
     state: "idle"
+
+  - name: "la tondeuse"
+    id: "lawn_mower.la_tondeuse"
+    area: "garden"
+    state: "docked"
 
 timers:
   - is_active: false

--- a/tests/fr/lawn_mower_HassLawnMowerDock.yaml
+++ b/tests/fr/lawn_mower_HassLawnMowerDock.yaml
@@ -1,0 +1,9 @@
+language: fr
+tests:
+  - sentences:
+      - "Renvoie la tondeuse sur sa base"
+    intent:
+      name: HassLawnMowerDock
+      slots:
+        name: "la tondeuse"
+    response: "Retour à la base"

--- a/tests/fr/lawn_mower_HassLawnMowerStartMowing.yaml
+++ b/tests/fr/lawn_mower_HassLawnMowerStartMowing.yaml
@@ -1,0 +1,9 @@
+language: fr
+tests:
+  - sentences:
+      - "Démarre la tondeuse"
+    intent:
+      name: HassLawnMowerStartMowing
+      slots:
+        name: "la tondeuse"
+    response: "Tonte lancée"


### PR DESCRIPTION
Add start mowing and dock intents for lawn mower. Very similar than the vacuum ones.

It needs https://github.com/home-assistant/core/pull/140525 to be merged to have core support.