### PR TITLE
[DE] add "wann endet mein Timer" sentence structure

### DIFF
--- a/sentences/de/homeassistant_HassTimerStatus.yaml
+++ b/sentences/de/homeassistant_HassTimerStatus.yaml
@@ -37,3 +37,4 @@ intents:
           - "wann läuft (der|mein) (<timer_start>|{area}) timer ab"
           - "wann läuft (der|mein) Timer <area> ab"
           - "wann ist [(der|mein) ]{timer_name:name} Timer (zu ende|fertig)"
+          - "wann (ist|sind) [(der|die|das|mein|meine) ]{timer_name:name} fertig"

--- a/tests/de/homeassistant_HassTimerStatus.yaml
+++ b/tests/de/homeassistant_HassTimerStatus.yaml
@@ -129,6 +129,14 @@ tests:
       - "wann ist mein Pizza Timer zu ende"
       - "wann ist mein Pizza Timer fertig"
       - "wann ist der Pizza Timer fertig"
+      - "wann ist Pizza fertig"
+      - "wann ist der Pizza fertig"
+      - "wann ist die Pizza fertig"
+      - "wann ist das Pizza fertig"
+      - "wann ist mein Pizza fertig"
+      - "wann ist meine Pizza fertig"
+      - "wann sind meine Pizza fertig"
+      - "wann sind die Pizza fertig"
     intent:
       name: HassTimerStatus
       slots:


### PR DESCRIPTION
as described in the title this PR adds support for sentences like
- wann ist mein timer fertig
- wann endet mein timer
- wann ist mein Pizza Timer fertig
- wann läuft mein Wohnzimmer Timer ab
- ...

i do remember that at some point in the past we discussed not skipping the "timer" command für starting timers.
what do you think about the following(Not yet included) sentence:
`wann (ist|sind) [(der|die) ]{timer_name:name} fertig`
in my opinion this is specific enough in the "homeassistant-context" to be a recognized as a timer command even without the "timer" specifically mentioned. 
it would allow for very naturally asking for "wann ist die Pizza fertig?". and since it does not start any action it might be worth including that one.