### PR TITLE
Update Speech-To-Phrase support for NL

### DIFF
--- a/languages.yaml
+++ b/languages.yaml
@@ -505,7 +505,7 @@ nl:
   support:
     BE:
       speech-to-text:
-        speech-to-phrase: false
+        speech-to-phrase: true
         whisper: false
         cloud: true
       text-to-speech:


### PR DESCRIPTION
I made an incorrect assumption when I initially filled the data.

I thought speech-to-phrase was supported only for nl-NL, but it's actually supported for nl-BE too.