### PR TITLE
[DE] MediaUnpause: add support for <hier> expansion rule in media type requests

### DIFF
--- a/sentences/de/media_player_HassMediaUnpause.yaml
+++ b/sentences/de/media_player_HassMediaUnpause.yaml
@@ -15,11 +15,11 @@ intents:
 
       # media_type
       - sentences:
-          - "[[(die|das|mein|meine) ]<media_type> ](fortsetzen|weiter[ (machen|<local_play>)]|wieder <local_play>)"
-          - "[[(die|das|mein|meine) ]<media_type> ]weiter(machen|schauen|hören|spielen|laufen lassen)"
-          - "lass [(die|das|mein|meine) ]<media_type> wieder (starten|[ab]spielen|laufen)"
-          - "lass [(die|das|mein|meine) ]<media_type> weiter ([ab]spielen|laufen)"
-          - "lass [(die|das|mein|meine) ]<media_type> weiter(spielen|laufen)"
+          - "[[(die|das|mein|meine) ]<media_type> ][<hier> ](fortsetzen|weiter[ (machen|<local_play>)]|wieder <local_play>)"
+          - "[[(die|das|mein|meine) ]<media_type> ][<hier> ]weiter(machen|schauen|hören|spielen|laufen lassen)"
+          - "lass [(die|das|mein|meine) ]<media_type> [<hier> ]wieder (starten|[ab]spielen|laufen)"
+          - "lass [(die|das|mein|meine) ]<media_type> [<hier> ]weiter ([ab]spielen|laufen)"
+          - "lass [(die|das|mein|meine) ]<media_type> [<hier> ]weiter(spielen|laufen)"
           - "(Ich (will|mag|möchte)|wir (wollen|mögen|möchten)) weiter (hören|schauen)"
           - "(Ich (will|mag|möchte)|wir (wollen|mögen|möchten)) weiter(hören|schauen)"
         requires_context:

--- a/tests/de/media_player_HassMediaUnpause.yaml
+++ b/tests/de/media_player_HassMediaUnpause.yaml
@@ -48,6 +48,17 @@ tests:
       - "Lass die Fernsehsendung weiter laufen"
       - "Lass die Fernsehsendung wieder laufen"
       - "Lass meine Musik weiterlaufen"
+      - die musik hier weiter laufen lassen
+      - Musik hier im Raum weiter abspielen
+      - Meine Sendung hier fortsetzen
+      - die Musik hier wieder abspielen
+      - meine Musik hier im Raum weiterlaufen lassen
+      - die Fernsehsendung hier weiterschauen
+      - lass die Musik hier wieder spielen
+      - lass meine Fernsehsendung hier wieder laufen
+      - lass die Musik im Raum wieder laufen
+      - lass die Musik hier im Raum weiter spielen
+      - lass die Musik hier im Raum weiter laufen
     intent:
       name: HassMediaUnpause
       slots:


### PR DESCRIPTION
This PR adds support for sentences like
- Lass die Musik hier weiter laufen
- lass die Musik im Raum wieder spielen
- die Musik hier weiter laufen lassen

and more similar sentence structures.