### PR TITLE
[CA] Add HassBroadcast

### DIFF
--- a/responses/ca/HassBroadcast.yaml
+++ b/responses/ca/HassBroadcast.yaml
@@ -1,0 +1,5 @@
+language: ca
+responses:
+  intents:
+    HassBroadcast:
+      default: "Fet"

--- a/sentences/ca/_common.yaml
+++ b/sentences/ca/_common.yaml
@@ -145,6 +145,9 @@ lists:
   response:
     wildcard: true
 
+  message:
+    wildcard: true
+
 expansion_rules:
   actual: "(ara|actual[ment])"
   pronom_singular: "((el|la|es|sa) |l'|s')"

--- a/sentences/ca/assist_satellite_HassBroadcast.yaml
+++ b/sentences/ca/assist_satellite_HassBroadcast.yaml
@@ -3,4 +3,5 @@ intents:
   HassBroadcast:
     data:
       - sentences:
-          - "[Fes un] (broadcast|anunci|anuncia) [a tot arreu] [(que digui)|(dient que)] {message}"
+          - "([Fes un] anunci|anuncia) [a tot arreu] [que digui|dient que] {message}"
+          - "[Fes un] broadcast [a tot arreu] [que digui|dient que] {message}"

--- a/sentences/ca/assist_satellite_HassBroadcast.yaml
+++ b/sentences/ca/assist_satellite_HassBroadcast.yaml
@@ -1,0 +1,6 @@
+language: "ca"
+intents:
+  HassBroadcast:
+    data:
+      - sentences:
+          - "[Fes un] (broadcast|anunci|anuncia) [a tot arreu] [(que digui)|(dient que)] {message}"

--- a/sentences/ca/assist_satellite_HassBroadcast.yaml
+++ b/sentences/ca/assist_satellite_HassBroadcast.yaml
@@ -3,5 +3,5 @@ intents:
   HassBroadcast:
     data:
       - sentences:
-          - "([Fes un] anunci|anuncia) [a tot arreu] [que digui|dient que] {message}"
-          - "[Fes un] broadcast [a tot arreu] [que digui|dient que] {message}"
+          - "([Fes un] anunci|anuncia) [a tot arreu] [que digui|dient] [que] {message}"
+          - "[Fes un] broadcast [a tot arreu] [que digui|dient] [que] {message}"

--- a/tests/ca/assist_satellite_HassBroadcast.yaml
+++ b/tests/ca/assist_satellite_HassBroadcast.yaml
@@ -2,6 +2,8 @@ language: ca
 tests:
   - sentences:
       - "Fes un anunci dient que el sopar ja està llest"
+      - anuncia que el sopar ja està llest
+      - fes un broadcast dient que el sopar ja està llest
     intent:
       name: HassBroadcast
       slots:

--- a/tests/ca/assist_satellite_HassBroadcast.yaml
+++ b/tests/ca/assist_satellite_HassBroadcast.yaml
@@ -1,0 +1,9 @@
+language: ca
+tests:
+  - sentences:
+      - "Fes un anunci dient que el sopar ja està llest"
+    intent:
+      name: HassBroadcast
+      slots:
+        message: "el sopar ja està llest"
+    response: "Fet"


### PR DESCRIPTION
CA version of https://github.com/home-assistant/intents/pull/2877

Hi @duhow I propose this sentence: "[Fes un] (broadcast|anunci|anuncia) [a tot arreu] [(que digui)|(dient que)] {message}"

Is it too big? Should I break it down?

Also, I would use "broadcast" as "anglicisme", but maybe it's just me. What do you think? Can we keep it?