### PR TITLE
[DE] add stt-fix for "setzen" for shopping-/todo-lists

### DIFF
--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -709,6 +709,8 @@ expansion_rules:
   stt_fix_licht_an: "Lichtern"
   # fix for "...aus im...."
   stt_fix_aus_im: "ausm"
+  # fix for "Setz[e] ... auf die Liste"
+  stt_fix_setze: "setzt"
 
 skip_words:
   - "bitte"

--- a/sentences/de/shopping_list_HassShoppingListAddItem.yaml
+++ b/sentences/de/shopping_list_HassShoppingListAddItem.yaml
@@ -7,7 +7,7 @@ intents:
           - "füge <item>[ (zu|zum)] <mein_einkauf_dativ> hinzu"
           - "füge[ (zu|zur)] <meine_liste_dativ> <item> hinzu"
           - "füge[ (zu|zum)] <mein_einkauf_dativ> <item> hinzu"
-          - "(setz[e]|schreib[e]|nehme|nimm|pack[e]) <item> (auf|in) <meine_liste_akkusativ>"
+          - "(setz[e]|<stt_fix_setze>|schreib[e]|nehme|nimm|pack[e]) <item> (auf|in) <meine_liste_akkusativ>"
           - "ergänze <item> (auf|in) <meine_liste_dativ>"
           - "<item> (auf|in) <meine_liste_akkusativ>[ (setzen|schreiben|nehmen|packen)]"
           - "<item> (auf|in) <meine_liste_dativ> ergänzen"

--- a/sentences/de/todo_HassListAddItem.yaml
+++ b/sentences/de/todo_HassListAddItem.yaml
@@ -5,7 +5,7 @@ intents:
       - sentences:
           - "füge <item>[ (zu|zur|zum)] <meine_liste_dativ> hinzu"
           - "füge[ (zu|zur|zum)] <meine_liste_dativ> <item> hinzu"
-          - "(setz[e]|schreib[e]|nehme|nimm|pack[e]) <item> (auf|in) <meine_liste_akkusativ>"
+          - "(setz[e]|<stt_fix_setze>|schreib[e]|nehme|nimm|pack[e]) <item> (auf|in) <meine_liste_akkusativ>"
           - "ergänze <item> (auf|in) <meine_liste_dativ>"
           - "<item> (auf|in) <meine_liste_akkusativ>[ (setzen|schreiben|nehmen|packen)]"
           - "<item>[ (zu|zur|zum)] <meine_liste_dativ> hinzufügen"

--- a/tests/de/shopping_list_HassShoppingListAddItem.yaml
+++ b/tests/de/shopping_list_HassShoppingListAddItem.yaml
@@ -14,6 +14,7 @@ tests:
       - "Milch auf die Liste packen"
       - "setze Milch auf die Liste"
       - "setz Milch auf die Liste"
+      - "setzt Milch auf die Liste"
       - "pack Milch auf die Liste"
       - "packe Milch auf die Liste"
       - "schreibe Milch auf die Liste"

--- a/tests/de/todo_HassListAddItem.yaml
+++ b/tests/de/todo_HassListAddItem.yaml
@@ -7,6 +7,7 @@ tests:
       - "Putzen auf die Liste Haushalt nehmen"
       - "setze Putzen auf die Liste Haushalt"
       - "setz Putzen auf die Liste Haushalt"
+      - "setzt Putzen auf die Liste Haushalt"
       - "schreibe Putzen auf die Liste Haushalt"
       - "schreibe Putzen in die Liste Haushalt"
       - "schreib Putzen auf die Liste Haushalt"


### PR DESCRIPTION
This PR adds a fix for stt-misunderstandings of "setz[e] x auf die [Einkaufs]Liste". This often results "Setzt x auf die Einkaufsliste" finally leading to "Setzt x" being added as an item to the shopping list.
