### PR TITLE
[CA] Fix list name on todo_HassListAddItem

### DIFF
--- a/sentences/ca/todo_HassListAddItem.yaml
+++ b/sentences/ca/todo_HassListAddItem.yaml
@@ -12,5 +12,5 @@ intents:
           domain: todo
         expansion_rules:
           my_list: "[la] [meva] llista [de|del|de la] {name}"
-          item: "{shopping_list_item:item}"
+          item: "{todo_list_item:item}"
           add: "(afeg[e]ix|posa)"


### PR DESCRIPTION
Like https://github.com/home-assistant/intents/pull/3145, but for CA.

- ca: small fix on todo_HassListAddItem (that was using shopping_list_item)