### PR TITLE
[DE] move existing tests for STT-fixes to separate section

### DIFF
--- a/tests/de/shopping_list_HassShoppingListAddItem.yaml
+++ b/tests/de/shopping_list_HassShoppingListAddItem.yaml
@@ -14,7 +14,6 @@ tests:
       - "Milch auf die Liste packen"
       - "setze Milch auf die Liste"
       - "setz Milch auf die Liste"
-      - "setzt Milch auf die Liste"
       - "pack Milch auf die Liste"
       - "packe Milch auf die Liste"
       - "schreibe Milch auf die Liste"
@@ -50,6 +49,7 @@ tests:
       - "Milch auf unserer Liste ergänzen"
       # stt-fixes
       - "schreibt Milch auf die Einkaufsliste"
+      - "setzt Milch auf die Liste"
     intent:
       name: HassShoppingListAddItem
       slots:

--- a/tests/de/todo_HassListAddItem.yaml
+++ b/tests/de/todo_HassListAddItem.yaml
@@ -7,7 +7,6 @@ tests:
       - "Putzen auf die Liste Haushalt nehmen"
       - "setze Putzen auf die Liste Haushalt"
       - "setz Putzen auf die Liste Haushalt"
-      - "setzt Putzen auf die Liste Haushalt"
       - "schreibe Putzen auf die Liste Haushalt"
       - "schreibe Putzen in die Liste Haushalt"
       - "schreib Putzen auf die Liste Haushalt"
@@ -50,6 +49,7 @@ tests:
       # stt-fixes
       - "schreibt Putzen auf die Liste Haushalt"
       - "schreibt Putzen auf die Haushalt Liste"
+      - "setzt Putzen auf die Liste Haushalt"
     intent:
       name: HassListAddItem
       slots:


### PR DESCRIPTION
This PR is more of a cosmetic nature.
i moved existing test sentences for previously implemented stt-fixes to a separate section in the corresponding test files for better future removability