### PR TITLE
[DE] fix/add get target temperature for climate

### DIFF
--- a/responses/de/HassClimateGetTemperature.yaml
+++ b/responses/de/HassClimateGetTemperature.yaml
@@ -2,7 +2,12 @@ language: de
 responses:
   intents:
     HassClimateGetTemperature:
-      default: >
+      current_temperature: >
         {% set current_temperature = state_attr(state.entity_id, 'current_temperature') %}
         {% set temperature = state.state if current_temperature is none else current_temperature %}
+        {{ temperature }} Grad
+
+      target_temperature: |
+        {% set target_temperature = state_attr(state.entity_id, 'temperature') %}
+        {% set temperature = state.state if target_temperature is none else target_temperature %}
         {{ temperature }} Grad

--- a/sentences/de/climate_HassClimateGetTemperature.yaml
+++ b/sentences/de/climate_HassClimateGetTemperature.yaml
@@ -8,7 +8,13 @@ intents:
           - "Wie[ (hoch|niedrig)] ist <hier> die Temperatur"
           - "Wie (warm|kalt) ist es[ <hier>]"
           - "<wieviel> Grad (hat|sind) es[ <hier>]"
+        response: current_temperature
+        requires_context:
+          area:
+            slot: true
+      - sentences:
           - "Auf (<wieviel> Grad|welche Temperatur) ist (die Heizung|(der|das) Thermostat|die Klima[anlage])[ <hier>] [ein]gestellt"
+        response: target_temperature
         requires_context:
           area:
             slot: true
@@ -21,10 +27,16 @@ intents:
           - "Wie[ (hoch|niedrig)] ist die Temperatur des Thermostat[s] <area_floor>"
           - "Wie (warm|kalt) ist es <area_floor>"
           - "<wieviel> Grad (hat|sind) es <area_floor>"
+        response: current_temperature
+      - sentences:
           - "Auf (<wieviel> Grad|welche Temperatur) ist[ (die Heizung|(der|das) Thermostat|die Klima[anlage])] <area_floor> [ein]gestellt"
+        response: target_temperature
 
       # Get temperature of a named climate
       - sentences:
           - "Wie[ (hoch|niedrig)] ist die Temperatur[ <von_dem>] <name>"
           - "Wie[ (hoch|niedrig)] ist die Temperatur des <name>[s]"
+        response: current_temperature
+      - sentences:
           - "Auf (<wieviel> Grad|welche Temperatur) ist[ (die Heizung|(der|das) Thermostat|die Klima[anlage])] <name> [ein]gestellt"
+        response: target_temperature

--- a/tests/de/_fixtures.yaml
+++ b/tests/de/_fixtures.yaml
@@ -80,12 +80,14 @@ entities:
     state: "heat"
     attributes:
       current_temperature: 22
+      temperature: 23
   - name: Küchenthermostat
     id: climate.kitchen
     area: kitchen
     state: "heat"
     attributes:
       current_temperature: 24
+      temperature: 23
   - name: "Markise Osten"
     id: "cover.terrasse_markise"
     area: terrace

--- a/tests/de/climate_HassClimateGetTemperature.yaml
+++ b/tests/de/climate_HassClimateGetTemperature.yaml
@@ -12,6 +12,13 @@ tests:
       - Wie kalt ist es im Wohnzimmer?
       - Wie viel Grad hat es im Wohnzimmer?
       - Wie viel Grad sind es im Wohnzimmer?
+    intent:
+      name: HassClimateGetTemperature
+      slots:
+        area: Wohnzimmer
+    response: "22 Grad"
+
+  - sentences:
       - Auf wie viel Grad ist die Heizung im Wohnzimmer eingestellt?
       - Auf wie viel Grad ist die Heizung im Wohnzimmer gestellt?
       - Auf wie viel Grad ist der Thermostat im Wohnzimmer eingestellt?
@@ -30,7 +37,8 @@ tests:
       name: HassClimateGetTemperature
       slots:
         area: Wohnzimmer
-    response: "22 Grad"
+    response: "23 Grad"
+
   # by floor
   - sentences:
       - Wie hoch ist die Temperatur im Erdgeschoss?
@@ -43,6 +51,13 @@ tests:
       - Wie kalt ist es im Erdgeschoss?
       - Wie viel Grad hat es im Erdgeschoss?
       - Wie viel Grad sind es im Erdgeschoss?
+    intent:
+      name: HassClimateGetTemperature
+      slots:
+        floor: Erdgeschoss
+    response: "22 Grad"
+
+  - sentences:
       - Auf wie viel Grad ist die Heizung im Erdgeschoss eingestellt?
       - Auf wie viel Grad ist die Heizung im Erdgeschoss gestellt?
       - Auf wie viel Grad ist der Thermostat im Erdgeschoss eingestellt?
@@ -61,7 +76,7 @@ tests:
       name: HassClimateGetTemperature
       slots:
         floor: Erdgeschoss
-    response: "22 Grad"
+    response: "23 Grad"
 
   - sentences:
       - Wie hoch ist die Temperatur der Küche?
@@ -70,6 +85,7 @@ tests:
       slots:
         area: Küche
     response: "24 Grad"
+
   # by satellite area
   - sentences:
       - Wie hoch ist die Temperatur?
@@ -86,6 +102,20 @@ tests:
       - Wie kalt ist es hier?
       - Wie viel Grad hat es hier?
       - Wie viel Grad sind es hier?
+      - Wie hoch ist die Temperatur in diesem Raum?
+      - Wie ist im Raum die Temperatur?
+      - Wie ist in diesem Bereich die Temperatur?
+      - Wie kalt ist es im Raum?
+      - Wieviel Grad hat es in diesem Raum?
+      - Wieviel Grad hat es in diesem Bereich?
+    intent:
+      name: HassClimateGetTemperature
+      context:
+        area: Wohnzimmer
+      slots:
+        area: Wohnzimmer
+    response: "22 Grad"
+  - sentences:
       - Auf wie viel Grad ist die Heizung hier eingestellt?
       - Auf wie viel Grad ist die Heizung hier gestellt?
       - Auf wie viel Grad ist die Heizung eingestellt?
@@ -110,12 +140,6 @@ tests:
       - Auf welche Temperatur ist das Thermostat hier gestellt?
       - Auf welche Temperatur ist das Thermostat eingestellt?
       - Auf welche Temperatur ist das Thermostat gestellt?
-      - Wie hoch ist die Temperatur in diesem Raum?
-      - Wie ist im Raum die Temperatur?
-      - Wie ist in diesem Bereich die Temperatur?
-      - Wie kalt ist es im Raum?
-      - Wieviel Grad hat es in diesem Raum?
-      - Wieviel Grad hat es in diesem Bereich?
       - Auf wieviel Grad ist die Klimaanlage in diesem Raum eingestellt?
     intent:
       name: HassClimateGetTemperature
@@ -123,13 +147,20 @@ tests:
         area: Wohnzimmer
       slots:
         area: Wohnzimmer
-    response: "22 Grad"
+    response: "23 Grad"
+
   # by name
   - sentences:
       - Wie hoch ist die Temperatur von dem Wohnzimmerthermostat?
       - Wie hoch ist die Temperatur vom Wohnzimmerthermostat?
       - Wie hoch ist die Temperatur des Wohnzimmerthermostat?
       - Wie hoch ist die Temperatur des Wohnzimmerthermostats?
+    intent:
+      name: HassClimateGetTemperature
+      slots:
+        name: Wohnzimmerthermostat
+    response: "22 Grad"
+  - sentences:
       - Auf wie viel Grad ist die Heizung Wohnzimmerthermostat eingestellt?
       - Auf wie viel Grad ist die Heizung Wohnzimmerthermostat gestellt?
       - Auf wie viel Grad ist das Wohnzimmerthermostat eingestellt?
@@ -150,7 +181,7 @@ tests:
       name: HassClimateGetTemperature
       slots:
         name: Wohnzimmerthermostat
-    response: "22 Grad"
+    response: "23 Grad"
 
   - sentences:
       - Wie hoch ist die Temperatur von dem Thermostat im Wohnzimmer?


### PR DESCRIPTION
Today I ask the voice assist: "whats the current target temperature for my office" (Auf wieviel Grad ist die Temperatur im Büro eingestellt?). I asked this, because the room wasn't getting hot and I wanted to know which temp is set for the climate.

The response was the actual (current) temperature of the room and not whats set as target temperature. I would say, that this is a "bug". If you ask in German what is configured (was ist eingestellt), you would expect the target temperture which is configured for this room and not the actual messaured temp.

So this PR will "fix" this. 😃 

To make the different responses more readable, I changed the word "default response" to "current_temperature" and the new one as "target_temperature".  
