### PR TITLE
Add "minuterie" french translation for timer

### DIFF
--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -476,6 +476,8 @@ expansion_rules:
   pourcent: "(%| %| pourcent| pour cent)"
   degres: "(°| °| degré| degrés)"
   le: (le |la |les |l')
+  au: (au |à la |aux |à l')
+  mon: (mon |ma |mes)
   dans: "(dans|du|de|des|à|au|aux|sur)"
   de: "(du|de|des)"
   tous: "(tout|tous|toute[s])"
@@ -534,8 +536,8 @@ expansion_rules:
   media: "(morceau|chanson|musique|son|élément|podcast|film|vidéo|épisode|radio|média)"
   lecture: "(lecture|visionnage)"
   volume: "(volume|son|watt[s])"
-  minuteur: "(compte a rebours)|(compte à rebours)|(minuteur)|(décompte)|<minuteur_dirty>"
-  minuteurs: "(comptes a rebours)|(comptes à rebours)|(minuteurs)|(décomptes)"
+  minuteur: "(compte a rebours)|(compte à rebours)|(minuteur)|(minuterie)|(décompte)|<minuteur_dirty>"
+  minuteurs: "(comptes a rebours)|(comptes à rebours)|(minuteurs)|(minuteries)|(décomptes)"
   serrure: "(verrou[s]|serrure[s]|loquet[s]|porte[s])"
 
   ### Timers ###

--- a/sentences/fr/homeassistant_HassCancelAllTimers.yaml
+++ b/sentences/fr/homeassistant_HassCancelAllTimers.yaml
@@ -6,23 +6,23 @@ intents:
       # All timers
       - sentences:
           # Supprime tous les minuteur
-          - "<supprime> tous [(les|mes)] <minuteurs>"
+          - "<supprime> <tous> [(les|mes)] <minuteurs>"
           # Arrête tous les minuteur
-          - "<eteins> tous [(les|mes)] <minuteurs>"
+          - "<eteins> <tous> [(les|mes)] <minuteurs>"
 
       # All timers in area
       - sentences:
           # Supprime tous les minuteur dans la cuisine
-          - "<supprime> tous [(les|mes)] <minuteurs> [(<de>|<dans>)] [<le>]{area}"
+          - "<supprime> <tous> [(les|mes)] <minuteurs> [(<de>|<dans>)] [<le>]{area}"
           # Arrête tous les minuteur dans le salon
-          - "<eteins> tous [(les|mes)] <minuteurs> [(<de>|<dans>)] [<le>]{area}"
+          - "<eteins> <tous> [(les|mes)] <minuteurs> [(<de>|<dans>)] [<le>]{area}"
 
       # All timers here (context awareness)
       - sentences:
           # Supprime tous les minuteur dans la cuisine
-          - "<supprime> tous [(les|mes)] <minuteurs> <ici>"
+          - "<supprime> <tous> [(les|mes)] <minuteurs> <ici>"
           # Arrête tous les minuteur dans le salon
-          - "<eteins> tous [(les|mes)] <minuteurs> <ici>"
+          - "<eteins> <tous> [(les|mes)] <minuteurs> <ici>"
         requires_context:
           area:
             slot: true

--- a/sentences/fr/homeassistant_HassCancelTimer.yaml
+++ b/sentences/fr/homeassistant_HassCancelTimer.yaml
@@ -31,4 +31,4 @@ intents:
           # Arrête le minuteur appelé Pizza
           - "<eteins> [<le>|<mon>] <minuteur> [<appele>] {timer_name:name}"
         expansion_rules:
-          appele: "(appelé[e]|[sur]nommé[e]|pour [<le>])"
+          appele: "(appelé[e]|nommé[e]|surnommé[e]|pour [<le>])"

--- a/sentences/fr/homeassistant_HassCancelTimer.yaml
+++ b/sentences/fr/homeassistant_HassCancelTimer.yaml
@@ -6,29 +6,29 @@ intents:
       # No name
       - sentences:
           # Supprime le minuteur
-          - "<supprime> [(le|mon)] <minuteur>"
+          - "<supprime> [<le>|<mon>] <minuteur>"
           # Arrête le minuteur
-          - "<eteins> [(le|mon)] <minuteur>"
+          - "<eteins> [<le>|<mon>] <minuteur>"
 
       # area
       - sentences:
           # Supprime le minuteur de la cuisine
-          - "<supprime> [(le|mon)] <minuteur> [(<de>|<dans>)] [<le>]{area}"
+          - "<supprime> [<le>|<mon>] <minuteur> [(<de>|<dans>)] [<le>]{area}"
           # Arrête le minuteur de la cuisine
-          - "<eteins> [(le|mon)] <minuteur> [(<de>|<dans>)] [<le>]{area}"
+          - "<eteins> [<le>|<mon>] <minuteur> [(<de>|<dans>)] [<le>]{area}"
 
       # duration
       - sentences:
           # Supprime le minuteur de 2 minutes
-          - "<supprime> [(le|mon)] <minuteur> [de] <timer_start>"
+          - "<supprime> [<le>|<mon>] <minuteur> [de] <timer_start>"
           # Arrête le minuteur de 2 minutes
-          - "<eteins> [(le|mon)] <minuteur> [de] <timer_start>"
+          - "<eteins> [<le>|<mon>] <minuteur> [de] <timer_start>"
 
       # name
       - sentences:
           # Supprime le minuteur appelé Pizza
-          - "<supprime> [(le|mon)] <minuteur> [<appele>] {timer_name:name}"
+          - "<supprime> [<le>|<mon>] <minuteur> [<appele>] {timer_name:name}"
           # Arrête le minuteur appelé Pizza
-          - "<eteins> [(le|mon)] <minuteur> [<appele>] {timer_name:name}"
+          - "<eteins> [<le>|<mon>] <minuteur> [<appele>] {timer_name:name}"
         expansion_rules:
-          appele: "(appelé|nommé|surnommé|pour [<le>])"
+          appele: "(appelé[e]|[sur]nommé[e]|pour [<le>])"

--- a/sentences/fr/homeassistant_HassDecreaseTimer.yaml
+++ b/sentences/fr/homeassistant_HassDecreaseTimer.yaml
@@ -39,4 +39,4 @@ intents:
           # Enleve 2 minute sur le minuteur Pizza
           - "<enleve> <timer_duration> (sur|dans) [<le>|<mon>] <minuteur> [<appele>] {timer_name:name}"
         expansion_rules:
-          appele: "(appelé[e]|[sur]nommé[e]|pour [<le>])"
+          appele: "(appelé[e]|nommé[e]|surnommé[e]|pour [<le>])"

--- a/sentences/fr/homeassistant_HassDecreaseTimer.yaml
+++ b/sentences/fr/homeassistant_HassDecreaseTimer.yaml
@@ -8,35 +8,35 @@ intents:
           # Enleve 2 minute du minuteur
           - "<enleve> <timer_duration> du <minuteur>"
           # Enleve 2 minute au minuteur
-          - "<enleve> <timer_duration> au <minuteur>"
+          - "<enleve> <timer_duration> <au> <minuteur>"
           # Enleve 2 minute sur le minuteur
-          - "<enleve> <timer_duration> (sur|dans) [(le|mon)] <minuteur>"
+          - "<enleve> <timer_duration> (sur|dans) [<le>|<mon>] <minuteur>"
 
       # area
       - sentences:
           # Enleve 2 minute du minuteur de la cuisine
           - "<enleve> <timer_duration> du <minuteur> [<de>] [<le>]{area}"
           # Enleve 2 minute au minuteur de la cuisine
-          - "<enleve> <timer_duration> au <minuteur> [<de>] [<le>]{area}"
+          - "<enleve> <timer_duration> <au> <minuteur> [<de>] [<le>]{area}"
           # Enleve 2 minute sur le minuteur de la cuisine
-          - "<enleve> <timer_duration> (sur|dans) [(le|mon)] <minuteur> [<de>] [<le>]{area}"
+          - "<enleve> <timer_duration> (sur|dans) [<le>|<mon>] <minuteur> [<de>] [<le>]{area}"
 
       # duration
       - sentences:
           # Enleve 2 minute du minuteur de 5 minutes
           - "<enleve> <timer_duration> du <minuteur> [de] <timer_start>"
           # Enleve 2 minute au minuteur de 5 minutes
-          - "<enleve> <timer_duration> au <minuteur> [de] <timer_start>"
+          - "<enleve> <timer_duration> <au> <minuteur> [de] <timer_start>"
           # Enleve 2 minute sur le minuteur de 5 minutes
-          - "<enleve> <timer_duration> (sur|dans) [(le|mon)] <minuteur> [de] <timer_start>"
+          - "<enleve> <timer_duration> (sur|dans) [<le>|<mon>] <minuteur> [de] <timer_start>"
 
       # name
       - sentences:
           # Enleve 2 minute du minuteur Pizza
           - "<enleve> <timer_duration> du <minuteur> [<appele>] {timer_name:name}"
           # Enleve 2 minute au minuteur Pizza
-          - "<enleve> <timer_duration> au <minuteur> [<appele>] {timer_name:name}"
+          - "<enleve> <timer_duration> <au> <minuteur> [<appele>] {timer_name:name}"
           # Enleve 2 minute sur le minuteur Pizza
-          - "<enleve> <timer_duration> (sur|dans) [(le|mon)] <minuteur> [<appele>] {timer_name:name}"
+          - "<enleve> <timer_duration> (sur|dans) [<le>|<mon>] <minuteur> [<appele>] {timer_name:name}"
         expansion_rules:
-          appele: "(appelé|nommé|surnommé|pour [<le>])"
+          appele: "(appelé[e]|[sur]nommé[e]|pour [<le>])"

--- a/sentences/fr/homeassistant_HassIncreaseTimer.yaml
+++ b/sentences/fr/homeassistant_HassIncreaseTimer.yaml
@@ -8,35 +8,35 @@ intents:
           # Ajoute 2 minute du minuteur
           - "<ajoute> <timer_duration> du <minuteur>"
           # Ajoute 2 minute au minuteur
-          - "<ajoute> <timer_duration> au <minuteur>"
+          - "<ajoute> <timer_duration> <au> <minuteur>"
           # Ajoute 2 minute sur le minuteur
-          - "<ajoute> <timer_duration> (sur|dans) [(le|mon)] <minuteur>"
+          - "<ajoute> <timer_duration> (sur|dans) [<le>|<mon>] <minuteur>"
 
       # area
       - sentences:
           # Ajoute 2 minute du minuteur de la cuisine
           - "<ajoute> <timer_duration> du <minuteur> [<de>] [<le>]{area}"
           # Ajoute 2 minute au minuteur de la cuisine
-          - "<ajoute> <timer_duration> au <minuteur> [<de>] [<le>]{area}"
+          - "<ajoute> <timer_duration> <au> <minuteur> [<de>] [<le>]{area}"
           # Ajoute 2 minute sur le minuteur de la cuisine
-          - "<ajoute> <timer_duration> (sur|dans) [(le|mon)] <minuteur> [<de>] [<le>]{area}"
+          - "<ajoute> <timer_duration> (sur|dans) [<le>|<mon>] <minuteur> [<de>] [<le>]{area}"
 
       # duration
       - sentences:
           # Ajoute 2 minute du minuteur de 5 minutes
           - "<ajoute> <timer_duration> du <minuteur> [de] <timer_start>"
           # Ajoute 2 minute au minuteur de 5 minutes
-          - "<ajoute> <timer_duration> au <minuteur> [de] <timer_start>"
+          - "<ajoute> <timer_duration> <au> <minuteur> [de] <timer_start>"
           # Ajoute 2 minute sur le minuteur de 5 minutes
-          - "<ajoute> <timer_duration> (sur|dans) [(le|mon)] <minuteur> [de] <timer_start>"
+          - "<ajoute> <timer_duration> (sur|dans) [<le>|<mon>] <minuteur> [de] <timer_start>"
 
       # name
       - sentences:
           # Ajoute 2 minute du minuteur Pizza
           - "<ajoute> <timer_duration> du <minuteur> [<appele>] {timer_name:name}"
           # Ajoute 2 minute au minuteur Pizza
-          - "<ajoute> <timer_duration> au <minuteur> [<appele>] {timer_name:name}"
+          - "<ajoute> <timer_duration> <au> <minuteur> [<appele>] {timer_name:name}"
           # Ajoute 2 minute sur le minuteur Pizza
-          - "<ajoute> <timer_duration> (sur|dans) [(le|mon)] <minuteur> [<appele>] {timer_name:name}"
+          - "<ajoute> <timer_duration> (sur|dans) [<le>|<mon>] <minuteur> [<appele>] {timer_name:name}"
         expansion_rules:
-          appele: "(appelé|nommé|surnommé|pour [<le>])"
+          appele: "(appelé[e]|[sur]nommé[e]|pour [<le>])"

--- a/sentences/fr/homeassistant_HassIncreaseTimer.yaml
+++ b/sentences/fr/homeassistant_HassIncreaseTimer.yaml
@@ -39,4 +39,4 @@ intents:
           # Ajoute 2 minute sur le minuteur Pizza
           - "<ajoute> <timer_duration> (sur|dans) [<le>|<mon>] <minuteur> [<appele>] {timer_name:name}"
         expansion_rules:
-          appele: "(appelé[e]|[sur]nommé[e]|pour [<le>])"
+          appele: "(appelé[e]|nommé[e]|surnommé[e]|pour [<le>])"

--- a/sentences/fr/homeassistant_HassPauseTimer.yaml
+++ b/sentences/fr/homeassistant_HassPauseTimer.yaml
@@ -47,4 +47,4 @@ intents:
           # Mets sur pause le minuteur appelé Pizza
           - "<mets> sur pause [<le>|<mon>] <minuteur> [<appele>] {timer_name:name}"
         expansion_rules:
-          appele: "(appelé[e]|[sur]nommé[e]|pour [<le>])"
+          appele: "(appelé[e]|nommé[e]|surnommé[e]|pour [<le>])"

--- a/sentences/fr/homeassistant_HassPauseTimer.yaml
+++ b/sentences/fr/homeassistant_HassPauseTimer.yaml
@@ -6,45 +6,45 @@ intents:
       # No name
       - sentences:
           # Mets le minuteur en pause
-          - "<mets> [(le|mon)] <minuteur> en pause"
+          - "<mets> [<le>|<mon>] <minuteur> en pause"
           # Mets le minuteur sur pause
-          - "<mets> [(le|mon)] <minuteur> sur pause"
+          - "<mets> [<le>|<mon>] <minuteur> sur pause"
           # Mets en pause le minuteur
-          - "<mets> en pause [(le|mon)] <minuteur>"
+          - "<mets> en pause [<le>|<mon>] <minuteur>"
           # Mets sur pause le minuteur
-          - "<mets> sur pause [(le|mon)] <minuteur>"
+          - "<mets> sur pause [<le>|<mon>] <minuteur>"
 
       # area
       - sentences:
           # Mets le minuteur de la cuisine en pause
-          - "<mets> [(le|mon)] <minuteur> [<de>] [<le>]{area} en pause"
+          - "<mets> [<le>|<mon>] <minuteur> [<de>] [<le>]{area} en pause"
           # Mets le minuteur de la cuisine sur pause
-          - "<mets> [(le|mon)] <minuteur> [<de>] [<le>]{area} sur pause"
+          - "<mets> [<le>|<mon>] <minuteur> [<de>] [<le>]{area} sur pause"
           # Mets en pause le minuteur de la cuisine
-          - "<mets> en pause [(le|mon)] <minuteur> [<de>] [<le>]{area}"
+          - "<mets> en pause [<le>|<mon>] <minuteur> [<de>] [<le>]{area}"
           # Mets sur pause le minuteur de la cuisine
-          - "<mets> sur pause [(le|mon)] <minuteur> [<de>] [<le>]{area}"
+          - "<mets> sur pause [<le>|<mon>] <minuteur> [<de>] [<le>]{area}"
 
       # duration
       - sentences:
           # Mets le minuteur de 2 minutes en pause
-          - "<mets> [(le|mon)] <minuteur> [de] <timer_start> en pause"
+          - "<mets> [<le>|<mon>] <minuteur> [de] <timer_start> en pause"
           # Mets le minuteur de 2 minutes sur pause
-          - "<mets> [(le|mon)] <minuteur> [de] <timer_start> sur pause"
+          - "<mets> [<le>|<mon>] <minuteur> [de] <timer_start> sur pause"
           # Mets en pause le minuteur de 2 minutes
-          - "<mets> en pause [(le|mon)] <minuteur> [de] <timer_start>"
+          - "<mets> en pause [<le>|<mon>] <minuteur> [de] <timer_start>"
           # Mets sur pause le minuteur de 2 minutes
-          - "<mets> sur pause [(le|mon)] <minuteur> [de] <timer_start>"
+          - "<mets> sur pause [<le>|<mon>] <minuteur> [de] <timer_start>"
 
       # name
       - sentences:
           # Mets le minuteur appelé Pizza en pause
-          - "<mets> [(le|mon)] <minuteur> [<appele>] {timer_name:name} en pause"
+          - "<mets> [<le>|<mon>] <minuteur> [<appele>] {timer_name:name} en pause"
           # Mets le minuteur appelé Pizza sur pause
-          - "<mets> [(le|mon)] <minuteur> [<appele>] {timer_name:name} sur pause"
+          - "<mets> [<le>|<mon>] <minuteur> [<appele>] {timer_name:name} sur pause"
           # Mets en pause le minuteur appelé Pizza
-          - "<mets> en pause [(le|mon)] <minuteur> [<appele>] {timer_name:name}"
+          - "<mets> en pause [<le>|<mon>] <minuteur> [<appele>] {timer_name:name}"
           # Mets sur pause le minuteur appelé Pizza
-          - "<mets> sur pause [(le|mon)] <minuteur> [<appele>] {timer_name:name}"
+          - "<mets> sur pause [<le>|<mon>] <minuteur> [<appele>] {timer_name:name}"
         expansion_rules:
-          appele: "(appelé|nommé|surnommé|pour [<le>])"
+          appele: "(appelé[e]|[sur]nommé[e]|pour [<le>])"

--- a/sentences/fr/homeassistant_HassStartTimer.yaml
+++ b/sentences/fr/homeassistant_HassStartTimer.yaml
@@ -54,7 +54,7 @@ intents:
           # Minuteur d'une heure appelé Pizza
           - "<minuteur> d'<timer_duration> <appele> {timer_name:name}"
         expansion_rules:
-          appele: "(appelé|nommé|surnommé|pour [<le>])"
+          appele: "(appelé[e]|[sur]nommé[e]|pour [<le>])"
 
       # Name / Verb
       - sentences:
@@ -101,7 +101,7 @@ intents:
           # Mets un minuteur pour fermer la fenêtre dans 5 minutes
           - "<mets> un <minuteur> pour {timer_name:name} dans <timer_duration>"
         expansion_rules:
-          appele: "(appelé|nommé|surnommé|pour [<le>])"
+          appele: "(appelé[e]|[sur]nommé[e]|pour [<le>])"
 
       - sentences:
           # "Ouvre les volets du salon dans 5 minutes"

--- a/sentences/fr/homeassistant_HassStartTimer.yaml
+++ b/sentences/fr/homeassistant_HassStartTimer.yaml
@@ -54,7 +54,7 @@ intents:
           # Minuteur d'une heure appelé Pizza
           - "<minuteur> d'<timer_duration> <appele> {timer_name:name}"
         expansion_rules:
-          appele: "(appelé[e]|[sur]nommé[e]|pour [<le>])"
+          appele: "(appelé[e]|nommé[e]|surnommé[e]|pour [<le>])"
 
       # Name / Verb
       - sentences:
@@ -101,7 +101,7 @@ intents:
           # Mets un minuteur pour fermer la fenêtre dans 5 minutes
           - "<mets> un <minuteur> pour {timer_name:name} dans <timer_duration>"
         expansion_rules:
-          appele: "(appelé[e]|[sur]nommé[e]|pour [<le>])"
+          appele: "(appelé[e]|nommé[e]|surnommé[e]|pour [<le>])"
 
       - sentences:
           # "Ouvre les volets du salon dans 5 minutes"

--- a/sentences/fr/homeassistant_HassTimerStatus.yaml
+++ b/sentences/fr/homeassistant_HassTimerStatus.yaml
@@ -66,4 +66,4 @@ intents:
           - "[Il reste] [encore] combien de temps avant (de |d'|<le>){timer_name:name}"
         expansion_rules:
           reste_t_il: "(reste-t-il)|(reste t il)"
-          appele: "(appelé[e]|[sur]nommé[e]|pour [<le>])"
+          appele: "(appelé[e]|nommé[e]|surnommé[e]|pour [<le>])"

--- a/sentences/fr/homeassistant_HassTimerStatus.yaml
+++ b/sentences/fr/homeassistant_HassTimerStatus.yaml
@@ -8,56 +8,56 @@ intents:
           # Combien de temps reste-t-il
           - "[Encore] Combien de temps <reste_t_il>"
           # Combien de temps reste-t-il au minuteur
-          - "[Encore] Combien de temps <reste_t_il> au <minuteur>"
+          - "[Encore] Combien de temps <reste_t_il> <au> <minuteur>"
           # Combien de temps reste-t-il sur le minuteur
-          - "[Encore] Combien de temps <reste_t_il> (sur|dans) [(le|mon)] <minuteur>"
+          - "[Encore] Combien de temps <reste_t_il> (sur|dans) [<le>|<mon>] <minuteur>"
           # Il reste combien de temps
           - "[Il reste] [encore] combien de temps"
           # Il reste combien de temps au minuteur
-          - "[Il reste] [encore] combien [de temps] au <minuteur>"
+          - "[Il reste] [encore] combien [de temps] <au> <minuteur>"
           # Il reste combien de temps sur le minuteur
-          - "[Il reste] [encore] combien [de temps] (sur|dans) [(le|mon)] <minuteur>"
+          - "[Il reste] [encore] combien [de temps] (sur|dans) [<le>|<mon>] <minuteur>"
         expansion_rules:
           reste_t_il: "(reste-t-il)|(reste t il)"
 
       # area
       - sentences:
           # Combien de temps reste-t-il au minuteur de la cuisine
-          - "[Encore] Combien [de temps] <reste_t_il> au <minuteur> [<de>] [<le>]{area}"
+          - "[Encore] Combien [de temps] <reste_t_il> <au> <minuteur> [<de>] [<le>]{area}"
           # Combien de temps reste-t-il sur le minuteur de la cuisine
-          - "[Encore] Combien [de temps] <reste_t_il> (sur|dans) [(le|mon)] <minuteur> [<de>] [<le>]{area}"
+          - "[Encore] Combien [de temps] <reste_t_il> (sur|dans) [<le>|<mon>] <minuteur> [<de>] [<le>]{area}"
           # Il reste combien de temps au minuteur de la cuisine
-          - "[Il reste] [encore] combien [de temps] au <minuteur> [<de>] [<le>]{area}"
+          - "[Il reste] [encore] combien [de temps] <au> <minuteur> [<de>] [<le>]{area}"
           # Il reste combien de temps sur le minuteur de la cuisine
-          - "[Il reste] [encore] combien [de temps] (sur|dans) [(le|mon)] <minuteur> [<de>] [<le>]{area}"
+          - "[Il reste] [encore] combien [de temps] (sur|dans) [<le>|<mon>] <minuteur> [<de>] [<le>]{area}"
         expansion_rules:
           reste_t_il: "(reste-t-il)|(reste t il)"
 
       # duration
       - sentences:
           # Combien de temps reste-t-il au minuteur de 2 minutes
-          - "[Encore] Combien [de temps] <reste_t_il> au <minuteur> [de] <timer_start>"
+          - "[Encore] Combien [de temps] <reste_t_il> <au> <minuteur> [de] <timer_start>"
           # Combien de temps reste-t-il sur le minuteur de 2 minutes
-          - "[Encore] Combien [de temps] <reste_t_il> (sur|dans) [(le|mon)] <minuteur> [de] <timer_start>"
+          - "[Encore] Combien [de temps] <reste_t_il> (sur|dans) [<le>|<mon>] <minuteur> [de] <timer_start>"
           # Il reste combien de temps au minuteur de 2 minutes
-          - "[Il reste] [encore] combien [de temps] au <minuteur> [de] <timer_start>"
+          - "[Il reste] [encore] combien [de temps] <au> <minuteur> [de] <timer_start>"
           # Il reste combien de temps sur le minuteur de 2 minutes
-          - "[Il reste] [encore] combien [de temps] (sur|dans) [(le|mon)] <minuteur> [de] <timer_start>"
+          - "[Il reste] [encore] combien [de temps] (sur|dans) [<le>|<mon>] <minuteur> [de] <timer_start>"
         expansion_rules:
           reste_t_il: "(reste-t-il)|(reste t il)"
 
       # name
       - sentences:
           # Combien de temps reste-t-il au minuteur appelé Pizza
-          - "[Encore] Combien [de temps] <reste_t_il> au <minuteur> [<appele>] {timer_name:name}"
+          - "[Encore] Combien [de temps] <reste_t_il> <au> <minuteur> [<appele>] {timer_name:name}"
           # Combien de temps reste-t-il sur le minuteur appelé Pizza
-          - "[Encore] Combien [de temps] <reste_t_il> (sur|dans) [(le|mon)] <minuteur> [<appele>] {timer_name:name}"
+          - "[Encore] Combien [de temps] <reste_t_il> (sur|dans) [<le>|<mon>] <minuteur> [<appele>] {timer_name:name}"
           # Combien de temps reste-t-il pour la pizza
           - "[Encore] Combien [de temps] <reste_t_il> [<appele>] {timer_name:name}"
           # Il reste combien de temps au minuteur appelé Pizza
-          - "[Il reste] [encore] combien [de temps] au <minuteur> [<appele>] {timer_name:name}"
+          - "[Il reste] [encore] combien [de temps] <au> <minuteur> [<appele>] {timer_name:name}"
           # Il reste combien de temps sur le minuteur appelé Pizza
-          - "[Il reste] [encore] combien [de temps] (sur|dans) [(le|mon)] <minuteur> [<appele>] {timer_name:name}"
+          - "[Il reste] [encore] combien [de temps] (sur|dans) [<le>|<mon>] <minuteur> [<appele>] {timer_name:name}"
           # Il reste combien pour la pizza
           - "Il reste [encore] combien [de temps] [<appele>] {timer_name:name}"
           # Combien de temps pour la pizza
@@ -66,4 +66,4 @@ intents:
           - "[Il reste] [encore] combien de temps avant (de |d'|<le>){timer_name:name}"
         expansion_rules:
           reste_t_il: "(reste-t-il)|(reste t il)"
-          appele: "(appelé|nommé|surnommé|pour [<le>])"
+          appele: "(appelé[e]|[sur]nommé[e]|pour [<le>])"

--- a/sentences/fr/homeassistant_HassUnpauseTimer.yaml
+++ b/sentences/fr/homeassistant_HassUnpauseTimer.yaml
@@ -23,4 +23,4 @@ intents:
           # Reprends le minuteur appelé Pizza en pause
           - "<reprends> [<le>|<mon>] <minuteur> [<appele>] {timer_name:name}"
         expansion_rules:
-          appele: "(appelé[e]|[sur]nommé[e]|pour [<le>])"
+          appele: "(appelé[e]|nommé[e]|surnommé[e]|pour [<le>])"

--- a/sentences/fr/homeassistant_HassUnpauseTimer.yaml
+++ b/sentences/fr/homeassistant_HassUnpauseTimer.yaml
@@ -6,21 +6,21 @@ intents:
       # No name
       - sentences:
           # Reprends le minuteur
-          - "<reprends> [(le|mon)] <minuteur>"
+          - "<reprends> [<le>|<mon>] <minuteur>"
 
       # area
       - sentences:
           # Reprends le minuteur de la cuisine
-          - "<reprends> [(le|mon)] <minuteur> [<de>] [<le>]{area}"
+          - "<reprends> [<le>|<mon>] <minuteur> [<de>] [<le>]{area}"
 
       # duration
       - sentences:
           # Reprends le minuteur de 2 minutes en pause
-          - "<reprends> [(le|mon)] <minuteur> [de] <timer_start>"
+          - "<reprends> [<le>|<mon>] <minuteur> [de] <timer_start>"
 
       # name
       - sentences:
           # Reprends le minuteur appelé Pizza en pause
-          - "<reprends> [(le|mon)] <minuteur> [<appele>] {timer_name:name}"
+          - "<reprends> [<le>|<mon>] <minuteur> [<appele>] {timer_name:name}"
         expansion_rules:
-          appele: "(appelé|nommé|surnommé|pour [<le>])"
+          appele: "(appelé[e]|[sur]nommé[e]|pour [<le>])"

--- a/tests/fr/homeassistant_HassCancelAllTimers.yaml
+++ b/tests/fr/homeassistant_HassCancelAllTimers.yaml
@@ -3,6 +3,7 @@ language: fr
 tests:
   - sentences:
       - "Supprimer tous mes minuteurs"
+      - "Supprime toutes les minuteries"
       - "Annuler tous les comptes a rebours"
     intent:
       name: HassCancelAllTimers

--- a/tests/fr/homeassistant_HassCancelTimer.yaml
+++ b/tests/fr/homeassistant_HassCancelTimer.yaml
@@ -4,6 +4,7 @@ tests:
   # No name
   - sentences:
       - "Supprime le minuteur"
+      - "Supprime la minuterie"
       - "Arrête mon minuteur"
     intent:
       name: HassCancelTimer

--- a/tests/fr/homeassistant_HassDecreaseTimer.yaml
+++ b/tests/fr/homeassistant_HassDecreaseTimer.yaml
@@ -40,6 +40,7 @@ tests:
   - sentences:
       - "Enlève 2 minute du minuteur chocolatine"
       - "Enlève 2 minute au minuteur chocolatine"
+      - "Enlève 2 minute à la minuterie nommée chocolatine"
       - "Enlève 2 minute sur mon minuteur chocolatine"
     intent:
       name: HassDecreaseTimer

--- a/tests/fr/homeassistant_HassPauseTimer.yaml
+++ b/tests/fr/homeassistant_HassPauseTimer.yaml
@@ -16,6 +16,7 @@ tests:
       - "Mets le minuteur de la cuisine en pause"
       - "Mets le minuteur de la cuisine sur pause"
       - "Mets en pause mon minuteur de la cuisine"
+      - "Mets en pause ma minuterie de la cuisine"
       - "Mets sur pause le minuteur de la cuisine"
     intent:
       name: HassPauseTimer

--- a/tests/fr/homeassistant_HassStartTimer.yaml
+++ b/tests/fr/homeassistant_HassStartTimer.yaml
@@ -6,6 +6,7 @@ tests:
       - "Minuteur 5 min"
       - "Minuteur pour 5 minutes"
       - "Minuteur de 5 min"
+      - "Minuterie de 5 minutes"
     intent:
       name: HassStartTimer
       context:

--- a/tests/fr/homeassistant_HassTimerStatus.yaml
+++ b/tests/fr/homeassistant_HassTimerStatus.yaml
@@ -49,6 +49,7 @@ tests:
   # name
   - sentences:
       - "Combien de temps reste-t-il au minuteur appelé chocolatine"
+      - "Combien de temps reste-t-il à la minuterie surnommée chocolatine"
       - "Combien de temps reste-t-il sur le minuteur appelé chocolatine"
       - "Combien de temps reste-t-il dans le minuteur appelé chocolatine"
       - "Il reste combien de temps au minuteur appelé chocolatine"

--- a/tests/fr/homeassistant_HassUnpauseTimer.yaml
+++ b/tests/fr/homeassistant_HassUnpauseTimer.yaml
@@ -4,6 +4,7 @@ tests:
   # No name
   - sentences:
       - "Reprends mon minuteur"
+      - "Reprends ma minuterie"
     intent:
       name: HassUnpauseTimer
     response: Minuteur relancé
@@ -11,6 +12,7 @@ tests:
   # area
   - sentences:
       - "Reprends le minuteur de la cuisine"
+      - "Reprends la minuterie de la cuisine"
     intent:
       name: HassUnpauseTimer
       slots:
@@ -30,6 +32,7 @@ tests:
   # name
   - sentences:
       - "Reprends le minuteur appelé chocolatine"
+      - "Reprends la minuterie appelée chocolatine"
     intent:
       name: HassUnpauseTimer
       slots:


### PR DESCRIPTION
Adding "minuterie" option in addition to "minuteur" for timer operations to support French Canadian idioms.

See the Office québécois de la langue française [definition](https://vitrinelinguistique.oqlf.gouv.qc.ca/fiche-gdt/fiche/8887901/minuterie) of "minuterie" as a translation of "timer".

Happy to add more tests as needed. I tried to keep the PR short.