### PR TITLE
Print response texts in assertion error

### DIFF
--- a/tests/test_language_sentences.py
+++ b/tests/test_language_sentences.py
@@ -288,9 +288,10 @@ def do_test_language_sentences_file(
                     actual_response_text = normalize_whitespace(
                         actual_response_text
                     ).strip()
-                    assert (
-                        actual_response_text in expected_response_texts
-                    ), f"Incorrect response for: {sentence}"
+                    assert actual_response_text in expected_response_texts, (
+                        f"Incorrect response for: {sentence}. "
+                        f"Got '{actual_response_text}' but expected one of: {expected_response_texts}"
+                    )
 
                 if expected_to_fail:
                     pytest.fail(f"Expected sentence to fail but it didn't: {sentence}")


### PR DESCRIPTION
pytest prints escaped Unicode strings with assertions for some reason, so it's very hard to debug incorrect responses. For example:

```
FAILED tests/test_language_sentences.py::test_homeassistant_HassTurnOff[hy] - AssertionError: Incorrect response for: անջատիր սեղանի լամպ
assert '\u0561\u0576\u057b\u0561\u057f\u0565\u0581\u056b \u056c\u0578\u0582\u0575\u057d' in {'\u0561\u0576\u057b\u0561\u057f\u0565\u0581\u056b \u056c\u0578\u0582\u0575\u057d\u0568'}
```

This PR adds the unescaped strings to the error message for easier debugging.