### PR TITLE
[DE] HassLightSet: consistent support of <hier> expansion rule for brightness controls

### DIFF
--- a/sentences/de/light_HassLightSet.yaml
+++ b/sentences/de/light_HassLightSet.yaml
@@ -37,7 +37,7 @@ intents:
           - "<stelle> [die ]Helligkeit[ (<licht>|<lichtes>|<lichter>|<alle_lichter>)][ <hier>][ auf] <brightness>[ ein]"
           - "[die ]Helligkeit[ (<licht>|<lichtes>|<lichter>|<alle_lichter>)][ <hier>] auf <brightness> (<setzen_end_of_sentence>|dimmen)"
           - "dimme[ (<licht>|<lichter>|<alle_lichter>)][ <hier>][ (auf|zu)] <brightness>"
-          - "[<licht>|<lichter>|<alle_lichter> ][<hier> ](auf|zu) <brightness> dimmen"
+          - "[(<licht>|<lichter>|<alle_lichter>) ][<hier> ](auf|zu) <brightness> dimmen"
         response: "brightness"
         requires_context:
           area:

--- a/tests/de/light_HassLightSet.yaml
+++ b/tests/de/light_HassLightSet.yaml
@@ -269,6 +269,15 @@ tests:
       - Setze die Helligkeit des Lichts auf 10
       - Setze die Helligkeit des Lichtes auf 10 Prozent
       - auf 10% dimmen
+      - Setze die Helligkeit hier im Raum auf 10%
+      - stell die Helligkeit in diesem Raum auf 10% ein
+      - Setze die Helligkeit der Lampen hier im Raum auf 10%
+      - stell die Helligkeit der Leuchten in diesem Raum auf 10% ein
+      - Helligkeit in diesem Raum auf 10% einstellen
+      - Helligkeit in diesem Raum auf 10% dimmen
+      - die Helligkeit der Lichter im Raum auf 10% einstellen
+      - dimme alle lichter in diesem Raum auf 10%
+      - Lichter hier auf 10% dimmen
     intent:
       name: HassLightSet
       context:


### PR DESCRIPTION
this PR adds `<hier>` to all sentences for brightness controls in the satellite´s area.

after inserting `<hier>` the first two sentences were covered by other sentences below -> deleted those.
the last sentence had missing brackets - so one fix besides the additions as well...