### PR TITLE
Mark intents as supported

### DIFF
--- a/intents.yaml
+++ b/intents.yaml
@@ -826,7 +826,7 @@ HassShoppingListAddItem:
 # -----------------------------------------------------------------------------
 
 HassShoppingListCompleteItem:
-  supported: false
+  supported: true
   domain: shopping_list
   description: "Checks off an item from the shopping list"
   slots:
@@ -1224,7 +1224,7 @@ HassSetVolume:
 # -----------------------------------------------------------------------------
 
 HassMediaPlayerMute:
-  supported: false
+  supported: true
   domain: media_player
   description: "Mutes a media player"
   slots:
@@ -1253,7 +1253,7 @@ HassMediaPlayerMute:
 # -----------------------------------------------------------------------------
 
 HassMediaPlayerUnmute:
-  supported: false
+  supported: true
   domain: media_player
   description: "Unmutes a media player"
   slots:
@@ -2588,7 +2588,7 @@ HassTimerStatus:
 # -----------------------------------------------------------------------------
 
 HassFanSetSpeed:
-  supported: false
+  supported: true
   domain: fan
   description: "Set the speed of a fan"
   slots:


### PR DESCRIPTION
Mark intents that are supported in HA but were not correctly marked in `intents.yaml`