### PR TITLE
Add "depois de" to HassStartTimer

### DIFF
--- a/sentences/pt-BR/homeassistant_HassStartTimer.yaml
+++ b/sentences/pt-BR/homeassistant_HassStartTimer.yaml
@@ -15,5 +15,5 @@ intents:
           - "{timer_command:conversation_command} <daqui_a> <timer_duration>"
           - "<daqui_a> <timer_duration> {timer_command:conversation_command}"
         expansion_rules:
-          daqui_a: "(em|dentro de|daqui a)"
+          daqui_a: "(em|dentro de|daqui a|depois de)"
         response: command

--- a/tests/pt-BR/homeassistant_HassStartTimer.yaml
+++ b/tests/pt-BR/homeassistant_HassStartTimer.yaml
@@ -100,6 +100,8 @@ tests:
       - "ligar a luz daqui a 5 minutos"
       - "daqui a 5 minutos, ligar a luz"
       - "em 5 minutos, ligar a luz"
+      - "ligar a luz depois de 5 minutos"
+      - "depois de 5 minutos, ligar a luz"
     intent:
       name: HassStartTimer
       slots:


### PR DESCRIPTION
Add "depois de" to HassStartTimer in Portuguese.

The equivalent in English would be "after".