### PR TITLE
[DE] ClimateGetTemperature: allow shorthand "Zieltemperatur" and "Solltemperatur"

### DIFF
--- a/sentences/de/climate_HassClimateGetTemperature.yaml
+++ b/sentences/de/climate_HassClimateGetTemperature.yaml
@@ -16,6 +16,7 @@ intents:
       - sentences:
           - "(Auf (<wieviel> Grad|welche [Ziel|Soll]Temperatur)|wie (warm|kalt)) ist (die Heizung|(der|das) Thermostat|die Klima[anlage])[ <hier>] [ein]gestellt"
           - "(Auf (<wieviel> Grad|welche [Ziel|Soll]Temperatur)|wie (warm|kalt)) ist <hier> (die Heizung|(der|das) Thermostat|die Klima[anlage]) [ein]gestellt"
+          - "(Ziel|Soll)temperatur[ <hier>]"
         response: target_temperature
         requires_context:
           area:
@@ -35,6 +36,8 @@ intents:
       - sentences:
           - "(Auf (<wieviel> Grad|welche [Ziel|Soll]Temperatur)|wie (warm|kalt)) ist[ (die Heizung|(der|das) Thermostat|die Klima[anlage])] <area_floor> [ein]gestellt"
           - "(Auf (<wieviel> Grad|welche [Ziel|Soll]Temperatur)|wie (warm|kalt)) ist <area_floor> (Heizung|Thermostat|Klima[anlage]) [ein]gestellt"
+          - "(Ziel|Soll)temperatur <area_floor>"
+          - "<area_floor> (Ziel|Soll)temperatur"
         response: target_temperature
 
       # Get temperature of a named climate
@@ -47,4 +50,6 @@ intents:
         response: current_temperature
       - sentences:
           - "(Auf (<wieviel> Grad|welche [Ziel|Soll]Temperatur)|wie (warm|kalt)) ist[ (die Heizung|(der|das) Thermostat|die Klima[anlage])] <name> [ein]gestellt"
+          - "(Ziel|Soll)temperatur <name>"
+          - "<name> (Ziel|Soll)temperatur"
         response: target_temperature

--- a/tests/de/climate_HassClimateGetTemperature.yaml
+++ b/tests/de/climate_HassClimateGetTemperature.yaml
@@ -76,6 +76,10 @@ tests:
       - wie kalt ist die Wohnzimmer Heizung gestellt
       - wie kalt ist das Wohnzimmer Thermostat gestellt
       - wie kalt ist die Wohnzimmer Klimaanlage gestellt
+      - Zieltemperatur Wohnzimmer
+      - Wohnzimmer Zieltemperatur
+      - Solltemperatur Wohnzimmer
+      - Wohnzimmer Solltemperatur
     intent:
       name: HassClimateGetTemperature
       slots:
@@ -158,6 +162,10 @@ tests:
       - wie kalt ist die Erdgeschoss Heizung gestellt
       - wie kalt ist das Erdgeschoss Thermostat gestellt
       - wie kalt ist die Erdgeschoss Klimaanlage gestellt
+      - Zieltemperatur Erdgeschoss
+      - Erdgeschoss Zieltemperatur
+      - Solltemperatur Erdgeschoss
+      - Erdgeschoss Solltemperatur
     intent:
       name: HassClimateGetTemperature
       slots:
@@ -296,6 +304,18 @@ tests:
       - wie kalt ist in diesem Zimmer der Thermostat gestellt
       - wie kalt ist hier im Raum die Klimaanlage eingestellt
       - wie kalt ist hier im Zimmer die Klimaanlage eingestellt
+      - Zieltemperatur
+      - Solltemperatur
+      - Zieltemperatur hier
+      - Zieltemperatur in diesem Raum
+      - Zieltemperatur in diesem Bereich
+      - Zieltemperatur in diesem Zimmer
+      - Zieltemperatur hier im Raum
+      - Solltemperatur hier
+      - Solltemperatur in diesem Raum
+      - Solltemperatur in diesem Bereich
+      - Solltemperatur in diesem Zimmer
+      - Solltemperatur hier im Raum
     intent:
       name: HassClimateGetTemperature
       context:
@@ -360,6 +380,10 @@ tests:
       - wie kalt ist die Heizung Wohnzimmerthermostat gestellt
       - wie kalt ist das thermostat Wohnzimmerthermostat gestellt
       - wie kalt ist die Klimaanlage Wohnzimmerthermostat eingestellt
+      - Zieltemperatur Wohnzimmerthermostat
+      - Solltemperatur Wohnzimmerthermostat
+      - Wohnzimmerthermostat Zieltemperatur
+      - Wohnzimmerthermostat Solltemperatur
     intent:
       name: HassClimateGetTemperature
       slots:


### PR DESCRIPTION
...as a followup for #3665 
This PR adds shorter target temperature requests to climate entities