### PR TITLE
[DE] ListAddItem: add STT-fix for "schreibt"

### DIFF
--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -726,6 +726,8 @@ expansion_rules:
   stt_fix_aus_im: "ausm"
   # fix for "Setz[e] ... auf die Liste"
   stt_fix_setze: "setzt"
+  # fix for "Schreib[e] ... auf die Liste"
+  stt_fix_schreib: "schreibt"
 
 skip_words:
   - "bitte"

--- a/sentences/de/shopping_list_HassShoppingListAddItem.yaml
+++ b/sentences/de/shopping_list_HassShoppingListAddItem.yaml
@@ -7,7 +7,7 @@ intents:
           - "füge <item>[ (zu|zum)] <mein_einkauf_dativ> hinzu"
           - "füge[ (zu|zur)] <meine_einkaufsliste_dativ> <item> hinzu"
           - "füge[ (zu|zum)] <mein_einkauf_dativ> <item> hinzu"
-          - "(setz[e]|<stt_fix_setze>|schreib[e]|nehme|nimm|pack[e]) <item> (auf|in) <meine_einkaufsliste_akkusativ>"
+          - "(setz[e]|<stt_fix_setze>|schreib[e]|<stt_fix_schreib>|nehme|nimm|pack[e]) <item> (auf|in) <meine_einkaufsliste_akkusativ>"
           - "ergänze <item> (auf|in) <meine_einkaufsliste_dativ>"
           - "<item> (auf|in) <meine_einkaufsliste_akkusativ>[ (setzen|schreiben|nehmen|packen)]"
           - "<item> (auf|in) <meine_einkaufsliste_dativ> ergänzen"

--- a/sentences/de/todo_HassListAddItem.yaml
+++ b/sentences/de/todo_HassListAddItem.yaml
@@ -5,7 +5,7 @@ intents:
       - sentences:
           - "füge <item>[ (zu|zur|zum)] <meine_liste_dativ> hinzu"
           - "füge[ (zu|zur|zum)] <meine_liste_dativ> <item> hinzu"
-          - "(setz[e]|<stt_fix_setze>|schreib[e]|nehme|nimm|pack[e]) <item> (auf|in) <meine_liste_akkusativ>"
+          - "(setz[e]|<stt_fix_setze>|schreib[e]|<stt_fix_schreib>|nehme|nimm|pack[e]) <item> (auf|in) <meine_liste_akkusativ>"
           - "ergänze <item> (auf|in) <meine_liste_dativ>"
           - "<item> (auf|in) <meine_liste_akkusativ>[ (setzen|schreiben|nehmen|packen)]"
           - "<item>[ (zu|zur|zum)] <meine_liste_dativ> hinzufügen"

--- a/tests/de/shopping_list_HassShoppingListAddItem.yaml
+++ b/tests/de/shopping_list_HassShoppingListAddItem.yaml
@@ -48,6 +48,8 @@ tests:
       - "Milch zum Einkauf hinzufügen"
       - "Milch auf meiner Liste ergänzen"
       - "Milch auf unserer Liste ergänzen"
+      # stt-fixes
+      - "schreibt Milch auf die Einkaufsliste"
     intent:
       name: HassShoppingListAddItem
       slots:

--- a/tests/de/todo_HassListAddItem.yaml
+++ b/tests/de/todo_HassListAddItem.yaml
@@ -47,6 +47,9 @@ tests:
       - "Putzen auf der Liste Haushalt ergänzen"
       - "Putzen in meiner Liste Haushalt ergänzen"
       - "Putzen in unserer Liste Haushalt ergänzen"
+      # stt-fixes
+      - "schreibt Putzen auf die Liste Haushalt"
+      - "schreibt Putzen auf die Haushalt Liste"
     intent:
       name: HassListAddItem
       slots:


### PR DESCRIPTION
This PR adds a fix for a common STT-error when using sentences like `schreib X auf die Einkaufsliste`. 
This often results in `schreibt X` being added to the shopping list.