### PR TITLE
[DE] STT-fixes: apply existing fix for "setze" to HassUnpauseTimer

### DIFF
--- a/sentences/de/homeassistant_HassUnpauseTimer.yaml
+++ b/sentences/de/homeassistant_HassUnpauseTimer.yaml
@@ -3,13 +3,13 @@ intents:
   HassUnpauseTimer:
     data:
       - sentences:
-          - "setze[ (den|meinen)] Timer fort"
-          - "setze[ (den|meinen)] <timer_start> Timer fort"
-          - "setze[ (den|meinen)] Timer für <timer_start> fort"
-          - "setze[ (den|meinen)] {area} Timer fort"
-          - "setze[ (den|meinen)] Timer <area> fort"
-          - "setze[ (den|meinen)] Timer (namens|für) {timer_name:name} fort"
-          - "setze[ (den|meinen)] {timer_name:name} Timer fort"
+          - "(setz[e]|<stt_fix_setze>)[ (den|meinen)] Timer fort"
+          - "(setz[e]|<stt_fix_setze>)[ (den|meinen)] <timer_start> Timer fort"
+          - "(setz[e]|<stt_fix_setze>)[ (den|meinen)] Timer für <timer_start> fort"
+          - "(setz[e]|<stt_fix_setze>)[ (den|meinen)] {area} Timer fort"
+          - "(setz[e]|<stt_fix_setze>)[ (den|meinen)] Timer <area> fort"
+          - "(setz[e]|<stt_fix_setze>)[ (den|meinen)] Timer (namens|für) {timer_name:name} fort"
+          - "(setz[e]|<stt_fix_setze>)[ (den|meinen)] {timer_name:name} Timer fort"
           - "[(den|meinen) ]Timer (fortsetzen|weiter[ ]laufen lassen)"
           - "[(den|meinen) ]<timer_start> Timer (fortsetzen|weiter[ ]laufen lassen)"
           - "[(den|meinen) ]Timer für <timer_start> (fortsetzen|weiter[ ]laufen lassen)"

--- a/tests/de/homeassistant_HassUnpauseTimer.yaml
+++ b/tests/de/homeassistant_HassUnpauseTimer.yaml
@@ -4,6 +4,8 @@ tests:
   - sentences:
       - "setze Timer fort"
       - "setze meinen Timer fort"
+      - "setz Timer fort"
+      - "setz meinen Timer fort"
       - "Timer fortsetzen"
       - "den Timer fortsetzen"
       - "meinen Timer fortsetzen"
@@ -11,6 +13,9 @@ tests:
       - "lasse den Timer weiterlaufen"
       - "Timer weiter laufen lassen"
       - "Den Timer weiterlaufen lassen"
+      # STT-Fixes
+      - "setzt Timer fort"
+      - "setzt meinen Timer fort"
     intent:
       name: HassUnpauseTimer
     response: Timer fortgesetzt
@@ -18,6 +23,8 @@ tests:
   - sentences:
       - "setze 1 Stunde Timer fort"
       - "setze Timer für 1 Stunde fort"
+      - "setz 1 Stunde Timer fort"
+      - "setz Timer für 1 Stunde fort"
       - "1 Stunde Timer fortsetzen"
       - "den 1 Stunde Timer fortsetzen"
       - "meinen 1 Stunde Timer fortsetzen"
@@ -25,6 +32,9 @@ tests:
       - lasse meinen eine Stunde Timer weiterlaufen
       - 1 Stunde Timer weiter laufen lassen
       - den 1 Stunde Timer weiterlaufen lassen
+      # STT-Fixes
+      - "setzt 1 Stunde Timer fort"
+      - "setzt Timer für 1 Stunde fort"
     intent:
       name: HassUnpauseTimer
       slots:
@@ -34,6 +44,8 @@ tests:
   - sentences:
       - "Setze Pizza Timer fort"
       - "Setze Timer für Pizza fort"
+      - "Setz Pizza Timer fort"
+      - "Setz Timer für Pizza fort"
       - "Pizza Timer fortsetzen"
       - "den Pizza Timer fortsetzen"
       - "meinen Pizza Timer fortsetzen"
@@ -48,6 +60,9 @@ tests:
       - lasse meinen Pizza timer weiter laufen
       - den Pizza Timer weiterlaufen lassen
       - meinen Pizza Timer weiter laufen lassen
+      # STT-Fixes
+      - "Setzt Pizza Timer fort"
+      - "Setzt Timer für Pizza fort"
     intent:
       name: HassUnpauseTimer
       slots:
@@ -58,6 +73,8 @@ tests:
   - sentences:
       - "Setze Wohnzimmer Timer fort"
       - "Setze Timer im Wohnzimmer fort"
+      - "Setz Wohnzimmer Timer fort"
+      - "Setz Timer im Wohnzimmer fort"
       - "Wohnzimmer Timer fortsetzen"
       - "den Wohnzimmer Timer fortsetzen"
       - "meinen Wohnzimmer Timer fortsetzen"
@@ -72,6 +89,9 @@ tests:
       - lasse meinen Wohnzimmertimer weiterlaufen
       - meinen Wohnzimmer Timer weiter laufen lassen
       - den Wohnzimmer Timer weiterlaufen lassen
+      # STT-Fixes
+      - "Setzt Wohnzimmer Timer fort"
+      - "Setzt Timer im Wohnzimmer fort"
     intent:
       name: HassUnpauseTimer
       slots:


### PR DESCRIPTION
similar to #3558 
this pr fixes STT-misunderstandings of "setze" first implemented in the pr mentioned above and applies this fix to resume timer commands.