### PR TITLE
[DE] HassLightSet: optimize brightness controls to reduce permutations

### DIFF
--- a/sentences/de/light_HassLightSet.yaml
+++ b/sentences/de/light_HassLightSet.yaml
@@ -25,7 +25,7 @@ intents:
       # brightness by area/floor
       - sentences:
           - "[<setze> ][die ]Helligkeit[ (<licht_ohne_artikel>|<lichtes_mit_artikel>|<lichter>|<alle_lichter>)] <area_floor>[ auf] <brightness>"
-          - "<stelle> [die ]Helligkeit[ (<licht_ohne_artikel>|<lichtes_mit_artikel>|<lichter>|<alle_lichter>)] <area_floor>[ auf] <brightness>[ ein]"
+          - "<stelle> [die ]Helligkeit[ (<licht_ohne_artikel>|<lichtes_mit_artikel>|<lichter>|<alle_lichter>)] <area_floor> auf <brightness>[ ein]"
           - "[die ]Helligkeit[ (<licht_ohne_artikel>|<lichtes_mit_artikel>|<lichter>|<alle_lichter>)] <area_floor> auf <brightness> (<setzen_end_of_sentence>|dimmen)"
           - "dimme[ (<licht>|<lichter>|<alle_lichter>)] <area_floor>[ (auf|zu)] <brightness>"
           - "[(<licht>|<lichter>|<alle_lichter>) ]<area_floor>[ (auf|zu)] <brightness> dimmen"
@@ -42,9 +42,9 @@ intents:
       # brightness by satellite area
       - sentences:
           - "[<setze> ][die ]Helligkeit[ (<licht_ohne_artikel>|<lichtes_mit_artikel>|<lichter>|<alle_lichter>)][ <hier>][ auf] <brightness>"
-          - "<stelle> [die ]Helligkeit[ (<licht_ohne_artikel>|<lichtes_mit_artikel>|<lichter>|<alle_lichter>)][ <hier>][ auf] <brightness>[ ein]"
+          - "<stelle> [die ]Helligkeit[ (<licht_ohne_artikel>|<lichtes_mit_artikel>|<lichter>|<alle_lichter>)][ <hier>] auf <brightness>[ ein]"
           - "[die ]Helligkeit[ (<licht_ohne_artikel>|<lichtes_mit_artikel>|<lichter>|<alle_lichter>)][ <hier>] auf <brightness> (<setzen_end_of_sentence>|dimmen)"
-          - "dimme[ (<licht>|<lichter>|<alle_lichter>)][ <hier>][ (auf|zu)] <brightness>"
+          - "dimme[ (<licht>|<lichter>|<alle_lichter>)][ <hier>] (auf|zu) <brightness>"
           - "[(<licht>|<lichter>|<alle_lichter>) ][<hier> ](auf|zu) <brightness> dimmen"
         response: "brightness"
         requires_context:

--- a/tests/de/light_HassLightSet.yaml
+++ b/tests/de/light_HassLightSet.yaml
@@ -426,7 +426,6 @@ tests:
       - Stelle die Farbe im Schlafzimmer auf blau
       - Stelle Farbe im Schlafzimmer auf blau
       - Stelle Farbe Schlafzimmer auf blau
-      - Stelle Farbe Schlafzimmer blau
       - Farbe Schlafzimmer blau
       - Schlafzimmer Farbe blau
       - Schlafzimmer blau


### PR DESCRIPTION
For this PR I changed "auf" in brightness controls from optional to mandatory in sentences where it made no sense otherwise.
OSC - ~400.000 / ~2.5%
I had to remove one test-sentence that made no sense and was covered by the previous sentences.