### PR TITLE
[NL] HassClimateGetTemperature improvement:

### DIFF
--- a/sentences/nl/climate_HassClimateGetTemperature.yaml
+++ b/sentences/nl/climate_HassClimateGetTemperature.yaml
@@ -13,8 +13,9 @@ intents:
         requires_context:
           domain: "climate"
       - sentences:
-          - "wat is de temperatuur"
-          - "hoe (warm|koud|heet|koel) is het"
+          - "wat is de temperatuur [<here>]"
+          - "wat is <here> de temperatuur"
+          - "hoe (warm|koud|heet|koel) is het [<here>]"
         requires_context:
           area:
             slot: true

--- a/tests/nl/climate_HassClimateGetTemperature.yaml
+++ b/tests/nl/climate_HassClimateGetTemperature.yaml
@@ -24,6 +24,9 @@ tests:
   - sentences:
       - "wat is de temperatuur"
       - "hoe warm is het"
+      - "wat is de temperatuur in deze kamer"
+      - "hoe warm is het hier"
+      - "wat is hier de temperatuur"
     intent:
       name: HassClimateGetTemperature
       context:


### PR DESCRIPTION
Fixes #3146

Adds the expansion rule `<here>` optionally to the area aware get temperature intents

Allowing sentences like
```
hoe warm is het hier
hoe warm is het in deze ruimte
wat is in deze ruimte de temperatuur
wat is de temperatuur hier
```