### PR TITLE
[DE] Allow shorthand "wie lang[e] noch" to ask for timer status

### DIFF
--- a/sentences/de/homeassistant_HassTimerStatus.yaml
+++ b/sentences/de/homeassistant_HassTimerStatus.yaml
@@ -6,6 +6,7 @@ intents:
           - "Timer (Restzeit|Status)"
           - "(Restzeit|Status) (des|meines) Timer[s]"
           - "(Restzeit|Status)[ (von (dem|meinem)|vom)] Timer"
+          - "wie lang[e]"
           - "wie lang[e] (läuft|braucht|hat|dauert|geht) (der|mein) Timer"
           - "was macht (der|mein) Timer"
           - "<timer_start> Timer (Restzeit|Status)"

--- a/tests/de/homeassistant_HassTimerStatus.yaml
+++ b/tests/de/homeassistant_HassTimerStatus.yaml
@@ -17,6 +17,8 @@ tests:
       - Status vom Timer
       - Status von dem Timer
       - Status von meinem Timer
+      - "Wie lang noch"
+      - "Wie lange noch"
       - "Wie lange läuft der Timer noch"
       - "Wie lange braucht der Timer noch"
       - "Wie lange hat der Timer noch"


### PR DESCRIPTION
This allows the shorthand "wie lange noch" to ask for the current timer status (_`noch` is a skip word_)