### PR TITLE
[DE] HassLightSet: fix brightness area awareness

### DIFF
--- a/sentences/de/light_HassLightSet.yaml
+++ b/sentences/de/light_HassLightSet.yaml
@@ -37,7 +37,7 @@ intents:
           - "<stelle> [die ]Helligkeit[ (<licht>|<lichtes>|<lichter>|<alle_lichter>)][ auf] <brightness>[ ein]"
           - "[die ]Helligkeit[ (<licht>|<lichtes>|<lichter>|<alle_lichter>)] auf <brightness> <setzen_end_of_sentence>"
           - "dimme[ (<licht>|<lichter>|<alle_lichter>)][ (auf|zu)] <brightness>"
-          - "(<licht>|<lichter>|<alle_lichter>)[ (auf|zu)] <brightness> dimmen"
+          - "[<licht>|<lichter>|<alle_lichter> ](auf|zu) <brightness> dimmen"
         response: "brightness"
         requires_context:
           area:

--- a/tests/de/light_HassLightSet.yaml
+++ b/tests/de/light_HassLightSet.yaml
@@ -209,6 +209,7 @@ tests:
       - Dimme das Licht auf 10
       - Setze die Helligkeit des Lichts auf 10
       - Setze die Helligkeit des Lichtes auf 10 Prozent
+      - auf 10% dimmen
     intent:
       name: HassLightSet
       context:


### PR DESCRIPTION
This PR fixes issues with brightness controls in the satellites area.
I changed sentences with an optional `<area>` and made it non-optional since these sentences without`<area>` would suggest to be executed in the satellites area, but were missing the slot area.
the same sentences without `<area>` are now in the satellite area section with `slot area`.
only the last sentence was slightly changed in it´s structure to compensate the missing `<area>` expansion rule.