### PR TITLE
Fix grammar of Italia add to timer intent

### DIFF
--- a/sentences/it/homeassistant_HassIncreaseTimer.yaml
+++ b/sentences/it/homeassistant_HassIncreaseTimer.yaml
@@ -4,13 +4,13 @@ intents:
   HassIncreaseTimer:
     data:
       - sentences:
-          - "aggiungi <timer_duration> da[l[ mio]] timer"
-          - "aggiungi <timer_duration> da[l[ mio]] timer <timer_start>"
-          - "aggiungi <timer_duration> da[l[ mio]] timer (per|da|di|d') <timer_start>"
-          - "aggiungi <timer_duration> da[l[ mio]] timer <in> <area>"
-          - "aggiungi <timer_duration> da[l[ mio]] timer {area}"
-          - "aggiungi <timer_duration> da[l[ mio]] timer (nominato|chiamato|per) {timer_name:name}"
-          - "aggiungi <timer_duration> da[l[ mio]] timer {timer_name:name}"
+          - "aggiungi <timer_duration> a[l[ mio]] timer"
+          - "aggiungi <timer_duration> a[l[ mio]] timer <timer_start>"
+          - "aggiungi <timer_duration> a[l[ mio]] timer (per|da|di|d') <timer_start>"
+          - "aggiungi <timer_duration> a[l[ mio]] timer <in> <area>"
+          - "aggiungi <timer_duration> a[l[ mio]] timer {area}"
+          - "aggiungi <timer_duration> a[l[ mio]] timer (nominato|chiamato|per) {timer_name:name}"
+          - "aggiungi <timer_duration> a[l[ mio]] timer {timer_name:name}"
       - sentences:
           - "aumenta[ il[ mio]] timer di <timer_duration>"
           - "aumenta[ il[ mio]] timer <timer_start> di <timer_duration>"

--- a/tests/it/homeassistant_HassIncreaseTimer.yaml
+++ b/tests/it/homeassistant_HassIncreaseTimer.yaml
@@ -2,7 +2,7 @@
 language: it
 tests:
   - sentences:
-      - "aggiungi 5 minuti dal timer"
+      - "aggiungi 5 minuti al timer"
       - "aumenta il mio timer di 5 minuti"
     intent:
       name: HassIncreaseTimer
@@ -11,8 +11,8 @@ tests:
     response: Timer aggiornato
 
   - sentences:
-      - "aggiungi 5 minuti dal mio timer di 1 ora"
-      - "aggiungi 5 minuti dal timer per 1 ora"
+      - "aggiungi 5 minuti al mio timer di 1 ora"
+      - "aggiungi 5 minuti al timer per 1 ora"
       - "aumenta timer 1 ora di 5 minuti"
       - "aumenta timer per 1 ora di 5 minuti"
     intent:
@@ -23,8 +23,8 @@ tests:
     response: Timer aggiornato
 
   - sentences:
-      - "aggiungi 5 minuti dal timer pizza"
-      - "aggiungi 5 minuti dal timer chiamato pizza"
+      - "aggiungi 5 minuti al timer pizza"
+      - "aggiungi 5 minuti al timer chiamato pizza"
       - "aumenta timer pizza di 5 minuti"
       - "aumenta timer per pizza di 5 minuti"
     intent:
@@ -37,8 +37,8 @@ tests:
     response: Timer aggiornato
 
   - sentences:
-      - "aggiungi 5 minuti dal timer cucina"
-      - "aggiungi 5 minuti dal timer in cucina"
+      - "aggiungi 5 minuti al timer cucina"
+      - "aggiungi 5 minuti al timer in cucina"
       - "aumenta timer in cucina di 5 minuti"
       - "aumenta timer cucina di 5 minuti"
     intent:


### PR DESCRIPTION
Changed from:

Add <timer_duration> **from** my timer

to:

Add <timer_duration> **to** my timer

because it is grammatically incorrect and not even used in common speaking.