### PR TITLE
[FR] Add a simpler sentence to stop a vacuum

### DIFF
--- a/sentences/fr/vacuum_HassVacuumReturnToBase.yaml
+++ b/sentences/fr/vacuum_HassVacuumReturnToBase.yaml
@@ -3,6 +3,9 @@ intents:
   HassVacuumReturnToBase:
     data:
       - sentences:
+          # Renvoyer Alfred à sa base
           - "<renvoie> [<le>]{name} [(à|sur) (sa|la) base]"
+          # Arrête Alfred
+          - "<eteins> [<le>]{name}"
         requires_context:
           domain: vacuum

--- a/tests/fr/vacuum_HassVacuumReturnToBase.yaml
+++ b/tests/fr/vacuum_HassVacuumReturnToBase.yaml
@@ -2,6 +2,7 @@ language: fr
 tests:
   - sentences:
       - "Renvoie Nestor sur sa base"
+      - "Arrêter Nestor"
     intent:
       name: HassVacuumReturnToBase
       slots:


### PR DESCRIPTION
I added a much simpler sentence to stop a vacuum.

Before:
  - ✅ Renvoie Nestor sur sa base

After
  - ✅ Renvoie Nestor sur sa base
  - ✅ Arrêter Nestor
  