### PR TITLE
[EN] Fix list name on todo_HassListAddItem

### DIFF
--- a/sentences/en/todo_HassListAddItem.yaml
+++ b/sentences/en/todo_HassListAddItem.yaml
@@ -10,4 +10,4 @@ intents:
           domain: todo
         expansion_rules:
           my_list: "[my|the] {name} [list]"
-          item: "{shopping_list_item:item}"
+          item: "{todo_list_item:item}"


### PR DESCRIPTION
- en: small fix on `todo_HassListAddItem` (that was using shopping_list_item)