### PR TITLE
[DE] ListAddItem: allow hyphen for todo-list-names

### DIFF
--- a/sentences/de/_common.yaml
+++ b/sentences/de/_common.yaml
@@ -685,8 +685,8 @@ expansion_rules:
   gas_sensor: "Gas[-]Sensor[en]"
 
   # ToDo-Lists
-  meine_liste_dativ: "[(meiner|unserer|der) ]({name}[([ ]|s[ ])Liste]|[Liste ]{name})"
-  meine_liste_akkusativ: "[(meine|unsere|die) ]({name}[([ ]|s[ ])Liste]|[Liste ]{name})"
+  meine_liste_dativ: "[(meiner|unserer|der) ]({name}[([ ]|s[ ]|-)Liste]|[Liste ]{name})"
+  meine_liste_akkusativ: "[(meine|unsere|die) ]({name}[([ ]|s[ ]|-)Liste]|[Liste ]{name})"
 
   # Timers
   timer_set: "(starte|setze|<stelle>|<erstelle>)"

--- a/tests/de/_fixtures.yaml
+++ b/tests/de/_fixtures.yaml
@@ -352,6 +352,10 @@ entities:
     id: "todo.haushalt"
     state: ""
 
+  - name: "To-Do"
+    id: "todo.todo"
+    state: ""
+
   - name: "Berlin"
     id: "weather.berlin"
     state: "rainy"

--- a/tests/de/todo_HassListAddItem.yaml
+++ b/tests/de/todo_HassListAddItem.yaml
@@ -53,3 +53,13 @@ tests:
         item: "Putzen"
         name: "Haushalt"
     response: Putzen hinzugefügt
+
+  - sentences:
+      - "schreib Putzen auf die to-do-liste"
+      - "füge Putzen zur to-do-liste hinzu"
+    intent:
+      name: HassListAddItem
+      slots:
+        item: "Putzen"
+        name: "To-Do"
+    response: Putzen hinzugefügt

--- a/tests/de/todo_HassListCompleteItem.yaml
+++ b/tests/de/todo_HassListCompleteItem.yaml
@@ -56,3 +56,13 @@ tests:
         item: "Putzen"
         name: "Haushalt"
     response: Putzen abgehakt
+
+  - sentences:
+      - "streiche Putzen von der to-do-liste"
+      - "lösche Putzen von unserer to-do-liste"
+    intent:
+      name: HassListCompleteItem
+      slots:
+        item: "Putzen"
+        name: "To-Do"
+    response: Putzen abgehakt


### PR DESCRIPTION
When using to-do-lists named e.g. `To-Do` or `to do` asking assist to add something to your to do list results in `schreibe something auf meine To-Do-Liste` which was not recognised by the current sentence templates. 
This PR allows hyphens between list name and `Liste` to cover e.g. the cases mentioned above.
