### PR TITLE
[DE] HassGetState: add support for "%" to brightness requests

### DIFF
--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -628,7 +628,6 @@ expansion_rules:
   im_bereich: "[((in|auf)[ <artikel_bestimmt>]|im)] {zone:state}"
   im_zuhause: "(zu Hause|[im ]Zuhause)"
   temperature: "{temperature}[ ][°|Grad]"
-  prozent: "(Prozent|%)"
 
   # cover
   rollladen: "Roll[l](a|ä)den"

--- a/sentences/de/homeassistant_HassGetState.yaml
+++ b/sentences/de/homeassistant_HassGetState.yaml
@@ -36,6 +36,8 @@ intents:
         requires_context:
           domain:
             - light
+        expansion_rules:
+          prozent: "(Prozent|%)"
 
       - sentences:
           - "auf (welche Farbtemperatur|wie viel Kelvin) ist <name>[ <area_floor>] eingestellt"


### PR DESCRIPTION
This PR adds support for the following:
- Auf wie viel Prozent ist die Tischlampe eingestellt
- Auf wie viel % ist die Tischlampe im Esszimmer gedimmt
- Auf wie viel Prozent ist die Tischlampe im Erdgeschoss gedimmt

"%" in the sentence definition itself throws an error so i had to offload it into an expansion rule(other light-related expansion rules already do the same)