### PR TITLE
[FR] Add "ouvrir" and "fermer" to light intents

### DIFF
--- a/sentences/fr/_common.yaml
+++ b/sentences/fr/_common.yaml
@@ -493,12 +493,12 @@ expansion_rules:
 
   # Verbs
   active: "(active|activer|joue|jouer|exécute|exécuter|démarre|démarrer|lance|lancer)"
-  allume: "(allume|allumer|active|activer|démarre|démarrer)"
+  allume: "(allume|allumer|active|activer|démarre|démarrer|ouvre|ouvrir)"
   augmente: "(augmente|augmenter|monte|monter)"
   demarre: "(démarre|démarrer|lance|lancer)"
   diminue: "(diminue|diminuer|baisse|baisser)"
   eclaire: "(éclaire|éclairer|illumine|illuminer)"
-  eteins: "(éteint|eteint|éteins|eteins|éteindre|eteindre|désactive|désactiver|stoppe|stopper|arrête|arrêter|coupe|couper|<eteins_dirty>)"
+  eteins: "(éteint|eteint|éteins|eteins|éteindre|eteindre|désactive|désactiver|stoppe|stopper|arrête|arrêter|coupe|couper|ferme|fermer|<eteins_dirty>)"
   ferme: "(ferme|fermer|<baisse>|<ferme_dirty>)"
   lis: "(lis|lire)"
   mets: "(mets|mettre|passe|passer|<mets_dirty>)"

--- a/tests/fr/light_HassLightSet.yaml
+++ b/tests/fr/light_HassLightSet.yaml
@@ -15,6 +15,7 @@ tests:
       - "Baisse la lumière de lampe de chevet à 50%"
       - "Monte la lampe de chevet à 50%"
       - "Baisse la lampe de chevet à 50 %"
+      - "Ouvre la lampe de chevet à 50%"
 
     intent:
       name: HassLightSet
@@ -30,6 +31,7 @@ tests:
       - "règle la luminosité dans la cuisine à 50%"
       - "changer luminosité cuisine à 50%"
       - "met la cuisine à 50% de luminosité"
+      - "ouvre la cuisine 50%"
       - "luminosité de la cuisine à 50%"
       - "luminosité cuisine 50%"
       - "cuisine 50% luminosité"
@@ -49,6 +51,7 @@ tests:
   - sentences:
       - Baisse la luminosité à 40%
       - Allumer la lumière à 40%
+      - Ouvre la lumière à 40%
       - Allume à 40% de luminosité
       - Luminosité 40%
       - 40% de luminosité
@@ -71,6 +74,7 @@ tests:
       - "luminosité de la lampe de chevet de la chambre à 50%"
       - "luminosité lampe de chevet chambre 50%"
       - "lampe de chevet chambre 50%"
+      - "ouvre la lampe de chevet chambre à 50%"
       - "lampe de chevet chambre 50% luminosité"
       - "lampe de chevet chambre luminosité 50%"
       - "Augmente la luminosité de la lampe de chevet dans la chambre à 50%"
@@ -96,6 +100,7 @@ tests:
       - "rez-de-chaussée luminosité 50%"
       - "Augmente la lumière du rez-de-chaussée à 50%"
       - "Monter le rez-de-chaussée à 50 %"
+      - "Ouvre le rez-de-chaussée à 50 %"
       - "Baisser le rez-de-chaussée à 50 %"
     intent:
       name: HassLightSet

--- a/tests/fr/light_HassTurnOff.yaml
+++ b/tests/fr/light_HassTurnOff.yaml
@@ -2,6 +2,7 @@ language: fr
 tests:
   - sentences:
       - Éteindre les lumières de la cuisine
+      - Ferme les lumières de la cuisine
       - Éteins la lumière de la cuisine
       - Éteins les lumières dans la cuisine
       - Éteins toutes les lumières dans la cuisine
@@ -22,6 +23,7 @@ tests:
 
   - sentences:
       - Éteins toutes les lumières
+      - Ferme toutes les lumières
       - Éteins les lumières partout
       - Éteins les lumières de partout
       - Éteindre la lumière partout
@@ -43,6 +45,7 @@ tests:
   - sentences:
       - "Eteins toutes les lumières ici"
       - "Eteins les lumières"
+      - "Ferme la lumière"
       - "Eteins la lumière dans cette pièce"
       - "Eteindre la lumière ici"
       - "Nuit"
@@ -66,6 +69,7 @@ tests:
       - "Éteindre la lumière du rez-de-chaussée"
       - "Éteins la lumière au rez-de-chaussée"
       - "Éteindre le rez-de-chaussée"
+      - "Ferme le rez-de-chaussée"
       - "Coupe les lumières du rez-de-chaussée"
       - "Désactive l'éclairage au rez-de-chaussée"
       - "Éteins toutes les lumières du rez-de-chaussée"

--- a/tests/fr/light_HassTurnOn.yaml
+++ b/tests/fr/light_HassTurnOn.yaml
@@ -3,7 +3,9 @@ tests:
   - sentences:
       - Allumer les lumières de la cuisine
       - Allume la lumière de la cuisine
+      - Ouvre la lumière de la cuisine
       - Allumer les lumières dans la cuisine
+      - Ouvrir les lumières dans la cuisine
       - Allume toutes les lumières dans la cuisine
       - Active la lumière de la cuisine
       - Lumières dans la cuisine
@@ -25,6 +27,7 @@ tests:
 
   - sentences:
       - Allume toutes les lumières
+      - Ouvre toutes les lumières
       - Allume les lumières partout
       - Allume les lumières de partout
       - Allumer la lumière partout
@@ -46,6 +49,7 @@ tests:
   - sentences:
       - "Allume toutes les lumières ici"
       - "Allume les lumières"
+      - "Ouvre la lumière"
       - "Allume la lumière dans cette pièce"
       - "Allumer la lumière ici"
       - "Jour"
@@ -67,6 +71,7 @@ tests:
       - "Allume la lumière du premier étage"
       - "Allume la lumière au premier étage"
       - "Allumer le premier étage"
+      - "Ouvre le premier étage"
       - "Lumière au premier étage"
       - "Éclaire le premier étage"
       - "Illumine le premier étage"


### PR DESCRIPTION
Add "ouvrir" and "fermer" to turn lights on and off, to support French Canadians specificity.

Reference:
- https://vitrinelinguistique.oqlf.gouv.qc.ca/fiche-gdt/fiche/18597275/ouvrir-la-lumiere

I didn't add any tests around setting light color. I wouldn't use "ouvrir" in that context.