### PR TITLE
[DE] ToDo-Lists: move local expansion rules to commons file

### DIFF
--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -684,6 +684,10 @@ expansion_rules:
   co_sensor: "<co>[-]Sensor[en]"
   gas_sensor: "Gas[-]Sensor[en]"
 
+  # ToDo-Lists
+  meine_liste_dativ: "[(meiner|unserer|der) ]({name}[([ ]|s[ ])Liste]|[Liste ]{name})"
+  meine_liste_akkusativ: "[(meine|unsere|die) ]({name}[([ ]|s[ ])Liste]|[Liste ]{name})"
+
   # Timers
   timer_set: "(starte|setze|<stelle>|<erstelle>)"
   timer_set_end_of_sentence: "(starten|setzen|[er|ein]stellen)"

--- a/sentences/de/shopping_list_HassShoppingListAddItem.yaml
+++ b/sentences/de/shopping_list_HassShoppingListAddItem.yaml
@@ -3,20 +3,20 @@ intents:
   HassShoppingListAddItem:
     data:
       - sentences:
-          - "füge <item>[ (zu|zur)] <meine_liste_dativ> hinzu"
+          - "füge <item>[ (zu|zur)] <meine_einkaufsliste_dativ> hinzu"
           - "füge <item>[ (zu|zum)] <mein_einkauf_dativ> hinzu"
-          - "füge[ (zu|zur)] <meine_liste_dativ> <item> hinzu"
+          - "füge[ (zu|zur)] <meine_einkaufsliste_dativ> <item> hinzu"
           - "füge[ (zu|zum)] <mein_einkauf_dativ> <item> hinzu"
-          - "(setz[e]|<stt_fix_setze>|schreib[e]|nehme|nimm|pack[e]) <item> (auf|in) <meine_liste_akkusativ>"
-          - "ergänze <item> (auf|in) <meine_liste_dativ>"
-          - "<item> (auf|in) <meine_liste_akkusativ>[ (setzen|schreiben|nehmen|packen)]"
-          - "<item> (auf|in) <meine_liste_dativ> ergänzen"
-          - "<item>[ (zu|zur)] <meine_liste_dativ> hinzufügen"
+          - "(setz[e]|<stt_fix_setze>|schreib[e]|nehme|nimm|pack[e]) <item> (auf|in) <meine_einkaufsliste_akkusativ>"
+          - "ergänze <item> (auf|in) <meine_einkaufsliste_dativ>"
+          - "<item> (auf|in) <meine_einkaufsliste_akkusativ>[ (setzen|schreiben|nehmen|packen)]"
+          - "<item> (auf|in) <meine_einkaufsliste_dativ> ergänzen"
+          - "<item>[ (zu|zur)] <meine_einkaufsliste_dativ> hinzufügen"
           - "<item>[ (zu|zum)] <mein_einkauf_dativ> hinzufügen"
-          - "<item>[ (auf|in)] <meine_liste_akkusativ> hinzufügen"
+          - "<item>[ (auf|in)] <meine_einkaufsliste_akkusativ> hinzufügen"
         response: item_added
         expansion_rules:
           mein_einkauf_dativ: "[(meinem|unserem|dem) ]Einkauf"
-          meine_liste_dativ: "[(meiner|unserer|der) ][Einkaufs[ ]]Liste"
-          meine_liste_akkusativ: "[(meine|unsere|die) ][Einkaufs[ ]]Liste"
+          meine_einkaufsliste_dativ: "[(meiner|unserer|der) ][Einkaufs[ ]]Liste"
+          meine_einkaufsliste_akkusativ: "[(meine|unsere|die) ][Einkaufs[ ]]Liste"
           item: "{shopping_list_item:item}"

--- a/sentences/de/shopping_list_HassShoppingListCompleteItem.yaml
+++ b/sentences/de/shopping_list_HassShoppingListCompleteItem.yaml
@@ -3,14 +3,14 @@ intents:
   HassShoppingListCompleteItem:
     data:
       - sentences:
-          - (entferne|lösche|streiche) <item> (von|auf|aus) <meine_liste_dativ>
+          - (entferne|lösche|streiche) <item> (von|auf|aus) <meine_einkaufsliste_dativ>
           - (entferne|lösche|streiche) <item> (von|auf|aus) <mein_einkauf_dativ>
-          - (schließe|hake) <item> (von|auf|aus) <meine_liste_dativ> ab
+          - (schließe|hake) <item> (von|auf|aus) <meine_einkaufsliste_dativ> ab
           - <item> (von|auf|aus) <mein_einkauf_dativ> (entfernen|löschen|streichen)
-          - <item> (von|auf|aus) <meine_liste_dativ> (entfernen|löschen|streichen)
+          - <item> (von|auf|aus) <meine_einkaufsliste_dativ> (entfernen|löschen|streichen)
         response: item_completed
         expansion_rules:
           mein_einkauf_dativ: "[(meinem|unserem|dem) ]Einkauf"
-          meine_liste_dativ: "[(meiner|unserer|der) ][Einkaufs[ ]]Liste"
-          meine_liste_akkusativ: "[(meine|unsere|die) ][Einkaufs[ ]]Liste"
+          meine_einkaufsliste_dativ: "[(meiner|unserer|der) ][Einkaufs[ ]]Liste"
+          meine_einkaufsliste_akkusativ: "[(meine|unsere|die) ][Einkaufs[ ]]Liste"
           item: "{shopping_list_item:item}"

--- a/sentences/de/todo_HassListAddItem.yaml
+++ b/sentences/de/todo_HassListAddItem.yaml
@@ -15,6 +15,4 @@ intents:
         requires_context:
           domain: todo
         expansion_rules:
-          meine_liste_dativ: "[(meiner|unserer|der) ]({name}[( |s[ ])Liste]|[Liste ]{name})"
-          meine_liste_akkusativ: "[(meine|unsere|die) ]({name}[( |s[ ])Liste]|[Liste ]{name})"
           item: "{todo_list_item:item}"

--- a/sentences/de/todo_HassListCompleteItem.yaml
+++ b/sentences/de/todo_HassListCompleteItem.yaml
@@ -10,5 +10,4 @@ intents:
         requires_context:
           domain: todo
         expansion_rules:
-          meine_liste_dativ: "[(meiner|unserer|der) ]([Liste ]{name}|{name}[s] Liste|{name}[s]liste)"
           item: "{todo_list_item:item}"

--- a/tests/de/todo_HassListAddItem.yaml
+++ b/tests/de/todo_HassListAddItem.yaml
@@ -36,6 +36,7 @@ tests:
       - "ergänze Putzen auf der Liste Haushalt"
       - "ergänze Putzen auf meiner Haushalt Liste"
       - "ergänze Putzen auf unserer Haushalt Liste"
+      - "ergänze Putzen auf unserer Haushaltliste"
       - "ergänze Putzen auf meiner Haushaltsliste"
       - "ergänze Putzen auf meiner Haushalts liste"
       - "ergänze Putzen auf unserer Haushaltsliste"

--- a/tests/de/todo_HassListCompleteItem.yaml
+++ b/tests/de/todo_HassListCompleteItem.yaml
@@ -40,6 +40,7 @@ tests:
       - entferne Putzen von meiner Haushalt Liste
       - entferne Putzen von unserer Haushalt Liste
       - entferne Putzen von der Haushalt Liste
+      - entferne Putzen von der Haushaltliste
       - entferne Putzen von Haushalt Liste
       - entferne Putzen von meiner Haushalts Liste
       - entferne Putzen von unserer Haushalts Liste


### PR DESCRIPTION
This PR moves the local expansion rules `meine_liste_dativ` and `meine_liste_akkusativ` from the todo list files to the commons file.
since those(at least `meine_liste_dativ`, but to keep those related two close i moved both) are used in both addItem and completeItem i wanted to make sure both actions support the same syntax.
there was already a small difference where CompleteItem would allow `{name}Liste` and AddItem did not recognize it - this is fixed with this PR as well(now supported by both intents - tests added).
since both shopping-lists and todo-lists used the same names for different expansion rules i renamed the corresponding shopping list expansion rules.