### PR TITLE
Add English sentences for HassMediaSearchAndPlay

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -1219,6 +1219,62 @@ HassSetVolume:
       example: "set volume in kitchen to 50%"
 
 # -----------------------------------------------------------------------------
+
+HassMediaSearchAndPlay:
+  supported: false
+  domain: media_player
+  description: "Searched for a media item and plays it"
+  slots:
+    name:
+      description: "Name of a device or entity"
+      required: false
+    area:
+      description: "Name of an area"
+      required: false
+    search_query:
+      description: "Media to search for and play"
+      required: true
+  slot_combinations:
+    default:
+      description: "Search and play on the media player in the voice satellite's area"
+      importance: "optional"
+      slots: []
+      context_area: true
+      example: "play Pink Floyd"
+
+    # -------------------------------------------------------------------------
+
+    name_only:
+      description: "Search and play on a media player by name"
+      slots:
+        - "name"
+      name_domains:
+        optional:
+          - "media_player"
+      example: "play Pink Floyd on Sonos Speakers"
+
+    # -------------------------------------------------------------------------
+
+    area_only:
+      description: "Search and play on the media player in an area"
+      importance: "optional"
+      slots:
+        - "area"
+      example: "play Pink Floyd in the Living Room"
+
+    # -------------------------------------------------------------------------
+
+    name_area:
+      description: "Search and play on a media player by name in an area"
+      name_domains:
+        optional:
+          - "media_player"
+      slots:
+        - "name"
+        - "area"
+      example: "play Pink Floyd on the Sonos Speakers in the Living Room"
+
+# -----------------------------------------------------------------------------
 # timers
 # -----------------------------------------------------------------------------
 

--- a/intents.yaml
+++ b/intents.yaml
@@ -1274,6 +1274,12 @@ HassMediaSearchAndPlay:
         - "area"
       example: "play Pink Floyd on the Sonos Speakers in the Living Room"
 
+  response_variables:
+    media:
+      description: |
+        Matched media item is search was successful (None if not).
+        This is a BrowseMedia object from Home Assistant.
+
 # -----------------------------------------------------------------------------
 # timers
 # -----------------------------------------------------------------------------
@@ -2381,7 +2387,7 @@ HassTimerStatus:
 
   response_variables:
     timers:
-      description: >-
+      description: |
         List of timer objects with:
           - is_active: true if timer is running (not paused)
           - name: name of the timer (optional)

--- a/intents.yaml
+++ b/intents.yaml
@@ -1238,7 +1238,8 @@ HassMediaSearchAndPlay:
     default:
       description: "Search and play on the media player in the voice satellite's area"
       importance: "optional"
-      slots: []
+      slots:
+        - "search_query"
       context_area: true
       example: "play Pink Floyd"
 
@@ -1248,6 +1249,7 @@ HassMediaSearchAndPlay:
       description: "Search and play on a media player by name"
       slots:
         - "name"
+        - "search_query"
       name_domains:
         optional:
           - "media_player"
@@ -1260,6 +1262,7 @@ HassMediaSearchAndPlay:
       importance: "optional"
       slots:
         - "area"
+        - "search_query"
       example: "play Pink Floyd in the Living Room"
 
     # -------------------------------------------------------------------------
@@ -1272,6 +1275,7 @@ HassMediaSearchAndPlay:
       slots:
         - "name"
         - "area"
+        - "search_query"
       example: "play Pink Floyd on the Sonos Speakers in the Living Room"
 
   response_variables:

--- a/lists/lights.yaml
+++ b/lists/lights.yaml
@@ -5,3 +5,7 @@ lists:
       type: "percentage"
       from: 0
       to: 100
+
+  # media
+  search_query:
+    wildcard: true

--- a/lists/media.yaml
+++ b/lists/media.yaml
@@ -1,0 +1,4 @@
+---
+lists:
+  search_query:
+    wildcard: true

--- a/responses/en/HassMediaSearchAndPlay.yaml
+++ b/responses/en/HassMediaSearchAndPlay.yaml
@@ -1,0 +1,10 @@
+language: en
+responses:
+  intents:
+    HassMediaSearchAndPlay:
+      default: |
+        {% if slots.media: %}
+        Playing media
+        {% else: %}
+        Media not found
+        {% endif %}

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -363,6 +363,7 @@ TESTS_FIXTURES = vol.Schema(
                 vol.Optional("is_active"): bool,
             }
         ],
+        vol.Optional("media"): [{vol.Required("title"): str}],
     }
 )
 
@@ -888,6 +889,9 @@ def validate_language(
             # For date/time intents
             slots["date"] = datetime.now().date()
             slots["time"] = datetime.now().time()
+
+            # Media search/play
+            slots["media"] = {"title": ""}
 
             for response_key, response_template in intent_responses.items():
                 possible_response_keys.add(response_key)

--- a/script/intentfest/validate.py
+++ b/script/intentfest/validate.py
@@ -463,6 +463,22 @@ def LANGUAGE_LISTS_SCHEMA(language: str) -> vol.Schema:
     )
 
 
+TIMER_SCHEMA_DICT = {
+    vol.Optional("start_hours"): int,
+    vol.Optional("start_minutes"): int,
+    vol.Optional("start_seconds"): int,
+    vol.Optional("total_seconds_left"): int,
+    vol.Optional("rounded_hours_left"): int,
+    vol.Optional("rounded_minutes_left"): int,
+    vol.Optional("rounded_seconds_left"): int,
+    vol.Optional("name"): str,
+    vol.Optional("area"): str,
+    vol.Optional("is_active"): bool,
+}
+
+MEDIA_SCHEMA_DICT = {vol.Required("title"): str}
+
+
 def SLOT_COMBO_TEST_SCHEMA(
     language: str,
     available_slot_names: set[str],
@@ -481,6 +497,8 @@ def SLOT_COMBO_TEST_SCHEMA(
             ],
             vol.Optional("areas"): [{vol.Required("name"): str}],
             vol.Optional("floors"): [{vol.Required("name"): str}],
+            vol.Optional("timers"): [TIMER_SCHEMA_DICT],
+            vol.Optional("media"): [MEDIA_SCHEMA_DICT],
             vol.Required("tests"): [
                 {
                     vol.Required("sentences"): [str],
@@ -489,20 +507,8 @@ def SLOT_COMBO_TEST_SCHEMA(
                         # slot name
                         vol.In(available_slot_names): vol.Any(str, int, [str])
                     },
-                    vol.Optional("timers"): [
-                        {
-                            vol.Optional("start_hours"): int,
-                            vol.Optional("start_minutes"): int,
-                            vol.Optional("start_seconds"): int,
-                            vol.Optional("total_seconds_left"): int,
-                            vol.Optional("rounded_hours_left"): int,
-                            vol.Optional("rounded_minutes_left"): int,
-                            vol.Optional("rounded_seconds_left"): int,
-                            vol.Optional("name"): str,
-                            vol.Optional("area"): str,
-                            vol.Optional("is_active"): bool,
-                        }
-                    ],
+                    vol.Optional("timers"): [TIMER_SCHEMA_DICT],
+                    vol.Optional("media"): [MEDIA_SCHEMA_DICT],
                 }
             ],
         }

--- a/sentences/en/HassMediaSearchAndPlay/area_only.yaml
+++ b/sentences/en/HassMediaSearchAndPlay/area_only.yaml
@@ -1,0 +1,12 @@
+---
+# HassMediaSearchAndPlay - area_only
+# example: play Pink Floyd in the Kitchen
+# slots:
+# - {area}
+# - {search_query}
+
+language: "en"
+data:
+  - sentences:
+      - "play {search_query} in [the] {area}"
+    response: "default"

--- a/sentences/en/HassMediaSearchAndPlay/default.yaml
+++ b/sentences/en/HassMediaSearchAndPlay/default.yaml
@@ -1,0 +1,10 @@
+---
+# HassMediaSearchAndPlay - default
+# example: play Pink Floyd
+# slots: {search_query}
+
+language: "en"
+data:
+  - sentences:
+      - "play {search_query}"
+    response: "default"

--- a/sentences/en/HassMediaSearchAndPlay/name_area.yaml
+++ b/sentences/en/HassMediaSearchAndPlay/name_area.yaml
@@ -1,0 +1,15 @@
+---
+# HassMediaSearchAndPlay - name_area
+# example: play Pink Floyd on the Sonos Speakers in the Kitchen
+# slots:
+# - {area}
+# - {name}
+# - {search_query}
+
+language: "en"
+data:
+  - sentences:
+      - "play {search_query} on [the] {name} in [the] {area}"
+    name_domains:
+      - "media_player"
+    response: "default"

--- a/sentences/en/HassMediaSearchAndPlay/name_only.yaml
+++ b/sentences/en/HassMediaSearchAndPlay/name_only.yaml
@@ -1,0 +1,14 @@
+---
+# HassMediaSearchAndPlay - name_only
+# example: play Pink Floyd on Sonos Speakers
+# slots:
+# - {name}
+# - {search_query}
+
+language: "en"
+data:
+  - sentences:
+      - "play {search_query} on [the] {name}"
+    name_domains:
+      - "media_player"
+    response: "default"

--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -359,6 +359,9 @@ lists:
   message:
     wildcard: true
 
+  search_query:
+    wildcard: true
+
 expansion_rules:
   the: "(the|my|our)"
   name: "[<the>] {name}"

--- a/sentences/en/media_player_HassMediaSearchAndPlay.yaml
+++ b/sentences/en/media_player_HassMediaSearchAndPlay.yaml
@@ -1,0 +1,18 @@
+language: "en"
+intents:
+  HassMediaSearchAndPlay:
+    data:
+      - sentences:
+          - "play {search_query}"
+        requires_context:
+          area:
+            slot: true
+
+      - sentences:
+          - "play {search_query} in <area>"
+
+      - sentences:
+          - "play {search_query} on <name>"
+          - "play {search_query} on <name> in <area>"
+        requires_context:
+          domain: "media_player"

--- a/tests/en/HassMediaSearchAndPlay/area_only.yaml
+++ b/tests/en/HassMediaSearchAndPlay/area_only.yaml
@@ -1,0 +1,20 @@
+---
+# HassMediaSearchAndPlay - area_only
+# example: play Pink Floyd in the Kitchen
+# slots:
+# - {area}
+# - {search_query}
+
+language: "en"
+areas:
+  - name: "Kitchen"
+media:
+  - title: "The Office"
+
+tests:
+  - sentences:
+      - "play The Office in the Kitchen"
+    slots:
+      area: "Kitchen"
+      search_query: "The Office"
+    response: "Playing media"

--- a/tests/en/HassMediaSearchAndPlay/default.yaml
+++ b/tests/en/HassMediaSearchAndPlay/default.yaml
@@ -1,0 +1,22 @@
+---
+# HassMediaSearchAndPlay - default
+# example: play Pink Floyd
+# slots: {search_query}
+
+language: "en"
+media:
+  - title: "The Office"
+
+tests:
+  - sentences:
+      - "play The Office"
+    slots:
+      search_query: "The Office"
+    response: "Playing media"
+
+  - sentences:
+      - "play The Office"
+    media: []
+    slots:
+      search_query: "The Office"
+    response: "Media not found"

--- a/tests/en/HassMediaSearchAndPlay/name_area.yaml
+++ b/tests/en/HassMediaSearchAndPlay/name_area.yaml
@@ -1,0 +1,25 @@
+---
+# HassMediaSearchAndPlay - name_area
+# example: play Pink Floyd on Sonos Speakers in the Kitchen
+# slots:
+# - {name}
+# - {area}
+# - {search_query}
+
+language: "en"
+areas:
+  - name: "Kitchen"
+entities:
+  - name: "TV"
+    domain: "media_player"
+media:
+  - title: "The Office"
+
+tests:
+  - sentences:
+      - "play The Office on the TV in the Kitchen"
+    slots:
+      name: "TV"
+      area: "Kitchen"
+      search_query: "The Office"
+    response: "Playing media"

--- a/tests/en/HassMediaSearchAndPlay/name_only.yaml
+++ b/tests/en/HassMediaSearchAndPlay/name_only.yaml
@@ -1,0 +1,21 @@
+---
+# HassMediaSearchAndPlay - name_only
+# example: play Pink Floyd on Sonos Speakers
+# slots:
+# - {name}
+# - {search_query}
+
+language: "en"
+entities:
+  - name: "TV"
+    domain: "media_player"
+media:
+  - title: "The Office"
+
+tests:
+  - sentences:
+      - "play The Office on the TV"
+    slots:
+      name: "TV"
+      search_query: "The Office"
+    response: "Playing media"

--- a/tests/en/_fixtures.yaml
+++ b/tests/en/_fixtures.yaml
@@ -789,3 +789,6 @@ timers:
     rounded_hours_left: 0
     rounded_minutes_left: 3
     rounded_seconds_left: 0
+
+media:
+  - title: "The Office"

--- a/tests/en/media_player_HassMediaSearchAndPlay.yaml
+++ b/tests/en/media_player_HassMediaSearchAndPlay.yaml
@@ -1,0 +1,51 @@
+language: en
+tests:
+  - sentences:
+      - "play The Office"
+    intent:
+      name: "HassMediaSearchAndPlay"
+      slots:
+        search_query: "The Office"
+        area: "Living Room"
+      context:
+        area: "Living Room"
+    response: "Playing media"
+
+  - sentences:
+      - "play The Office on the TV"
+    intent:
+      name: "HassMediaSearchAndPlay"
+      slots:
+        search_query: "The Office"
+        name: "TV"
+    response: "Playing media"
+
+  - sentences:
+      - "play The Office in the Kitchen"
+    intent:
+      name: "HassMediaSearchAndPlay"
+      slots:
+        search_query: "The Office"
+        area: "Kitchen"
+    response: "Playing media"
+
+  - sentences:
+      - "play The Office on the TV in the Kitchen"
+    intent:
+      name: "HassMediaSearchAndPlay"
+      slots:
+        search_query: "The Office"
+        name: "TV"
+        area: "Kitchen"
+    response: "Playing media"
+
+  - sentences:
+      - "play Does Not Exist"
+    intent:
+      name: "HassMediaSearchAndPlay"
+      slots:
+        search_query: "Does Not Exist"
+        area: "Living Room"
+      context:
+        area: "Living Room"
+    response: "Media not found"

--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -21,13 +21,16 @@ from yaml import safe_load
 
 from shared import (
     AreaEntry,
+    BrowseMedia,
     FloorEntry,
     State,
     Timer,
     get_areas,
     get_floors,
+    get_matched_media,
     get_matched_states,
     get_matched_timers,
+    get_media_items,
     get_slot_lists,
     get_states,
     get_timers,
@@ -37,11 +40,17 @@ from shared import (
 from . import TESTS_DIR, get_test_path, load_test
 
 
+@pytest.fixture(name="lang_fixtures", scope="session")
+def lang_fixtures_fixture(language: str) -> dict[str, Any]:
+    return load_test(language, "_fixtures")
+
+
 @pytest.fixture(name="slot_lists", scope="session")
-def slot_lists_fixture(language: str) -> dict[str, SlotList]:
+def slot_lists_fixture(
+    language: str, lang_fixtures: dict[str, Any]
+) -> dict[str, SlotList]:
     """Loads the slot lists for the language."""
-    fixtures = load_test(language, "_fixtures")
-    return get_slot_lists(fixtures)
+    return get_slot_lists(lang_fixtures)
 
 
 @pytest.fixture(name="name_trie", scope="session")
@@ -60,31 +69,33 @@ def name_trie_fixture(language: str, slot_lists: dict[str, SlotList]) -> Trie:
 
 
 @pytest.fixture(name="states", scope="session")
-def states_fixture(language: str) -> List[State]:
+def states_fixture(language: str, lang_fixtures: dict[str, Any]) -> List[State]:
     """Loads test entity states for the language."""
-    fixtures = load_test(language, "_fixtures")
-    return get_states(fixtures)
+    return get_states(lang_fixtures)
 
 
 @pytest.fixture(name="areas", scope="session")
-def areas_fixture(language: str) -> List[AreaEntry]:
+def areas_fixture(language: str, lang_fixtures: dict[str, Any]) -> List[AreaEntry]:
     """Loads test areas for the language."""
-    fixtures = load_test(language, "_fixtures")
-    return get_areas(fixtures)
+    return get_areas(lang_fixtures)
 
 
 @pytest.fixture(name="floors", scope="session")
-def floors_fixture(language: str) -> List[FloorEntry]:
+def floors_fixture(language: str, lang_fixtures: dict[str, Any]) -> List[FloorEntry]:
     """Loads test floors for the language."""
-    fixtures = load_test(language, "_fixtures")
-    return get_floors(fixtures)
+    return get_floors(lang_fixtures)
 
 
 @pytest.fixture(name="timers", scope="session")
-def timers_fixture(language: str) -> List[Timer]:
+def timers_fixture(language: str, lang_fixtures: dict[str, Any]) -> List[Timer]:
     """Loads test timers for the language."""
-    fixtures = load_test(language, "_fixtures")
-    return get_timers(fixtures)
+    return get_timers(lang_fixtures)
+
+
+@pytest.fixture(name="media", scope="session")
+def media_fixture(language: str, lang_fixtures: dict[str, Any]) -> List[BrowseMedia]:
+    """Loads test media for the language."""
+    return get_media_items(lang_fixtures)
 
 
 def do_test_language_sentences_file(
@@ -97,6 +108,7 @@ def do_test_language_sentences_file(
     areas: List[AreaEntry],
     floors: List[FloorEntry],
     timers: List[Timer],
+    media: List[BrowseMedia],
     language_sentences: Intents,
     language_responses: dict[str, Any],
     name_trie: Trie,
@@ -271,6 +283,7 @@ def do_test_language_sentences_file(
                         unmatched,
                         env=template_env,
                         timers=get_matched_timers(timers, result),
+                        media=get_matched_media(media, result),
                     )
                     actual_response_text = normalize_whitespace(
                         actual_response_text
@@ -293,6 +306,7 @@ def gen_test(test_file_stem: str) -> None:
         areas: List[AreaEntry],
         floors: List[FloorEntry],
         timers: List[Timer],
+        media: List[BrowseMedia],
         language_sentences: Intents,
         language_responses: dict[str, Any],
         name_trie: Trie,
@@ -306,6 +320,7 @@ def gen_test(test_file_stem: str) -> None:
             areas=areas,
             floors=floors,
             timers=timers,
+            media=media,
             language_sentences=language_sentences,
             language_responses=language_responses,
             name_trie=name_trie,

--- a/tests/test_slot_combinations.py
+++ b/tests/test_slot_combinations.py
@@ -207,6 +207,7 @@ def do_test_slot_combination(
     }
 
     timers: list[dict[str, Any]] = test_dict.get("timers", [])
+    media: list[dict[str, Any]] = test_dict.get("media", [])
 
     # For quick look-up during individual tests
     entity_domains_by_name: dict[str, set[str]] = defaultdict(set)
@@ -239,6 +240,7 @@ def do_test_slot_combination(
 
         expected_response = test_group["response"]
         group_timers = test_group.get("timers", timers)
+        group_media = test_group.get("media", media)
 
         for test_sentence in test_group["sentences"]:
             sentence_error_info = f"sentence='{test_sentence}', {error_info}"
@@ -271,7 +273,12 @@ def do_test_slot_combination(
             matching_sentence_templates[test_sentence] = result.intent_sentence.text
 
             actual_response = _render_response(
-                lang_resources, result, template_slots={"timers": group_timers}
+                lang_resources,
+                result,
+                template_slots={
+                    "timers": group_timers,
+                    "media": group_media[0] if group_media else None,
+                },
             )
             assert (
                 actual_response == expected_response


### PR DESCRIPTION
Adds intent definition and English sentences for upcoming `HassMediaSearchAndPlay` intent: https://github.com/home-assistant/core/pull/144269

This intent has a `search_query` wildcard slot that will search for and play the first matching item. The targeted media player must support the search and play media features.

The media player may be targeted implicitly (context area), by name, by area, or by name and area.