### PR TITLE
[DE] add support for canceling timers with leading timer name

### DIFF
--- a/sentences/de/homeassistant_HassCancelTimer.yaml
+++ b/sentences/de/homeassistant_HassCancelTimer.yaml
@@ -10,4 +10,4 @@ intents:
           - "<timer_cancel>[ (den|meinen)] Timer <area>"
           - "<timer_cancel>[ (den|meinen)] {timer_name:name} Timer"
           - "<timer_cancel>[ (den|meinen)] Timer für {timer_name:name}"
-          - "[(den|meinen) ][<timer_start> ]Timer <timer_cancel_end_of_sentence>"
+          - "[(den|meinen) ][(<timer_start>|{timer_name:name}) ]Timer <timer_cancel_end_of_sentence>"

--- a/tests/de/homeassistant_HassCancelTimer.yaml
+++ b/tests/de/homeassistant_HassCancelTimer.yaml
@@ -32,6 +32,11 @@ tests:
       - "stopp den Pizza Timer"
       - "lösch meinen Pizza Timer"
       - "lösche Pizza Timer"
+      - "Pizza Timer abbrechen"
+      - "den Pizza Timer ausschalten"
+      - "meinen Pizza Timer deaktivieren"
+      - "Pizza Timer aus"
+      - "den Pizza Timer stoppen"
     intent:
       name: HassCancelTimer
       slots:


### PR DESCRIPTION
This PR adds support for the following sentence structures:

- Pizza Timer abbrechen
- den Pizza timer stoppen
- meinen Pizza Timer deaktivieren
- Pizza Timer aus
- ...