### PR TITLE
[NL] HassClimateSetTemperature: allow verwarming next to temperatuur

### DIFF
--- a/sentences/nl/_common.yaml
+++ b/sentences/nl/_common.yaml
@@ -715,6 +715,7 @@ expansion_rules:
   brightness_value: "{brightness}[ ][%|procent]"
   # temperature/climate states
   degrees: ([ ]°| graad| graden)
+  temp: "(temperatuur|verwarming)"
   temperature: "{temperature}[<degrees>]"
   warm: "(warm|heet|koud|koel)"
   # cover states

--- a/sentences/nl/climate_HassClimateSetTemperature.yaml
+++ b/sentences/nl/climate_HassClimateSetTemperature.yaml
@@ -7,21 +7,20 @@ intents:
       # current area or floor
       - sentences:
           # 'temperatuur' required, 'graden' optional
-          - "[<numeric_value_set>] [de] temperatuur <to> <temperature>"
-          - "temperatuur [<to>] <temperature> [(zetten|draaien|doen)]"
-          - "[<would>] [de] temperatuur [<to>] <temperature> (zetten|draaien|doen)"
+          - "[<numeric_value_set>] [de] <temp> <to> <temperature>"
+          - "<temp> [<to>] <temperature> [(zetten|draaien|doen)]"
+          - "[<would>] [de] <temp> [<to>] <temperature> (zetten|draaien|doen)"
           # 'graden' required
           - "<numeric_value_set> <to> {temperature}<degrees>"
 
       # by area or floor name
       - sentences:
           # 'temperatuur' required, 'graden' optional
-          - "<numeric_value_set> [de] temperatuur [<in>] (<area>|<floor>) <to> <temperature>"
-          - "<numeric_value_set> [de] temperatuur <to> <temperature> <in> (<area>|<floor>)"
-          - "<numeric_value_set> [de] (<area>|<floor>)[ ]temperatuur <to> <temperature>"
-          - "[<would>] (<area>|<floor>)[ ]temperatuur [<to>] <temperature> [(zetten|draaien|doen)]"
-          - "[<would>] [de] temperatuur [<in>] (<area>|<floor>) [<to>] <temperature> [(zetten|draaien|doen)]"
-          # 'graden' required
+          - "<numeric_value_set> [de] <temp> [<in>] (<area>|<floor>) <to> <temperature>"
+          - "<numeric_value_set> [de] <temp> <to> <temperature> <in> (<area>|<floor>)"
+          - "<numeric_value_set> [de] (<area>|<floor>)[ ]<temp> <to> <temperature>"
+          - "[<would>] (<area>|<floor>)[ ]<temp> [<to>] <temperature> [(zetten|draaien|doen)]"
+          - "[<would>] [de] <temp> [<in>] (<area>|<floor>) [<to>] <temperature> [(zetten|draaien|doen)]"
           - "<numeric_value_set> (<area>|<floor>) <to> {temperature}<degrees>"
           - "[<would>] (<area>|<floor>) [<to>] {temperature}<degrees> [(zetten|draaien|doen)]"
 

--- a/tests/nl/climate_HassClimateSetTemperature.yaml
+++ b/tests/nl/climate_HassClimateSetTemperature.yaml
@@ -3,12 +3,17 @@ tests:
   # current area or floor
   - sentences:
       - "Zet de temperatuur op 19 graden"
+      - "Zet de verwarming op 19 graden"
       - "Mag de temperatuur op 19?"
+      - "Mag de verwarming op 19?"
       - "Verander de temperatuur naar 19"
       - "Verlaag de temperatuur naar 19"
       - "Temperatuur 19 graden"
+      - "Verwarming 19 graden"
       - "Temperatuur op 19 zetten"
+      - "Verwarming op 19 zetten"
       - "wil je de temperatuur naar 19 graden draaien"
+      - "wil je de verwarming naar 19 graden draaien"
       - "zet naar 19 graden"
     intent:
       name: HassClimateSetTemperature
@@ -20,10 +25,14 @@ tests:
   - sentences:
       - "Verander de temperatuur naar 19 graden in de woonkamer"
       - "Zet de woonkamer temperatuur op 19"
+      - "Zet de woonkamer verwarming op 19"
       - "Verhoog de woonkamertemperatuur naar 19 graden"
       - "Verlaag de temperatuur in de woonkamer naar 19 graden"
+      - "Verlaag de verwarming in de woonkamer naar 19 graden"
+      - "Zet de verwarming in de woonkamer op 19 graden"
       - "Woonkamer 19 graden"
       - "wil je de woonkamertemperatuur naar 19 graden zetten"
+      - "wil je de woonkamerverwarming naar 19 graden zetten"
       - "zet woonkamer op 19 graden"
       - "woonkamer naar 19 graden draaien"
     intent:


### PR DESCRIPTION
PR for #3147. Allow use of the word 'verwarming' next to 'temperatuur' 