### PR TITLE
[DE] reduce overall sentence count by optimizing the "<alle>" expansion rule

### DIFF
--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -577,7 +577,6 @@ expansion_rules:
   von_dem: "(von[ dem]|vom)"
   zu_dem: "(zu[ dem]|zum)"
   alle: "((alle|sämtliche)[r| der]|jede[r|s|n][ der]|die (ganze|komplette)|die (ganzen|kompletten)[ der]|der (ganzen|kompletten|sämtlichen)[ der])"
-  #  alle: "((alle|sämtliche)[r]|jede[r|s|n]|(die|der) (ganze|komplette|sämtliche)[n])[ der]"
   schliessen: "schlie(ß|ss)[e]"
   schliessen_end_of_sentence: "(schlie(ß|ss)en|zumachen|zu machen)"
   öffnen_end_of_sentence: "(öffnen|aufmachen|auf machen)"


### PR DESCRIPTION
this PR reduces the OSC by another ~14.2 million down to currently 48.8 million 