### PR TITLE
Use list for media_class

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -1283,7 +1283,7 @@ HassMediaSearchAndPlay:
 
     # -------------------------------------------------------------------------
 
-    with_media_class:
+    media_class_only:
       description: "Search and play a specific type of media on the media player in the voice satellite's area"
       importance: "optional"
       slots:

--- a/sentences/en/_common.yaml
+++ b/sentences/en/_common.yaml
@@ -362,6 +362,23 @@ lists:
   search_query:
     wildcard: true
 
+  media_class:
+    values:
+      - in: "artist"
+        out: "artist"
+      - in: "album"
+        out: "album"
+      - in: "(track|song)"
+        out: "track"
+      - in: "playlist"
+        out: "playlist"
+      - in: "podcast"
+        out: "podcast"
+      - in: "movie"
+        out: "movie"
+      - in: "[tv] show"
+        out: "tv_show"
+
 expansion_rules:
   the: "(the|my|our)"
   name: "[<the>] {name}"

--- a/sentences/en/media_player_HassMediaSearchAndPlay.yaml
+++ b/sentences/en/media_player_HassMediaSearchAndPlay.yaml
@@ -2,80 +2,28 @@ language: "en"
 intents:
   HassMediaSearchAndPlay:
     data:
+      # current area
       - sentences:
+          - "play [the] {media_class} {search_query}"
+          - "play [the] {search_query} {media_class}"
           - "play {search_query}"
         requires_context:
           area:
             slot: true
 
+      # explicit area
       - sentences:
           - "play {search_query} in <area>"
+          - "play [the] {media_class} {search_query} in <area>"
+          - "play [the] {search_query} {media_class} in <area>"
 
+      # explicit media player name and area
       - sentences:
           - "play {search_query} on <name>"
+          - "play [the] {media_class} {search_query} on <name>"
+          - "play [the] {search_query} {media_class} on <name>"
           - "play {search_query} on <name> in <area>"
+          - "play [the] {media_class} {search_query} on <name> in <area>"
+          - "play [the] {search_query} {media_class} on <name> in <area>"
         requires_context:
           domain: "media_player"
-
-      - sentences:
-          - "play [the] {search_query} track"
-          - "play [the] track {search_query}"
-        slots:
-          media_class: "track"
-        requires_context:
-          area:
-            slot: true
-
-      - sentences:
-          - "play [the] {search_query} album"
-          - "play [the] album {search_query}"
-        slots:
-          media_class: "album"
-        requires_context:
-          area:
-            slot: true
-
-      - sentences:
-          - "play [the] {search_query} artist"
-          - "play artist {search_query}"
-        slots:
-          media_class: "artist"
-        requires_context:
-          area:
-            slot: true
-
-      - sentences:
-          - "play [the] {search_query} playlist"
-          - "play [the] playlist {search_query}"
-        slots:
-          media_class: "playlist"
-        requires_context:
-          area:
-            slot: true
-
-      - sentences:
-          - "play [the] {search_query} podcast"
-          - "play [the] podcast {search_query}"
-        slots:
-          media_class: "podcast"
-        requires_context:
-          area:
-            slot: true
-
-      - sentences:
-          - "play [the] {search_query} movie"
-          - "play [the] movie {search_query}"
-        slots:
-          media_class: "movie"
-        requires_context:
-          area:
-            slot: true
-
-      - sentences:
-          - "play [the] {search_query} tv show"
-          - "play [the] tv show {search_query}"
-        slots:
-          media_class: "tv_show"
-        requires_context:
-          area:
-            slot: true

--- a/tests/en/media_player_HassMediaSearchAndPlay.yaml
+++ b/tests/en/media_player_HassMediaSearchAndPlay.yaml
@@ -154,3 +154,34 @@ tests:
       context:
         area: "Living Room"
     response: "Playing media"
+
+  - sentences:
+      - "play the Breaking Bad TV show on the TV"
+    intent:
+      name: "HassMediaSearchAndPlay"
+      slots:
+        search_query: "Breaking Bad"
+        name: "TV"
+        media_class: "tv_show"
+    response: "Playing media"
+
+  - sentences:
+      - "play the song Bohemian Rhapsody in the Kitchen"
+    intent:
+      name: "HassMediaSearchAndPlay"
+      slots:
+        search_query: "Bohemian Rhapsody"
+        area: "Kitchen"
+        media_class: "track"
+    response: "Playing media"
+
+  - sentences:
+      - "play the artist Queen on the TV in the Kitchen"
+    intent:
+      name: "HassMediaSearchAndPlay"
+      slots:
+        search_query: "Queen"
+        name: "TV"
+        area: "Kitchen"
+        media_class: "artist"
+    response: "Playing media"


### PR DESCRIPTION
Use a list for `media_class` instead of writing out each option.
Also add `media_class` support to name/area sentences.