### PR TITLE
[DE] Allow shorthand "wie spät" to get current time

### DIFF
--- a/sentences/de/homeassistant_HassGetCurrentTime.yaml
+++ b/sentences/de/homeassistant_HassGetCurrentTime.yaml
@@ -4,6 +4,6 @@ intents:
     data:
       - sentences:
           - "uhrzeit"
-          - "wie spät ist es"
+          - "wie spät[ ist es]"
           - "(wie viel|wieviel) uhr (ist es|haben wir|hat es)"
           - "(nenn[e]|gib|gebe|sag[e]|verrat[e]) mir die[ aktuelle] uhrzeit"

--- a/tests/de/homeassistant_HassGetCurrentTime.yaml
+++ b/tests/de/homeassistant_HassGetCurrentTime.yaml
@@ -2,6 +2,7 @@ language: de
 tests:
   - sentences:
       - "Uhrzeit"
+      - "wie spät"
       - "wie spät ist es"
       - "wie spät ist es jetzt"
       - "wie spät ist es aktuell"


### PR DESCRIPTION
This allows the shorthand "wie spät" to ask for the current time