### PR TITLE
[DE] HassSetVolume: add support for <hier> expansion rule in the satellites area

### DIFF
--- a/sentences/de/media_player_HassSetVolume.yaml
+++ b/sentences/de/media_player_HassSetVolume.yaml
@@ -20,13 +20,13 @@ intents:
         requires_context:
           domain: media_player
       - sentences:
-          - "<setzen> [die ]Lautstärke[ auf] <volume>"
-          - "<stelle> [die ]Lautstärke[ auf] <volume> ein"
-          - "[die ]Lautstärke[ (auf|zu)] <volume>[ <setzen_end_of_sentence>]"
+          - "<setzen> [die ]Lautstärke[ <hier>][ auf] <volume>"
+          - "<stelle> [die ]Lautstärke[ <hier>][ auf] <volume> ein"
+          - "[die ]Lautstärke[ <hier>][ (auf|zu)] <volume>[ <setzen_end_of_sentence>]"
         requires_context:
           area:
             slot: true
       - sentences:
           - "<setzen> [die ]Lautstärke[ (in|im)] <area>[ auf] <volume>"
           - "<stelle> [die ]Lautstärke[ (in|im)] <area>[ auf] <volume> ein"
-          - "[die ]Lautstärke[ (in|im)] <area>[ auf] <volume>[ <setzen_end_of_sentence>]"
+          - "[die ]Lautstärke[ (in|im)] <area>[ (auf|zu)] <volume>[ <setzen_end_of_sentence>]"

--- a/tests/de/media_player_HassSetVolume.yaml
+++ b/tests/de/media_player_HassSetVolume.yaml
@@ -116,6 +116,15 @@ tests:
       - Lautstärke zu 10% verändern
       - die Lautstärke auf 10% stellen
       - Lautstärke auf 10% einstellen
+      - stell die Lautstärke hier auf 10 %
+      - stelle die Lautstärke im raum auf 10%
+      - ändere die Lautstärke hier im Raum auf 10 Prozent
+      - stelle die Lautstärke hier im Raum auf 10 Prozent ein
+      - Lautstärke hier 10 Prozent
+      - Lautstärke im Raum 10%
+      - Lautstärke im Raum auf 10 Prozent
+      - Lautstärke im Raum zu 10 % verändern
+      - die Lautstärke hier im Raum auf 10 Prozent einstellen
     intent:
       name: HassSetVolume
       context:
@@ -132,6 +141,7 @@ tests:
       - Die Lautstärke im Wohnzimmer auf 10 stellen
       - Lautstärke im Wohnzimmer 10 %
       - Lautstärke im Wohnzimmer auf 10 % setzen
+      - die Lautstärke im Wohnzimmer zu 10 Prozent verändern
     intent:
       name: HassSetVolume
       context:


### PR DESCRIPTION
this pr adds support for volume controls in the satellites area with sentences containing 
- hier
- im raum
- in diesem raum
- hier im raum

...


as a minor fix(for consistency with other sentences) for volume controls in other areas allowing `zu` is included as well