### PR TITLE
[DE] reduce sentence-count of HassSetVolumeRelative

### DIFF
--- a/sentences/de/media_player_HassSetVolumeRelative.yaml
+++ b/sentences/de/media_player_HassSetVolumeRelative.yaml
@@ -9,7 +9,7 @@ intents:
           - "(verringere|reduziere) die lautstärke[ der Musik][ (etwas|ein bisschen|ein wenig)]"
           - "senke die lautstärke[ der Musik][ (etwas|ein bisschen|ein wenig)][ ab]"
           - "[die ]lautstärke[ der Musik] [(etwas|ein bisschen|ein wenig) ](verringern|reduzieren|[ab]senken|[he]runterdrehen)"
-          - "dreh[e] [die ]lautstärke[ der Musik] [(etwas|ein bisschen|ein wenig) ][he]runter"
+          - "dreh[e] die lautstärke[ der Musik] [(etwas|ein bisschen|ein wenig) ][he]runter"
           - "[(es|die Musik) ist [(etwas|ein bisschen|ein wenig) ]]zu laut"
         slots:
           volume_step: "down"
@@ -23,7 +23,7 @@ intents:
           - "(verringere|reduziere) die lautstärke[ der Musik][ um]<volume_step>"
           - "senke die lautstärke[ der Musik][ um] <volume_step>[ ab]"
           - "[die ]lautstärke[ der Musik][ um] <volume_step> (verringern|reduzieren|[ab]senken|[he]runterdrehen)"
-          - "dreh[e] [die ]lautstärke[ der Musik][ um] <volume_step> [he]runter"
+          - "dreh[e] die lautstärke[ der Musik][ um] <volume_step> [he]runter"
         expansion_rules:
           volume_step: "{volume_step_down:volume_step}[%| prozent]"
         requires_context:
@@ -35,7 +35,7 @@ intents:
           - "[([den ]ton|[die ]lautstärke[ der Musik]|[die ]Musik) ][(etwas|ein bisschen|ein wenig) ]lauter (machen|[ein]stellen)"
           - "erhöhe die lautstärke[ der Musik][ (etwas|ein bisschen|ein wenig)]"
           - "[die ]lautstärke[ der Musik] [(etwas|ein bisschen|ein wenig) ](erhöhen|[her]aufdrehen)"
-          - "dreh[e] [die ]lautstärke[ der Musik] [(etwas|ein bisschen|ein wenig) ]([he]rauf|auf)"
+          - "dreh[e] die lautstärke[ der Musik] [(etwas|ein bisschen|ein wenig) ]([he]rauf|auf)"
           - "[(es|die Musik) ist [(etwas|ein bisschen|ein wenig) ]]zu leise"
         slots:
           volume_step: "up"
@@ -48,7 +48,7 @@ intents:
           - "[([den ]ton|[die ]lautstärke[ der Musik]|[die ]Musik) ][um ]<volume_step> lauter (machen|[ein]stellen)"
           - "erhöhe die lautstärke[ der Musik][ um] <volume_step>"
           - "[die ]lautstärke[ der Musik][ um] <volume_step> (erhöhen|[her]aufdrehen)"
-          - "dreh[e] [die ]lautstärke[ der Musik][ um] <volume_step> ([he]rauf|auf)"
+          - "dreh[e] die lautstärke[ der Musik][ um] <volume_step> ([he]rauf|auf)"
         expansion_rules:
           volume_step: "{volume_step_up:volume_step}[%| prozent]"
         requires_context:
@@ -63,7 +63,7 @@ intents:
           - "(verringere|reduziere) die lautstärke[ der Musik] <von_dem> <name>[ (etwas|ein bisschen|ein wenig)]"
           - "senke die lautstärke[ der Musik] <von_dem> <name>[ (etwas|ein bisschen|ein wenig)][ ab]"
           - "[die ]lautstärke[ der Musik] <von_dem> <name> [(etwas|ein bisschen|ein wenig) ](verringern|reduzieren|[ab]senken|[he]runterdrehen)"
-          - "dreh[e] [die ]lautstärke[ der Musik] <von_dem> <name> [(etwas|ein bisschen|ein wenig) ][he]runter"
+          - "dreh[e] die lautstärke[ der Musik] <von_dem> <name> [(etwas|ein bisschen|ein wenig) ][he]runter"
         slots:
           volume_step: "down"
         requires_context:
@@ -76,7 +76,7 @@ intents:
           - "(verringere|reduziere) die lautstärke[ der Musik] <von_dem> <name>[ um] <volume_step>"
           - "senke die lautstärke[ der Musik] <von_dem> <name>[ um] <volume_step> [ ab]"
           - "[die ]lautstärke[ der Musik] <von_dem> <name>[ um] <volume_step> (verringern|reduzieren|[ab]senken|[he]runterdrehen)"
-          - "dreh[e] [die ]lautstärke[ der Musik] <von_dem> <name>[ um] <volume_step> [he]runter"
+          - "dreh[e] die lautstärke[ der Musik] <von_dem> <name>[ um] <volume_step> [he]runter"
         expansion_rules:
           volume_step: "{volume_step_down:volume_step}[%| prozent]"
         slots:
@@ -90,7 +90,7 @@ intents:
           - "([den ]ton|[die ]lautstärke[ der Musik]|[die ]Musik) <von_dem> <name> [(etwas|ein bisschen|ein wenig) ]lauter (machen|[ein]stellen)"
           - "erhöhe die lautstärke[ der Musik] <von_dem> <name>[ (etwas|ein bisschen|ein wenig)]"
           - "[die ]lautstärke[ der Musik] <von_dem> <name> [(etwas|ein bisschen|ein wenig) ](erhöhen|[her]aufdrehen)"
-          - "dreh[e] [die ]lautstärke[ der Musik] <von_dem> <name> [(etwas|ein bisschen|ein wenig) ]([he]rauf|auf)"
+          - "dreh[e] die lautstärke[ der Musik] <von_dem> <name> [(etwas|ein bisschen|ein wenig) ]([he]rauf|auf)"
         slots:
           volume_step: "up"
         requires_context:
@@ -102,7 +102,7 @@ intents:
           - "([den ]ton|[die ]lautstärke[ der Musik]|[die ]Musik) <von_dem> <name>[ um] <volume_step> lauter (machen|[ein]stellen)"
           - "erhöhe die lautstärke[ der Musik] <von_dem> <name>[ um] <volume_step>"
           - "[die ]lautstärke[ der Musik] <von_dem> <name>[ um] <volume_step> (erhöhen|[her]aufdrehen)"
-          - "dreh[e] [die ]lautstärke[ der Musik] <von_dem> <name>[ um] <volume_step> ([he]rauf|auf)"
+          - "dreh[e] die lautstärke[ der Musik] <von_dem> <name>[ um] <volume_step> ([he]rauf|auf)"
         expansion_rules:
           volume_step: "{volume_step_up:volume_step}[%| prozent]"
         slots:
@@ -118,7 +118,7 @@ intents:
           - "(verringere|reduziere) die lautstärke[ der Musik] <area_floor>[ (etwas|ein bisschen|ein wenig)]"
           - "senke die lautstärke[ der Musik] <area_floor>[ (etwas|ein bisschen|ein wenig)][ ab]"
           - "[die ]lautstärke[ der Musik] <area_floor> [(etwas|ein bisschen|ein wenig) ](verringern|reduzieren|[ab]senken|[he]runterdrehen)"
-          - "dreh[e] [die ]lautstärke[ der Musik] <area_floor> [(etwas|ein bisschen|ein wenig) ][he]runter"
+          - "dreh[e] die lautstärke[ der Musik] <area_floor> [(etwas|ein bisschen|ein wenig) ][he]runter"
         slots:
           volume_step: "down"
       # Area/floor by name - step_down
@@ -129,7 +129,7 @@ intents:
           - "(verringere|reduziere) die lautstärke[ der Musik] <area_floor>[ um] <volume_step>"
           - "senke die lautstärke[ der Musik] <area_floor>[ um] <volume_step>[ ab]"
           - "[die ]lautstärke[ der Musik] <area_floor>[ um] <volume_step> (verringern|reduzieren|[ab]senken|[he]runterdrehen)"
-          - "dreh[e] [die ]lautstärke[ der Musik] <area_floor>[ um] <volume_step> [he]runter"
+          - "dreh[e] die lautstärke[ der Musik] <area_floor>[ um] <volume_step> [he]runter"
         expansion_rules:
           volume_step: "{volume_step_down:volume_step}[%| Prozent]"
       # Area/floor by name - up
@@ -139,7 +139,7 @@ intents:
           - "([den ]ton|[die ]lautstärke[ der Musik]|[die ]Musik) <area_floor> [(etwas|ein bisschen|ein wenig) ]lauter (machen|[ein]stellen)"
           - "erhöhe die lautstärke[ der Musik] <area_floor>[ (etwas|ein bisschen|ein wenig)]"
           - "[die ]lautstärke[ der Musik] <area_floor> [(etwas|ein bisschen|ein wenig) ](erhöhen|[her]aufdrehen)"
-          - "dreh[e] [die ]lautstärke[ der Musik] <area_floor> [(etwas|ein bisschen|ein wenig) ]([he]rauf|auf)"
+          - "dreh[e] die lautstärke[ der Musik] <area_floor> [(etwas|ein bisschen|ein wenig) ]([he]rauf|auf)"
         slots:
           volume_step: "up"
       # Area/floor by name - step_up
@@ -149,6 +149,6 @@ intents:
           - "([den ]ton|[die ]lautstärke[ der Musik]|[die ]Musik) <area_floor>[ um] <volume_step> lauter (machen|[ein]stellen)"
           - "erhöhe die lautstärke[ der Musik] <area_floor>[ um] <volume_step>"
           - "[die ]lautstärke[ der Musik] <area_floor>[ um] <volume_step> (erhöhen|[her]aufdrehen)"
-          - "dreh[e] [die ]lautstärke[ der Musik] <area_floor>[ um] <volume_step> ([he]rauf|auf)"
+          - "dreh[e] die lautstärke[ der Musik] <area_floor>[ um] <volume_step> ([he]rauf|auf)"
         expansion_rules:
           volume_step: "{volume_step_up:volume_step}[%| Prozent]"


### PR DESCRIPTION
This PR removes one optional "die" from each sentence-category that makes no sense at that position and thereby reduces sentencecount of HassSetVolumeRelative by ~12%.
No tested sentences lost.