### PR TITLE
Fix responses for get temperature

### DIFF
--- a/responses/ca/HassClimateGetTemperature.yaml
+++ b/responses/ca/HassClimateGetTemperature.yaml
@@ -3,5 +3,6 @@ responses:
   intents:
     HassClimateGetTemperature:
       default: >
-        {% set temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature = state.state if current_temperature is none else current_temperature %}
         {{ temperature | float | abs | round(1) | replace('.0', '') | replace('.',',') }} {{ 'grau' if temperature | float | abs == 1 else 'graus' }} {{ 'sota zero' if temperature | float < 0 else '' }}

--- a/responses/cs/HassClimateGetTemperature.yaml
+++ b/responses/cs/HassClimateGetTemperature.yaml
@@ -3,7 +3,8 @@ responses:
   intents:
     HassClimateGetTemperature:
       default: >
-        {% set temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature = state.state if current_temperature is none else current_temperature %}
         {% if temperature is not none %}
           {% set rounded_temp = (temperature | int) if temperature % 1 == 0 else (temperature | float | round(1)) %}
           {% set degree_word = 'stupeň' if rounded_temp == 1 else 'stupně' if rounded_temp in [2,3,4] or rounded_temp % 1 != 0 else 'stupňů' %}

--- a/responses/da/HassClimateGetTemperature.yaml
+++ b/responses/da/HassClimateGetTemperature.yaml
@@ -3,7 +3,8 @@ responses:
   intents:
     HassClimateGetTemperature:
       default: >
-        {% set temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature = state.state if current_temperature is none else current_temperature %}
         {% if temperature == 1: %}
         {{ temperature }} grad
         {% else: %}

--- a/responses/en/HassClimateGetTemperature.yaml
+++ b/responses/en/HassClimateGetTemperature.yaml
@@ -3,7 +3,8 @@ responses:
   intents:
     HassClimateGetTemperature:
       default: >
-        {% set temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature = state.state if current_temperature is none else current_temperature %}
         {% if temperature == 1: %}
         {{ temperature }} degree
         {% else: %}

--- a/responses/es/HassClimateGetTemperature.yaml
+++ b/responses/es/HassClimateGetTemperature.yaml
@@ -3,5 +3,6 @@ responses:
   intents:
     HassClimateGetTemperature:
       default: >
-        {% set temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature = state.state if current_temperature is none else current_temperature %}
         {{ temperature | float | abs | round(1) | replace('.0', '') | replace('.',',') }} {{ 'grado' if temperature | float | abs == 1 else 'grados' }} {{ 'bajo cero' if temperature | float < 0 else '' }}

--- a/responses/gl/HassClimateGetTemperature.yaml
+++ b/responses/gl/HassClimateGetTemperature.yaml
@@ -3,5 +3,6 @@ responses:
   intents:
     HassClimateGetTemperature:
       default: >
-        {% set temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature = state.state if current_temperature is none else current_temperature %}
         {{ temperature | float | abs | round(1) | replace('.0', '') | replace('.',',') }} {{ 'grao' if temperature | float | abs == 1 else 'graos' }} {{ 'baixo cero' if temperature | float < 0 else '' }}

--- a/responses/he/HassClimateGetTemperature.yaml
+++ b/responses/he/HassClimateGetTemperature.yaml
@@ -3,9 +3,10 @@ responses:
   intents:
     HassClimateGetTemperature:
       default: >
-        {% set temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature = state.state if current_temperature is none else current_temperature %}
         {% if slots.area: %}
-        ב{{ slots.area }} {{ state_attr(state.entity_id, 'current_temperature') }} מעלות
+        ב{{ slots.area }} {{ temperature }} מעלות
         {% else: %}
-        הטמפרטורה היא {{ state_attr(state.entity_id, 'current_temperature') }} מעלות
+        הטמפרטורה היא {{ temperature }} מעלות
         {% endif %}

--- a/responses/hu/HassClimateGetTemperature.yaml
+++ b/responses/hu/HassClimateGetTemperature.yaml
@@ -3,7 +3,8 @@ responses:
   intents:
     HassClimateGetTemperature:
       default: >
-        {% set temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature = state.state if current_temperature is none else current_temperature %}
         {% if temperature is number %}
           {% if temperature < 0 %}
             {% set temperature_string = 'mínusz ' ~ (temperature * -1) | string | replace('.', ',') %}

--- a/responses/it/HassClimateGetTemperature.yaml
+++ b/responses/it/HassClimateGetTemperature.yaml
@@ -3,7 +3,8 @@ responses:
   intents:
     HassClimateGetTemperature:
       default: >
-        {% set temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature = state.state if current_temperature is none else current_temperature %}
         {% if temperature == 1: %}
         {{ temperature }} grado
         {% else: %}

--- a/responses/kw/HassClimateGetTemperature.yaml
+++ b/responses/kw/HassClimateGetTemperature.yaml
@@ -2,9 +2,8 @@ language: kw
 responses:
   intents:
     HassClimateGetTemperature:
-      default:
-        "TODO: {% set temperature = state_attr(state.entity_id, 'current_temperature')
+      default: >
+        TODO: {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature = state.state if current_temperature is none else current_temperature %}
         %} {% if temperature == 1: %} {{ temperature }} degree {% else: %} {{ temperature
         }} degrees {% endif %}
-
-        "

--- a/responses/mr/HassClimateGetTemperature.yaml
+++ b/responses/mr/HassClimateGetTemperature.yaml
@@ -3,7 +3,8 @@ responses:
   intents:
     HassClimateGetTemperature:
       default:
-        "TODO: {% set temperature = state_attr(state.entity_id, 'current_temperature')
+        "TODO: {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature = state.state if current_temperature is none else current_temperature %}
         %} {% if temperature == 1: %} {{ temperature }} degree {% else: %} {{ temperature
         }} degrees {% endif %}
 

--- a/responses/nl/HassClimateGetTemperature.yaml
+++ b/responses/nl/HassClimateGetTemperature.yaml
@@ -3,7 +3,8 @@ responses:
   intents:
     HassClimateGetTemperature:
       default: >
-        {% set temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature = state.state if current_temperature is none else current_temperature %}
         {% if temperature == 1: %}
           {{ temperature }} graad
         {% else: %}

--- a/responses/pl/HassClimateGetTemperature.yaml
+++ b/responses/pl/HassClimateGetTemperature.yaml
@@ -3,7 +3,8 @@ responses:
   intents:
     HassClimateGetTemperature:
       default: >
-        {% set temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature = state.state if current_temperature is none else current_temperature %}
         {% set temperature_pl = (temperature | string).replace(".", ",") %}
         {% set temperature_decimal = (temperature | float - temperature | int) | round(2) %}
         {% set negative_name = "" %}

--- a/responses/pt-br/HassClimateGetTemperature.yaml
+++ b/responses/pt-br/HassClimateGetTemperature.yaml
@@ -3,7 +3,8 @@ responses:
   intents:
     HassClimateGetTemperature:
       default: >
-        {% set temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature = state.state if current_temperature is none else current_temperature %}
         {% if (temperature | float) >= -1 and (temperature | float) <= 1  %}
         {{ temperature }} grau
         {% else: %}

--- a/responses/ro/HassClimateGetTemperature.yaml
+++ b/responses/ro/HassClimateGetTemperature.yaml
@@ -3,7 +3,8 @@ responses:
   intents:
     HassClimateGetTemperature:
       default: |
-        {% set temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature = state.state if current_temperature is none else current_temperature %}
         {% set temperature_ro = (temperature|string).replace(".", ",") %}
         {% set temperature_num = temperature | float %}
         {% if temperature_num | abs == 1 %}

--- a/responses/ru/HassClimateGetTemperature.yaml
+++ b/responses/ru/HassClimateGetTemperature.yaml
@@ -4,8 +4,10 @@ responses:
     HassClimateGetTemperature:
       # Extract the last integer digit from number and use it to select the right word ending
       default: >-
-        {{ state_attr(state.entity_id, 'current_temperature') }}
-        {% set temp = state_attr(state.entity_id, 'current_temperature') | float %}
+        {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature = state.state if current_temperature is none else current_temperature %}
+        {{ temperature }}
+        {% set temp = temperature | float %}
         {% set last_digit = temp|abs|int % 10 %}
         {% set last_two_digits = temp|abs|int % 100 %}
         {% if last_digit == 1 and last_two_digits != 11 %}

--- a/responses/sk/HassClimateGetTemperature.yaml
+++ b/responses/sk/HassClimateGetTemperature.yaml
@@ -3,5 +3,6 @@ responses:
   intents:
     HassClimateGetTemperature:
       default: >
-        {% set temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature = state.state if current_temperature is none else current_temperature %}
         {{ temperature }} {{ 'stupeň' if temperature | int | abs == 1 else 'stupne' if temperature | int | abs in [2,3,4] else 'stupňov' }}

--- a/responses/sl/HassClimateGetTemperature.yaml
+++ b/responses/sl/HassClimateGetTemperature.yaml
@@ -3,7 +3,8 @@ responses:
   intents:
     HassClimateGetTemperature:
       default: |
-        {% set temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature = state.state if current_temperature is none else current_temperature %}
         {% set temperature_sl = (temperature|string).replace(".", ",") %}
         {% set temperature_num = temperature | float %}
         {% set temperature_abs = temperature_num | abs %}

--- a/responses/sr-Latn/HassClimateGetTemperature.yaml
+++ b/responses/sr-Latn/HassClimateGetTemperature.yaml
@@ -2,7 +2,11 @@ language: sr-Latn
 responses:
   intents:
     HassClimateGetTemperature:
-      default:
-        "{% set temperature = state_attr(state.entity_id, 'current_temperature')
-        %} {% if temperature == 1: %} {{ temperature }} stepen {% else: %} {{ temperature
-        }} stepena {% endif %}"
+      default: >
+        {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature = state.state if current_temperature is none else current_temperature %}
+        {% if temperature == 1: %}
+        {{ temperature }} stepen
+        {% else: %}
+        {{ temperature}} stepena
+        {% endif %}

--- a/responses/sr/HassClimateGetTemperature.yaml
+++ b/responses/sr/HassClimateGetTemperature.yaml
@@ -3,7 +3,8 @@ responses:
   intents:
     HassClimateGetTemperature:
       default: >
-        {% set temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature = state.state if current_temperature is none else current_temperature %}
         {% set value = state.state | int | abs %}
         {% set variant = 0 if (value % 10 == 1 and value != 11) else 1 if (value % 10 in [2, 3, 4] and (value < 10 or value > 20)) else 2 %}
         {{ temperature}} {{ ['степен', 'степена', 'степени'][variant] }}

--- a/responses/th/HassClimateGetTemperature.yaml
+++ b/responses/th/HassClimateGetTemperature.yaml
@@ -3,7 +3,8 @@ responses:
   intents:
     HassClimateGetTemperature:
       default:
-        "TODO: {% set temperature = state_attr(state.entity_id, 'current_temperature')
+        "TODO: {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature = state.state if current_temperature is none else current_temperature %}
         %} {% if temperature == 1: %} {{ temperature }} degree {% else: %} {{ temperature
         }} degrees {% endif %}
 

--- a/responses/vi/HassClimateGetTemperature.yaml
+++ b/responses/vi/HassClimateGetTemperature.yaml
@@ -3,7 +3,8 @@ responses:
   intents:
     HassClimateGetTemperature:
       default: >
-        {% set temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
+        {% set temperature = state.state if current_temperature is none else current_temperature %}
         {% if temperature == 1: %}
         {{ temperature }} độ
         {% else: %}


### PR DESCRIPTION
See: https://github.com/home-assistant/core/issues/142331#issuecomment-2838261604

When a temperature `sensor` is set for an area (instead of a `climate` device), most responses fail because they look for a `current_temperature` attribute (valid for `climate`) instead of using `state.state` (valid for `sensor`).

This PR adjust all responses to first check the attribute and then fall back to the state.