### PR TITLE
[DE] HassLightSet: allow shorthand(s) without "dimmen"

### DIFF
--- a/sentences/de/light_HassLightSet.yaml
+++ b/sentences/de/light_HassLightSet.yaml
@@ -49,6 +49,7 @@ intents:
           - "[die ]Helligkeit[ (<licht_ohne_artikel>|<lichtes_mit_artikel>|<lichter>|<alle_lichter>)][ <hier>] auf <brightness> (<setzen_end_of_sentence>|dimmen)"
           - "dimme[ (<licht>|<lichter>|<alle_lichter>)][ <hier>] (auf|zu) <brightness>"
           - "[(<licht>|<lichter>|<alle_lichter>) ][<hier> ](auf|zu) <brightness> dimmen"
+          - "(<licht>|<lichter>|<alle_lichter>) [<hier> ][ auf] <brightness>"
         response: "brightness"
         requires_context:
           area:

--- a/tests/de/light_HassLightSet.yaml
+++ b/tests/de/light_HassLightSet.yaml
@@ -209,6 +209,7 @@ tests:
       - Schlafzimmer auf minimale Helligkeit
       - Stell das Schlafzimmer auf die minimale Helligkeit ein
       - Schlafzimmer auf minimale Helligkeit dimmen
+      - Schlafzimmer auf minimale Helligkeitsstufe
       - änder die Helligkeit im Schlafzimmer auf minimum
       - ändere die Helligkeit im schlafzimmer auf minimale Stufe
       - stell die Helligkeit im Schlafzimmer auf das minimum ein
@@ -253,8 +254,11 @@ tests:
       - Setze die Helligkeit des Lichts im Schlafzimmer auf 11
       - Setze die Helligkeit des Lichtes im Schlafzimmer auf 11
       - Die Helligkeit der Lampen im Schlafzimmer auf 11 Prozent dimmen
+      - Die Helligkeit der Lampen im Schlafzimmer auf 11 Prozent
       - Helligkeit aller Lampen im Schlafzimmer auf 11 Prozent dimmen
+      - Helligkeit aller Lampen im Schlafzimmer auf 11 Prozent
       - Helligkeit im Schlafzimmer auf 11 Prozent dimmen
+      - Helligkeit im Schlafzimmer auf 11 Prozent
       - Schlafzimmer Helligkeit 11%
       - im Schlafzimmer Helligkeit Licht 11%
       - im Schlafzimmer Helligkeit des Lichts 11%
@@ -270,8 +274,11 @@ tests:
       - im Schlafzimmer helligkeit aller Lampen auf 11% einstellen
       - im Schlafzimmer Helligkeit auf 11% dimmen
       - im Schlafzimmer Helligkeit des Lichts auf 11% dimmen
+      - im Schlafzimmer Helligkeit des Lichts auf 11%
       - im Schlafzimmer helligkeit der Lampen auf 11% dimmen
+      - im Schlafzimmer helligkeit der Lampen auf 11%
       - im Schlafzimmer helligkeit aller Lampen auf 11% dimmen
+      - im Schlafzimmer helligkeit aller Lampen auf 11%
       - im Schlafzimmer Helligkeit auf 11% ändern
       - im Schlafzimmer Helligkeit Licht auf 11% ändern
       - im Schlafzimmer Helligkeit des Lichts auf 11 Prozent stellen
@@ -304,6 +311,7 @@ tests:
       - ändere das Erdgeschoss auf die maximale Helligkeitsstufe
       - Stell das Erdgeschoss auf die maximale Helligkeit ein
       - Erdgeschoss auf maximale Helligkeit dimmen
+      - Erdgeschoss auf maximale Helligkeitsstufe
       - änder die Helligkeit im Erdgeschoss auf maximum
       - ändere die Helligkeit im Erdgeschoss auf maximale Stufe
       - stell die Helligkeit im Erdgeschoss auf das maximum ein
@@ -328,6 +336,7 @@ tests:
       - Erdgeschoss auf minimale Helligkeit
       - Stell das Erdgeschoss auf die minimale Helligkeit ein
       - Erdgeschoss auf minimale Helligkeit dimmen
+      - Erdgeschoss auf minimale Helligkeitsstufe
       - änder die Helligkeit im Erdgeschoss auf minimum
       - ändere die Helligkeit im Erdgeschoss auf minimale Stufe
       - stell die Helligkeit im Erdgeschoss auf das minimum ein
@@ -373,7 +382,9 @@ tests:
       - Setze die Helligkeit des Lichts im Erdgeschoss auf 15
       - Setze die Helligkeit des Lichtes im Erdgeschoss auf 15
       - Die Helligkeit der Lampen im Erdgeschoss auf 15 Prozent dimmen
+      - Die Helligkeit der Lampen im Erdgeschoss auf 15 Prozent
       - Helligkeit aller Lampen im Erdgeschoss auf 15 Prozent dimmen
+      - Helligkeit aller Lampen im Erdgeschoss auf 15 Prozent
       - Helligkeit im Erdgeschoss auf 15 Prozent dimmen
       - Erdgeschoss Helligkeit 15%
       - im Erdgeschoss Helligkeit Licht 15%
@@ -389,9 +400,13 @@ tests:
       - im Erdgeschoss helligkeit der Lampen auf 15% einstellen
       - im Erdgeschoss helligkeit aller Lampen auf 15% einstellen
       - im Erdgeschoss Helligkeit auf 15% dimmen
+      - im Erdgeschoss Helligkeit auf 15%
       - im Erdgeschoss Helligkeit des Lichts auf 15% dimmen
+      - im Erdgeschoss Helligkeit des Lichts auf 15%
       - im Erdgeschoss helligkeit der Lampen auf 15% dimmen
+      - im Erdgeschoss helligkeit der Lampen auf 15%
       - im Erdgeschoss helligkeit aller Lampen auf 15% dimmen
+      - im Erdgeschoss helligkeit aller Lampen auf 15%
       - im Erdgeschoss Helligkeit auf 15% ändern
       - im Erdgeschoss Helligkeit Licht auf 15% ändern
       - im Erdgeschoss Helligkeit des Lichts auf 15 Prozent stellen
@@ -407,9 +422,13 @@ tests:
       - im Erdgeschoss die helligkeit der Lampen auf 15% einstellen
       - im Erdgeschoss die helligkeit aller Lampen auf 15% einstellen
       - im Erdgeschoss die Helligkeit auf 15% dimmen
+      - im Erdgeschoss die Helligkeit auf 15%
       - im Erdgeschoss die Helligkeit des Lichts auf 15% dimmen
+      - im Erdgeschoss die Helligkeit des Lichts auf 15%
       - im Erdgeschoss die helligkeit der Lampen auf 15% dimmen
+      - im Erdgeschoss die helligkeit der Lampen auf 15%
       - im Erdgeschoss die helligkeit aller Lampen auf 15% dimmen
+      - im Erdgeschoss die helligkeit aller Lampen auf 15%
       - im Erdgeschoss die Helligkeit auf 15% ändern
       - im Erdgeschoss die Helligkeit Licht auf 15% ändern
       - im Erdgeschoss die Helligkeit des Lichts auf 15 Prozent stellen
@@ -471,6 +490,16 @@ tests:
       - dimme alle lichter in diesem Raum auf 10%
       - dimme alle lichter in diesem Zimmer auf 10%
       - Lichter hier auf 10% dimmen
+      - Licht 10%
+      - Lichter 10%
+      - alle Lichter 10%
+      - Licht auf 10%
+      - Lichter auf 10 Prozent
+      - alle lichter auf 10 Prozent
+      - lampe hier auf 10%
+      - licht in diesem Raum 10%
+      - leuchten hier im raum auf 10%
+      - alle lichter in diesem raum auf 10%
     intent:
       name: HassLightSet
       context:


### PR DESCRIPTION
since it´s the dark time of the year - it´s time for light controls ;)
this PR introduces shorthands without "dimmen" for the satellite´s area. the same commands are already supported for named device/area/floor controls, but not yet for the satellite´s area.
this PR adds support for
- Licht[er] 10%
- Licht[er] auf 10%
- Licht im Raum 10%
- Licht in diesem raum auf 10% 

and similar sentences.
i added some missing test sentences for other light controls as well - but without any additions to the sentence definitions.